### PR TITLE
feat: Introduce mod keyword description injection and enhancements

### DIFF
--- a/Cards/Patches/ModKeywordCardDescriptionPatches.cs
+++ b/Cards/Patches/ModKeywordCardDescriptionPatches.cs
@@ -1,0 +1,45 @@
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Keywords;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.Cards.Patches
+{
+    /// <summary>
+    ///     Postfixes vanilla card description builders so mod keywords with
+    ///     <see cref="ModKeywordDefinition.CardDescriptionPlacement" /> inject BBCode like vanilla keywords.
+    /// </summary>
+    public sealed class ModKeywordCardDescriptionPatches : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "card_mod_keyword_description";
+
+        /// <inheritdoc />
+        public static string Description => "Inject mod keyword BBCode into CardModel description rendering";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(CardModel), nameof(CardModel.GetDescriptionForPile),
+                    [typeof(PileType), typeof(Creature)]),
+                new(typeof(CardModel), nameof(CardModel.GetDescriptionForUpgradePreview), Type.EmptyTypes),
+            ];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Appends or prepends keyword fragments after vanilla description composition.
+        /// </summary>
+        public static void Postfix(CardModel __instance, ref string __result)
+        {
+            ModKeywordCardDescriptionInjector.AppendFragments(__instance, ref __result);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/Keywords/KeywordRegistrationEntry.cs
+++ b/Keywords/KeywordRegistrationEntry.cs
@@ -3,35 +3,119 @@ namespace STS2RitsuLib.Keywords
     /// <summary>
     ///     Declarative keyword row for content packs: register with a <see cref="ModKeywordRegistry" /> in one call.
     /// </summary>
-    /// <param name="Id">Keyword id (normalized on register).</param>
-    /// <param name="TitleTable">Title localization table.</param>
-    /// <param name="TitleKey">Title localization key.</param>
-    /// <param name="DescriptionTable">Description localization table.</param>
-    /// <param name="DescriptionKey">Description localization key.</param>
-    /// <param name="IconPath">Optional icon resource path.</param>
-    public sealed record KeywordRegistrationEntry(
-        string Id,
-        string TitleTable,
-        string TitleKey,
-        string DescriptionTable,
-        string DescriptionKey,
-        string? IconPath = null)
+    public sealed record KeywordRegistrationEntry
     {
+        /// <summary>
+        ///     Full constructor including placement and hover-tip flags.
+        /// </summary>
+        public KeywordRegistrationEntry(
+            string Id,
+            string TitleTable,
+            string TitleKey,
+            string DescriptionTable,
+            string DescriptionKey,
+            string? IconPath,
+            ModKeywordCardDescriptionPlacement cardDescriptionPlacement,
+            bool includeInCardHoverTip)
+        {
+            this.Id = Id;
+            this.TitleTable = TitleTable;
+            this.TitleKey = TitleKey;
+            this.DescriptionTable = DescriptionTable;
+            this.DescriptionKey = DescriptionKey;
+            this.IconPath = IconPath;
+            CardDescriptionPlacement = cardDescriptionPlacement;
+            IncludeInCardHoverTip = includeInCardHoverTip;
+        }
+
+        /// <summary>
+        ///     Legacy constructor signature (six CLR parameters) preserved for older mods.
+        /// </summary>
+        public KeywordRegistrationEntry(
+            string Id,
+            string TitleTable,
+            string TitleKey,
+            string DescriptionTable,
+            string DescriptionKey,
+            string? IconPath)
+            : this(
+                Id,
+                TitleTable,
+                TitleKey,
+                DescriptionTable,
+                DescriptionKey,
+                IconPath,
+                ModKeywordCardDescriptionPlacement.None,
+                true)
+        {
+        }
+
+        /// <summary>
+        ///     Keyword id (normalized on register).
+        /// </summary>
+        public string Id { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Title localization table.
+        /// </summary>
+        public string TitleTable { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Title localization key.
+        /// </summary>
+        public string TitleKey { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Description localization table.
+        /// </summary>
+        public string DescriptionTable { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Description localization key.
+        /// </summary>
+        public string DescriptionKey { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Optional icon resource path.
+        /// </summary>
+        public string? IconPath { get; init; }
+
+        /// <summary>
+        ///     Inline card-description injection placement.
+        /// </summary>
+        public ModKeywordCardDescriptionPlacement CardDescriptionPlacement { get; init; } =
+            ModKeywordCardDescriptionPlacement.None;
+
+        /// <summary>
+        ///     Whether this id participates in template keyword hover-tip expansion.
+        /// </summary>
+        public bool IncludeInCardHoverTip { get; init; }
+
         /// <summary>
         ///     Registers this entry on <paramref name="registry" />.
         /// </summary>
         public void Register(ModKeywordRegistry registry)
         {
-            registry.Register(Id, TitleTable, TitleKey, DescriptionTable, DescriptionKey, IconPath);
+            registry.Register(
+                Id,
+                TitleTable,
+                TitleKey,
+                DescriptionTable,
+                DescriptionKey,
+                IconPath,
+                CardDescriptionPlacement,
+                IncludeInCardHoverTip);
         }
 
         /// <summary>
-        ///     Builds a <c>card_keywords</c> entry using <paramref name="locKeyPrefix" /> for title/description keys.
+        ///     Builds a <c>card_keywords</c> entry (full factory signature).
         /// </summary>
-        /// <param name="id">Keyword id.</param>
-        /// <param name="locKeyPrefix">Prefix for <c>{prefix}.title</c> and <c>{prefix}.description</c> keys.</param>
-        /// <param name="iconPath">Optional icon path.</param>
-        public static KeywordRegistrationEntry Card(string id, string locKeyPrefix, string? iconPath = null)
+        public static KeywordRegistrationEntry Card(
+            string id,
+            string locKeyPrefix,
+            string? iconPath,
+            ModKeywordCardDescriptionPlacement cardDescriptionPlacement,
+            bool includeInCardHoverTip)
         {
             return new(
                 id,
@@ -39,7 +123,22 @@ namespace STS2RitsuLib.Keywords
                 $"{locKeyPrefix}.title",
                 "card_keywords",
                 $"{locKeyPrefix}.description",
-                iconPath);
+                iconPath,
+                cardDescriptionPlacement,
+                includeInCardHoverTip);
+        }
+
+        /// <summary>
+        ///     Legacy <c>Card</c> factory signature preserved for older mods.
+        /// </summary>
+        public static KeywordRegistrationEntry Card(string id, string locKeyPrefix, string? iconPath = null)
+        {
+            return Card(
+                id,
+                locKeyPrefix,
+                iconPath,
+                ModKeywordCardDescriptionPlacement.None,
+                true);
         }
     }
 }

--- a/Keywords/KeywordRegistrationEntry.cs
+++ b/Keywords/KeywordRegistrationEntry.cs
@@ -37,7 +37,7 @@ namespace STS2RitsuLib.Keywords
             string TitleKey,
             string DescriptionTable,
             string DescriptionKey,
-            string? IconPath)
+            string? IconPath = null)
             : this(
                 Id,
                 TitleTable,

--- a/Keywords/ModKeywordCardDescriptionInjector.cs
+++ b/Keywords/ModKeywordCardDescriptionInjector.cs
@@ -11,8 +11,7 @@ namespace STS2RitsuLib.Keywords
     {
         internal static void AppendFragments(CardModel card, ref string description)
         {
-            if (string.IsNullOrEmpty(description))
-                return;
+            description ??= string.Empty;
 
             var before = new List<string>();
             var after = new List<string>();
@@ -22,14 +21,13 @@ namespace STS2RitsuLib.Keywords
                 if (!ModKeywordRegistry.TryGet(id, out var def))
                     continue;
 
-                var fragment = ModKeywordRegistry.GetCardText(id);
                 switch (def.CardDescriptionPlacement)
                 {
                     case ModKeywordCardDescriptionPlacement.BeforeCardDescription:
-                        before.Add(fragment);
+                        before.Add(ModKeywordRegistry.GetCardText(id));
                         break;
                     case ModKeywordCardDescriptionPlacement.AfterCardDescription:
-                        after.Add(fragment);
+                        after.Add(ModKeywordRegistry.GetCardText(id));
                         break;
                     case ModKeywordCardDescriptionPlacement.None:
                         break;
@@ -39,14 +37,19 @@ namespace STS2RitsuLib.Keywords
             if (before.Count == 0 && after.Count == 0)
                 return;
 
-            var lines = description.Split('\n').ToList();
+            List<string> lines;
+            if (description.Length == 0)
+                lines = new List<string>();
+            else
+                lines = description.Split('\n').ToList();
+
             for (var i = before.Count - 1; i >= 0; i--)
                 lines.Insert(0, before[i]);
 
             foreach (var line in after)
                 lines.Add(line);
 
-            description = string.Join('\n', lines.Where(static l => !string.IsNullOrEmpty(l)));
+            description = string.Join('\n', lines);
         }
 
         private static IEnumerable<string> EnumerateKeywordIds(CardModel card)

--- a/Keywords/ModKeywordCardDescriptionInjector.cs
+++ b/Keywords/ModKeywordCardDescriptionInjector.cs
@@ -1,0 +1,78 @@
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Scaffolding.Content;
+
+namespace STS2RitsuLib.Keywords
+{
+    /// <summary>
+    ///     Injects registered keyword BBCode into <see cref="CardModel" /> description strings based on
+    ///     <see cref="ModKeywordDefinition.CardDescriptionPlacement" />.
+    /// </summary>
+    internal static class ModKeywordCardDescriptionInjector
+    {
+        internal static void AppendFragments(CardModel card, ref string description)
+        {
+            if (string.IsNullOrEmpty(description))
+                return;
+
+            var before = new List<string>();
+            var after = new List<string>();
+
+            foreach (var id in EnumerateKeywordIds(card))
+            {
+                if (!ModKeywordRegistry.TryGet(id, out var def))
+                    continue;
+
+                var fragment = ModKeywordRegistry.GetCardText(id);
+                switch (def.CardDescriptionPlacement)
+                {
+                    case ModKeywordCardDescriptionPlacement.BeforeCardDescription:
+                        before.Add(fragment);
+                        break;
+                    case ModKeywordCardDescriptionPlacement.AfterCardDescription:
+                        after.Add(fragment);
+                        break;
+                    case ModKeywordCardDescriptionPlacement.None:
+                        break;
+                }
+            }
+
+            if (before.Count == 0 && after.Count == 0)
+                return;
+
+            var lines = description.Split('\n').ToList();
+            for (var i = before.Count - 1; i >= 0; i--)
+                lines.Insert(0, before[i]);
+
+            foreach (var line in after)
+                lines.Add(line);
+
+            description = string.Join('\n', lines.Where(static l => !string.IsNullOrEmpty(l)));
+        }
+
+        private static IEnumerable<string> EnumerateKeywordIds(CardModel card)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (card is ModCardTemplate mod)
+                foreach (var id in mod.EnumerateDeclaredModKeywordIds())
+                {
+                    if (string.IsNullOrWhiteSpace(id))
+                        continue;
+
+                    var normalized = id.Trim().ToLowerInvariant();
+                    if (string.IsNullOrEmpty(normalized) || !seen.Add(normalized))
+                        continue;
+
+                    yield return normalized;
+                }
+
+            foreach (var id in card.GetModKeywordIds())
+            {
+                if (!seen.Add(id))
+                    continue;
+
+                yield return id;
+            }
+        }
+    }
+}

--- a/Keywords/ModKeywordCardDescriptionPlacement.cs
+++ b/Keywords/ModKeywordCardDescriptionPlacement.cs
@@ -1,0 +1,24 @@
+namespace STS2RitsuLib.Keywords
+{
+    /// <summary>
+    ///     Where a registered mod keyword’s inline card text (gold title + period) is merged into the rendered card
+    ///     description, mirroring vanilla <c>CardKeywordOrder</c> behavior.
+    /// </summary>
+    public enum ModKeywordCardDescriptionPlacement
+    {
+        /// <summary>
+        ///     Do not inject keyword text into the card description (default).
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        ///     Insert before the main description block (vanilla “before description” keywords).
+        /// </summary>
+        BeforeCardDescription = 1,
+
+        /// <summary>
+        ///     Append after the main description block (vanilla “after description” keywords).
+        /// </summary>
+        AfterCardDescription = 2,
+    }
+}

--- a/Keywords/ModKeywordDefinition.cs
+++ b/Keywords/ModKeywordDefinition.cs
@@ -15,7 +15,7 @@ namespace STS2RitsuLib.Keywords
             string TitleKey,
             string DescriptionTable,
             string DescriptionKey,
-            string? IconPath)
+            string? IconPath = null)
         {
             this.ModId = ModId;
             this.Id = Id;

--- a/Keywords/ModKeywordDefinition.cs
+++ b/Keywords/ModKeywordDefinition.cs
@@ -3,19 +3,101 @@ namespace STS2RitsuLib.Keywords
     /// <summary>
     ///     Immutable registration data for a mod keyword (localization tables, keys, optional icon).
     /// </summary>
-    /// <param name="ModId">Owning mod manifest id.</param>
-    /// <param name="Id">Normalized keyword id (lowercase).</param>
-    /// <param name="TitleTable">Localization table for the title.</param>
-    /// <param name="TitleKey">Key for the title string.</param>
-    /// <param name="DescriptionTable">Localization table for the body text.</param>
-    /// <param name="DescriptionKey">Key for the description string.</param>
-    /// <param name="IconPath">Optional Godot resource path for hover icon.</param>
-    public sealed record ModKeywordDefinition(
-        string ModId,
-        string Id,
-        string TitleTable,
-        string TitleKey,
-        string DescriptionTable,
-        string DescriptionKey,
-        string? IconPath = null);
+    public sealed record ModKeywordDefinition
+    {
+        /// <summary>
+        ///     Original binary-compatible constructor (seven CLR parameters); prior RitsuLib keyword definitions.
+        /// </summary>
+        public ModKeywordDefinition(
+            string ModId,
+            string Id,
+            string TitleTable,
+            string TitleKey,
+            string DescriptionTable,
+            string DescriptionKey,
+            string? IconPath)
+        {
+            this.ModId = ModId;
+            this.Id = Id;
+            this.TitleTable = TitleTable;
+            this.TitleKey = TitleKey;
+            this.DescriptionTable = DescriptionTable;
+            this.DescriptionKey = DescriptionKey;
+            this.IconPath = IconPath;
+            CardDescriptionPlacement = ModKeywordCardDescriptionPlacement.None;
+            IncludeInCardHoverTip = true;
+        }
+
+        /// <summary>
+        ///     Extended constructor: same as the legacy seven-parameter ABI plus placement and hover-tip inclusion.
+        /// </summary>
+        public ModKeywordDefinition(
+            string ModId,
+            string Id,
+            string TitleTable,
+            string TitleKey,
+            string DescriptionTable,
+            string DescriptionKey,
+            string? IconPath,
+            ModKeywordCardDescriptionPlacement cardDescriptionPlacement,
+            bool includeInCardHoverTip)
+        {
+            this.ModId = ModId;
+            this.Id = Id;
+            this.TitleTable = TitleTable;
+            this.TitleKey = TitleKey;
+            this.DescriptionTable = DescriptionTable;
+            this.DescriptionKey = DescriptionKey;
+            this.IconPath = IconPath;
+            CardDescriptionPlacement = cardDescriptionPlacement;
+            IncludeInCardHoverTip = includeInCardHoverTip;
+        }
+
+        /// <summary>
+        ///     Owning mod manifest id.
+        /// </summary>
+        public string ModId { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Normalized keyword id (lowercase).
+        /// </summary>
+        public string Id { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Localization table for the title.
+        /// </summary>
+        public string TitleTable { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Key for the title string.
+        /// </summary>
+        public string TitleKey { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Localization table for the body text.
+        /// </summary>
+        public string DescriptionTable { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Key for the description string.
+        /// </summary>
+        public string DescriptionKey { get; init; } = string.Empty;
+
+        /// <summary>
+        ///     Optional Godot resource path for hover icon.
+        /// </summary>
+        public string? IconPath { get; init; }
+
+        /// <summary>
+        ///     Whether and where to inject keyword BBCode into card descriptions.
+        /// </summary>
+        public ModKeywordCardDescriptionPlacement CardDescriptionPlacement { get; init; } =
+            ModKeywordCardDescriptionPlacement.None;
+
+        /// <summary>
+        ///     When true, this keyword’s hover tip is included from <c>RegisteredKeywordIds</c> / runtime mod-keyword sets
+        ///     on cards and other mod templates.
+        /// </summary>
+        public bool IncludeInCardHoverTip { get; init; }
+    }
 }

--- a/Keywords/ModKeywordExtensions.cs
+++ b/Keywords/ModKeywordExtensions.cs
@@ -101,7 +101,8 @@ namespace STS2RitsuLib.Keywords
             }
 
             /// <summary>
-            ///     Maps each non-empty keyword id to a registered <see cref="IHoverTip" />.
+            ///     Maps each non-empty keyword id to a registered <see cref="IHoverTip" /> when
+            ///     <see cref="ModKeywordDefinition.IncludeInCardHoverTip" /> is true.
             /// </summary>
             public IEnumerable<IHoverTip> ToHoverTips()
             {
@@ -111,6 +112,8 @@ namespace STS2RitsuLib.Keywords
                     .Where(static id => !string.IsNullOrWhiteSpace(id))
                     .Select(static id => id.Trim().ToLowerInvariant())
                     .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Where(static id =>
+                        ModKeywordRegistry.TryGet(id, out var def) && def.IncludeInCardHoverTip)
                     .Select(ModKeywordRegistry.CreateHoverTip)
                     .ToArray();
             }

--- a/Keywords/ModKeywordRegistry.cs
+++ b/Keywords/ModKeywordRegistry.cs
@@ -48,7 +48,8 @@ namespace STS2RitsuLib.Keywords
         }
 
         /// <summary>
-        ///     Registers a keyword for this mod; duplicates from the same mod return the existing definition.
+        ///     Registers a keyword for this mod; duplicates from the same mod return the existing definition (full
+        ///     signature).
         /// </summary>
         /// <param name="id">Keyword id (trimmed, lowercased).</param>
         /// <param name="titleTable">Title localization table.</param>
@@ -56,13 +57,17 @@ namespace STS2RitsuLib.Keywords
         /// <param name="descriptionTable">Description table; defaults to <paramref name="titleTable" /> when null.</param>
         /// <param name="descriptionKey">Description key; defaults to <c>{id}.description</c> when null.</param>
         /// <param name="iconPath">Optional Godot resource path for the icon.</param>
+        /// <param name="cardDescriptionPlacement">Inline card-description injection placement.</param>
+        /// <param name="includeInCardHoverTip">Whether this id participates in template keyword hover-tip expansion.</param>
         public ModKeywordDefinition Register(
             string id,
-            string titleTable = "card_keywords",
-            string? titleKey = null,
-            string? descriptionTable = null,
-            string? descriptionKey = null,
-            string? iconPath = null)
+            string titleTable,
+            string? titleKey,
+            string? descriptionTable,
+            string? descriptionKey,
+            string? iconPath,
+            ModKeywordCardDescriptionPlacement cardDescriptionPlacement,
+            bool includeInCardHoverTip)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(id);
             ArgumentException.ThrowIfNullOrWhiteSpace(titleTable);
@@ -75,7 +80,9 @@ namespace STS2RitsuLib.Keywords
                 titleKey ?? $"{normalizedId}.title",
                 descriptionTable ?? titleTable,
                 descriptionKey ?? $"{normalizedId}.description",
-                iconPath);
+                iconPath,
+                cardDescriptionPlacement,
+                includeInCardHoverTip);
 
             lock (SyncRoot)
             {
@@ -96,10 +103,36 @@ namespace STS2RitsuLib.Keywords
         }
 
         /// <summary>
-        ///     Convenience for card keywords: uses <c>card_keywords</c> and slugified keys from <paramref name="id" /> or
-        ///     <paramref name="locKeyPrefix" />.
+        ///     Legacy <c>Register</c> signature preserved for older mods; forwards with prior hover-tip behavior.
         /// </summary>
-        public ModKeywordDefinition RegisterCardKeyword(string id, string? locKeyPrefix = null, string? iconPath = null)
+        public ModKeywordDefinition Register(
+            string id,
+            string titleTable = "card_keywords",
+            string? titleKey = null,
+            string? descriptionTable = null,
+            string? descriptionKey = null,
+            string? iconPath = null)
+        {
+            return Register(
+                id,
+                titleTable,
+                titleKey,
+                descriptionTable,
+                descriptionKey,
+                iconPath,
+                ModKeywordCardDescriptionPlacement.None,
+                true);
+        }
+
+        /// <summary>
+        ///     Convenience for card keywords: uses <c>card_keywords</c> and slugified keys (full signature).
+        /// </summary>
+        public ModKeywordDefinition RegisterCardKeyword(
+            string id,
+            string? locKeyPrefix,
+            string? iconPath,
+            ModKeywordCardDescriptionPlacement cardDescriptionPlacement,
+            bool includeInCardHoverTip)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(id);
 
@@ -113,7 +146,22 @@ namespace STS2RitsuLib.Keywords
                 $"{prefix}.title",
                 "card_keywords",
                 $"{prefix}.description",
-                iconPath);
+                iconPath,
+                cardDescriptionPlacement,
+                includeInCardHoverTip);
+        }
+
+        /// <summary>
+        ///     Legacy <c>RegisterCardKeyword</c> signature preserved for older mods; forwards with prior hover-tip behavior.
+        /// </summary>
+        public ModKeywordDefinition RegisterCardKeyword(string id, string? locKeyPrefix = null, string? iconPath = null)
+        {
+            return RegisterCardKeyword(
+                id,
+                locKeyPrefix,
+                iconPath,
+                ModKeywordCardDescriptionPlacement.None,
+                true);
         }
 
         /// <summary>

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -116,6 +116,7 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<CardBannerMaterialPatch>();
             patcher.RegisterPatch<CardDynamicVarTooltipPatch>();
             patcher.RegisterPatch<DynamicVarTooltipClonePatch>();
