### PR TITLE
Update local.props path and ignore .vs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 *.sln.DotSettings.user
 artifacts/nuget/
 
+.vs/
+
 local.props
 !local.props.template

--- a/STS2-RitsuLib.csproj
+++ b/STS2-RitsuLib.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Godot.NET.Sdk/4.5.1">
-    <Import Project="..\local.props" Condition="Exists('..\local.props')"/>
+    <Import Project=".\local.props" Condition="Exists('.\local.props')"/>
     <PropertyGroup>
         <RootNamespace>STS2RitsuLib</RootNamespace>
         <TargetFramework>net9.0</TargetFramework>
@@ -23,8 +23,8 @@
         <Sts2DataDir>$(Sts2Dir)\data_sts2_windows_x86_64</Sts2DataDir>
     </PropertyGroup>
 
-    <Target Name="EnsureLocalProps" BeforeTargets="PrepareForBuild" Condition="!Exists('..\local.props')">
-        <Error Text="Missing '..\local.props'. Copy '..\local.props.template' to '..\local.props', then update 'Sts2Dir' for your local environment."/>
+    <Target Name="EnsureLocalProps" BeforeTargets="PrepareForBuild" Condition="!Exists('.\local.props')">
+        <Error Text="Missing '.\local.props'. Copy '..\local.props.template' to '.\local.props', then update 'Sts2Dir' for your local environment."/>
     </Target>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request makes a small but important change to the `STS2-RitsuLib.csproj` project file. The change updates the project to look for the `local.props` file in the current directory instead of the parent directory, both when importing the file and when checking for its existence before building. This should make the project setup more intuitive and reduce confusion for developers.

- Project configuration update:
  * Changed the import and existence check for `local.props` in `STS2-RitsuLib.csproj` to reference the current directory (`.\local.props`) instead of the parent directory (`..\local.props`). This also updates the error message to match the new location. [[1]](diffhunk://#diff-861b3a30df16d3c876ace926f8c21fbe98c4589572f64bdf1651018e17ca5c3cL2-R2) [[2]](diffhunk://#diff-861b3a30df16d3c876ace926f8c21fbe98c4589572f64bdf1651018e17ca5c3cL26-R27)