### PR TITLE
Import local.props for collaborative development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .idea/
 *.sln.DotSettings.user
 artifacts/nuget/
+
+local.props
+!local.props.template

--- a/STS2-RitsuLib.csproj
+++ b/STS2-RitsuLib.csproj
@@ -1,4 +1,5 @@
-<Project Sdk="Godot.NET.Sdk/4.5.1">
+﻿<Project Sdk="Godot.NET.Sdk/4.5.1">
+    <Import Project="..\local.props" Condition="Exists('..\local.props')" />
     <PropertyGroup>
         <RootNamespace>STS2RitsuLib</RootNamespace>
         <TargetFramework>net9.0</TargetFramework>
@@ -19,9 +20,13 @@
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>
     <PropertyGroup>
-        <Sts2Dir>E:\SteamLibrary\steamapps\common\Slay the Spire 2</Sts2Dir>
         <Sts2DataDir>$(Sts2Dir)\data_sts2_windows_x86_64</Sts2DataDir>
     </PropertyGroup>
+
+    <Target Name="EnsureLocalProps" BeforeTargets="PrepareForBuild" Condition="!Exists('..\local.props')">
+        <Error Text="Missing '..\local.props'. Copy '..\local.props.template' to '..\local.props', then update 'Sts2Dir' for your local environment."/>
+    </Target>
+
     <ItemGroup>
         <PackageReference Include="Krafs.Publicizer" Version="2.3.0" PrivateAssets="all"/>
     </ItemGroup>

--- a/local.props.template
+++ b/local.props.template
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <Sts2Dir>Path\To\SteamLibrary\steamapps\common\Slay the Spire 2</Sts2Dir>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
This pull request improves the configuration management for the `STS2RitsuLib` project by introducing a mechanism for handling local, user-specific properties outside of version control. The changes ensure that developers have a clear way to configure their local environment and prevent build errors due to missing configuration.

Configuration management improvements:

* Added an import for a `local.props` file in `STS2-RitsuLib.csproj`, allowing user-specific settings to be managed separately from the main project file.
* Introduced a build target (`EnsureLocalProps`) in `STS2-RitsuLib.csproj` that checks for the existence of `local.props` before building and provides a clear error message with setup instructions if the file is missing.
* Added a `local.props.template` file that provides a template for the required `Sts2Dir` property, making it easier for developers to set up their local environment.

Project file cleanup:

* Removed the hardcoded `Sts2Dir` property from `STS2-RitsuLib.csproj` to avoid storing user-specific paths in version control.