+            patcher.RegisterPatch<ModKeywordCardDescriptionPatches>();
             patcher.RegisterPatch<EnergyIconHelperPathPatch>();
             patcher.RegisterPatch<EnergyIconFormatterPatch>();
 

--- a/Scaffolding/Content/ModCardTemplate.cs
+++ b/Scaffolding/Content/ModCardTemplate.cs
@@ -84,5 +84,13 @@ namespace STS2RitsuLib.Scaffolding.Content
 
         /// <inheritdoc />
         public virtual string? CustomBannerMaterialPath => AssetProfile.BannerMaterialPath;
+
+        /// <summary>
+        ///     Materializes <see cref="RegisteredKeywordIds" /> for keyword plumbing in the same assembly.
+        /// </summary>
+        internal IEnumerable<string> EnumerateDeclaredModKeywordIds()
+        {
+            return RegisteredKeywordIds;
+        }
     }
 }

--- a/Scaffolding/Content/ModContentPackBuilder.cs
+++ b/Scaffolding/Content/ModContentPackBuilder.cs
@@ -362,15 +362,58 @@ namespace STS2RitsuLib.Scaffolding.Content
         }
 
         /// <summary>
-        ///     Queues <see cref="ModKeywordRegistry.RegisterCardKeyword" />.
+        ///     Queues full-signature
+        ///     <see cref="ModKeywordRegistry.RegisterCardKeyword(string,string?,string?,ModKeywordCardDescriptionPlacement,bool)" />
+        ///     .
         /// </summary>
-        public ModContentPackBuilder CardKeyword(string id, string? locKeyPrefix = null, string? iconPath = null)
+        public ModContentPackBuilder CardKeyword(
+            string id,
+            string? locKeyPrefix,
+            string? iconPath,
+            ModKeywordCardDescriptionPlacement cardDescriptionPlacement,
+            bool includeInCardHoverTip)
         {
-            return AddStep(ctx => ctx.Keywords.RegisterCardKeyword(id, locKeyPrefix, iconPath));
+            return AddStep(ctx =>
+                ctx.Keywords.RegisterCardKeyword(id, locKeyPrefix, iconPath, cardDescriptionPlacement,
+                    includeInCardHoverTip));
         }
 
         /// <summary>
-        ///     Queues a general keyword registration on <see cref="ModKeywordRegistry" />.
+        ///     Legacy <c>CardKeyword</c> signature preserved for older mods; forwards with prior hover-tip behavior.
+        /// </summary>
+        public ModContentPackBuilder CardKeyword(string id, string? locKeyPrefix = null, string? iconPath = null)
+        {
+            return CardKeyword(
+                id,
+                locKeyPrefix,
+                iconPath,
+                ModKeywordCardDescriptionPlacement.None,
+                true);
+        }
+
+        /// <summary>
+        ///     Queues full-signature
+        ///     <see
+        ///         cref="ModKeywordRegistry.Register(string,string,string?,string?,string?,string?,ModKeywordCardDescriptionPlacement,bool)" />
+        ///     .
+        /// </summary>
+        public ModContentPackBuilder Keyword(
+            string id,
+            string titleTable,
+            string? titleKey,
+            string? descriptionTable,
+            string? descriptionKey,
+            string? iconPath,
+            ModKeywordCardDescriptionPlacement cardDescriptionPlacement,
+            bool includeInCardHoverTip)
+        {
+            return AddStep(ctx =>
+                ctx.Keywords.Register(id, titleTable, titleKey, descriptionTable, descriptionKey, iconPath,
+                    cardDescriptionPlacement, includeInCardHoverTip));
+        }
+
+        /// <summary>
+        ///     Legacy <c>Keyword</c> signature preserved for older mods; forwards with prior hover-tip behavior.
         /// </summary>
         public ModContentPackBuilder Keyword(
             string id,
@@ -380,8 +423,15 @@ namespace STS2RitsuLib.Scaffolding.Content
             string? descriptionKey = null,
             string? iconPath = null)
         {
-            return AddStep(ctx =>
-                ctx.Keywords.Register(id, titleTable, titleKey, descriptionTable, descriptionKey, iconPath));
+            return Keyword(
+                id,
+                titleTable,
+                titleKey,
+                descriptionTable,
+                descriptionKey,
+                iconPath,
+                ModKeywordCardDescriptionPlacement.None,
+                true);
         }
 
         /// <summary>

--- a/Scaffolding/Content/ModContentPackBuilder.cs
+++ b/Scaffolding/Content/ModContentPackBuilder.cs
@@ -362,9 +362,7 @@ namespace STS2RitsuLib.Scaffolding.Content
         }
 
         /// <summary>
-        ///     Queues full-signature
-        ///     <see cref="ModKeywordRegistry.RegisterCardKeyword(string,string?,string?,ModKeywordCardDescriptionPlacement,bool)" />
-        ///     .
+        ///     Queues extended <see cref="ModKeywordRegistry" /> card-keyword registration (placement + hover-tip flags).
         /// </summary>
         public ModContentPackBuilder CardKeyword(
             string id,
@@ -392,10 +390,7 @@ namespace STS2RitsuLib.Scaffolding.Content
         }
 
         /// <summary>
-        ///     Queues full-signature
-        ///     <see
-        ///         cref="ModKeywordRegistry.Register(string,string,string?,string?,string?,string?,ModKeywordCardDescriptionPlacement,bool)" />
-        ///     .
+        ///     Queues extended <see cref="ModKeywordRegistry" /> keyword registration (placement + hover-tip flags).
         /// </summary>
         public ModContentPackBuilder Keyword(
             string id,


### PR DESCRIPTION
- Added `ModKeywordCardDescriptionPatches` to inject mod keyword BBCode into card descriptions.
- Updated `KeywordRegistrationEntry` to include parameters for card description placement and hover-tip inclusion.
- Implemented `ModKeywordCardDescriptionInjector` for managing keyword text placement in card descriptions.
- Enhanced `ModKeywordDefinition` and `ModKeywordRegistry` to support new registration features.
- Updated `ModContentPackBuilder` to facilitate full-signature keyword registration.