### PR TITLE
feat: Integrate and refactor BaseLib health bar forecasting functionality

### DIFF
--- a/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
+++ b/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using STS2RitsuLib.Compat;
+
+namespace STS2RitsuLib.Combat.HealthBars
+{
+    internal static class BaseLibHealthBarForecastBridge
+    {
+        private const string SourceId = "ritsulib.registry";
+        private static bool _registered;
+        private static bool _baselibSupportsForecastInterop;
+        private static bool _loggedMissingInterop;
+        private static bool _primaryAttemptIssued;
+        private static bool _secondaryAttemptIssued;
+
+        static BaseLibHealthBarForecastBridge()
+        {
+            AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+        }
+
+        public static bool ShouldRitsuRendererStandDown()
+        {
+            return _registered && _baselibSupportsForecastInterop;
+        }
+
+        public static void TryRegisterPrimary()
+        {
+            if (_primaryAttemptIssued || _registered)
+                return;
+            _primaryAttemptIssued = true;
+            TryRegisterCore();
+        }
+
+        public static void TryRegisterSecondary()
+        {
+            if (_secondaryAttemptIssued || _registered)
+                return;
+            _secondaryAttemptIssued = true;
+            TryRegisterCore();
+        }
+
+        public static void TryRegister()
+        {
+            TryRegisterPrimary();
+        }
+
+        private static void TryRegisterCore()
+        {
+            if (_registered)
+                return;
+
+            try
+            {
+                var registryType = ResolveBaseLibRegistryType();
+                if (registryType == null)
+                    return;
+
+                var registerForeign = registryType.GetMethod(
+                    "RegisterForeign",
+                    BindingFlags.Public | BindingFlags.Static,
+                    null,
+                    [typeof(string), typeof(string), typeof(Func<Creature, IEnumerable<object>>)],
+                    null);
+
+                if (registerForeign == null)
+                    return;
+
+                var provider = GetSegmentsForCreature;
+                registerForeign.Invoke(null, [Const.ModId, SourceId, provider]);
+                _registered = true;
+                _baselibSupportsForecastInterop = true;
+                RitsuLibFramework.Logger.Debug("[HealthBarForecast] Registered BaseLib bridge provider.");
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.Logger.Warn($"[HealthBarForecast] Failed to register BaseLib bridge provider: {ex}");
+            }
+        }
+
+        private static void OnAssemblyLoad(object? sender, AssemblyLoadEventArgs args)
+        {
+            if (_registered)
+                return;
+            var loadedAssembly = args.LoadedAssembly;
+            var type = loadedAssembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry");
+            if (type == null)
+                return;
+            TryRegisterCore();
+        }
+
+        private static IEnumerable<object> GetSegmentsForCreature(Creature creature)
+        {
+            return HealthBarForecastRegistry.GetSegments(creature)
+                .Select(registered => (object)registered.Segment)
+                .ToArray();
+        }
+
+        private static Type? ResolveBaseLibRegistryType()
+        {
+            var registryType = ResolveRegistryTypeFromLoadedAssemblies();
+            _baselibSupportsForecastInterop = registryType != null;
+
+            if (!_baselibSupportsForecastInterop)
+            {
+                if (_loggedMissingInterop)
+                    return null;
+                _loggedMissingInterop = true;
+                RitsuLibFramework.Logger.Debug(
+                    "[HealthBarForecast] BaseLib detected but forecast interop API is unavailable.");
+                return null;
+            }
+
+            _loggedMissingInterop = false;
+
+            return registryType;
+        }
+
+        private static Type? ResolveRegistryTypeFromLoadedAssemblies()
+        {
+            var byQualifiedName = Type.GetType("BaseLib.Hooks.HealthBarForecastRegistry, BaseLib");
+            if (byQualifiedName != null)
+                return byQualifiedName;
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var type = assembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry");
+                if (type != null)
+                    return type;
+            }
+
+            try
+            {
+                var loadedWithAssembly = Sts2ModManagerCompat.EnumerateLoadedModsWithAssembly();
+                foreach (var mod in loadedWithAssembly)
+                {
+                    var assembly = mod.assembly;
+                    if (assembly == null)
+                        continue;
+
+                    var type = assembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry");
+                    if (type != null)
+                        return type;
+                }
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.Logger.Debug(
+                    $"[HealthBarForecast] Loaded mod enumeration failed during BaseLib detection: {ex.Message}");
+            }
+
+            return null;
+        }
+    }
+}

--- a/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
+++ b/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
@@ -10,6 +10,7 @@ namespace STS2RitsuLib.Combat.HealthBars
         private static bool _registered;
         private static bool _baselibSupportsForecastInterop;
         private static bool _loggedMissingInterop;
+        private static bool _loggedMissingRegisterForeign;
         private static bool _primaryAttemptIssued;
         private static bool _secondaryAttemptIssued;
 
@@ -60,7 +61,18 @@ namespace STS2RitsuLib.Combat.HealthBars
                     null);
 
                 if (registerForeign == null)
+                {
+                    _baselibSupportsForecastInterop = false;
+                    if (!_loggedMissingRegisterForeign)
+                    {
+                        _loggedMissingRegisterForeign = true;
+                        RitsuLibFramework.Logger.Warn(
+                            $"[HealthBarForecast] BaseLib registry type '{registryType.FullName}' does not expose " +
+                            "RegisterForeign(string, string, Func<Creature, IEnumerable<object>>); forecast interop unavailable.");
+                    }
+
                     return;
+                }
 
                 var provider = GetSegmentsForCreature;
                 registerForeign.Invoke(null, [Const.ModId, SourceId, provider]);

--- a/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
+++ b/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
@@ -13,11 +13,6 @@ namespace STS2RitsuLib.Combat.HealthBars
         private static bool _primaryAttemptIssued;
         private static bool _secondaryAttemptIssued;
 
-        static BaseLibHealthBarForecastBridge()
-        {
-            AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
-        }
-
         public static bool ShouldRitsuRendererStandDown()
         {
             return _registered && _baselibSupportsForecastInterop;
@@ -48,6 +43,8 @@ namespace STS2RitsuLib.Combat.HealthBars
         {
             if (_registered)
                 return;
+            if (!IsBaseLibLoaded())
+                return;
 
             try
             {
@@ -69,23 +66,12 @@ namespace STS2RitsuLib.Combat.HealthBars
                 registerForeign.Invoke(null, [Const.ModId, SourceId, provider]);
                 _registered = true;
                 _baselibSupportsForecastInterop = true;
-                RitsuLibFramework.Logger.Debug("[HealthBarForecast] Registered BaseLib bridge provider.");
+                RitsuLibFramework.Logger.Info("[HealthBarForecast] Registered BaseLib bridge provider.");
             }
             catch (Exception ex)
             {
                 RitsuLibFramework.Logger.Warn($"[HealthBarForecast] Failed to register BaseLib bridge provider: {ex}");
             }
-        }
-
-        private static void OnAssemblyLoad(object? sender, AssemblyLoadEventArgs args)
-        {
-            if (_registered)
-                return;
-            var loadedAssembly = args.LoadedAssembly;
-            var type = loadedAssembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry");
-            if (type == null)
-                return;
-            TryRegisterCore();
         }
 
         private static IEnumerable<object> GetSegmentsForCreature(Creature creature)
@@ -105,7 +91,7 @@ namespace STS2RitsuLib.Combat.HealthBars
                 if (_loggedMissingInterop)
                     return null;
                 _loggedMissingInterop = true;
-                RitsuLibFramework.Logger.Debug(
+                RitsuLibFramework.Logger.Info(
                     "[HealthBarForecast] BaseLib detected but forecast interop API is unavailable.");
                 return null;
             }
@@ -115,37 +101,43 @@ namespace STS2RitsuLib.Combat.HealthBars
             return registryType;
         }
 
+        private static bool IsBaseLibLoaded()
+        {
+            foreach (var mod in Sts2ModManagerCompat.EnumerateLoadedModsWithAssembly())
+            {
+                var assembly = mod.assembly;
+                if (assembly == null)
+                    continue;
+                if (assembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry") != null)
+                    return true;
+            }
+
+            return false;
+        }
+
         private static Type? ResolveRegistryTypeFromLoadedAssemblies()
         {
             var byQualifiedName = Type.GetType("BaseLib.Hooks.HealthBarForecastRegistry, BaseLib");
             if (byQualifiedName != null)
                 return byQualifiedName;
 
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            var loadedWithAssembly = Sts2ModManagerCompat.EnumerateLoadedModsWithAssembly();
+            foreach (var mod in loadedWithAssembly)
             {
+                var assembly = mod.assembly;
+                if (assembly == null)
+                    continue;
+
                 var type = assembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry");
                 if (type != null)
                     return type;
             }
 
-            try
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                var loadedWithAssembly = Sts2ModManagerCompat.EnumerateLoadedModsWithAssembly();
-                foreach (var mod in loadedWithAssembly)
-                {
-                    var assembly = mod.assembly;
-                    if (assembly == null)
-                        continue;
-
-                    var type = assembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry");
-                    if (type != null)
-                        return type;
-                }
-            }
-            catch (Exception ex)
-            {
-                RitsuLibFramework.Logger.Debug(
-                    $"[HealthBarForecast] Loaded mod enumeration failed during BaseLib detection: {ex.Message}");
+                var type = assembly.GetType("BaseLib.Hooks.HealthBarForecastRegistry");
+                if (type != null)
+                    return type;
             }
 
             return null;

--- a/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
+++ b/Combat/HealthBars/BaseLibHealthBarForecastBridge.cs
@@ -4,6 +4,14 @@ using STS2RitsuLib.Compat;
 
 namespace STS2RitsuLib.Combat.HealthBars
 {
+    /// <summary>
+    ///     When BaseLib is loaded, registers <see cref="HealthBarForecastRegistry.GetSegments" /> with BaseLib's
+    ///     <c>HealthBarForecastRegistry.RegisterForeign</c> so a single renderer can consume Ritsu-typed segments.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="ShouldRitsuRendererStandDown" /> becomes true after a successful bridge so duplicate overlays are
+    ///     not drawn.
+    /// </remarks>
     internal static class BaseLibHealthBarForecastBridge
     {
         private const string SourceId = "ritsulib.registry";
@@ -14,11 +22,18 @@ namespace STS2RitsuLib.Combat.HealthBars
         private static bool _primaryAttemptIssued;
         private static bool _secondaryAttemptIssued;
 
+        /// <summary>
+        ///     When <see langword="true" />, Ritsu's <c>NHealthBar</c> forecast postfixes should skip drawing because BaseLib
+        ///     already merged this mod's segments.
+        /// </summary>
         public static bool ShouldRitsuRendererStandDown()
         {
             return _registered && _baselibSupportsForecastInterop;
         }
 
+        /// <summary>
+        ///     Attempts foreign registration from <c>NHealthBar._Ready</c> (early load path).
+        /// </summary>
         public static void TryRegisterPrimary()
         {
             if (_primaryAttemptIssued || _registered)
@@ -27,6 +42,9 @@ namespace STS2RitsuLib.Combat.HealthBars
             TryRegisterCore();
         }
 
+        /// <summary>
+        ///     Attempts foreign registration from forecast render path if <see cref="TryRegisterPrimary" /> did not run yet.
+        /// </summary>
         public static void TryRegisterSecondary()
         {
             if (_secondaryAttemptIssued || _registered)
@@ -35,6 +53,9 @@ namespace STS2RitsuLib.Combat.HealthBars
             TryRegisterCore();
         }
 
+        /// <summary>
+        ///     Alias for <see cref="TryRegisterPrimary" />.
+        /// </summary>
         public static void TryRegister()
         {
             TryRegisterPrimary();

--- a/Combat/HealthBars/HealthBarForecastRegistry.cs
+++ b/Combat/HealthBars/HealthBarForecastRegistry.cs
@@ -32,11 +32,24 @@ namespace STS2RitsuLib.Combat.HealthBars
     ///     edge; for <see cref="HealthBarForecastGrowthDirection.FromLeft" />, earlier segments stay closer to the empty
     ///     edge.
     /// </param>
+    /// <param name="OverlayMaterial">
+    ///     Optional Godot material (e.g. shader like vanilla doom). When null, only <see cref="Color" /> tint applies.
+    /// </param>
     public readonly record struct HealthBarForecastSegment(
         int Amount,
         Color Color,
         HealthBarForecastGrowthDirection Direction,
-        int Order = 0);
+        int Order,
+        Material? OverlayMaterial)
+    {
+        /// <summary>
+        ///     Overload for mods built against the original four-parameter constructor (no custom material).
+        /// </summary>
+        public HealthBarForecastSegment(int amount, Color color, HealthBarForecastGrowthDirection direction, int order = 0)
+            : this(amount, color, direction, order, null)
+        {
+        }
+    }
 
     /// <summary>
     ///     Helpers for common turn-relative ordering of forecast segments.

--- a/Combat/HealthBars/HealthBarForecastRegistry.cs
+++ b/Combat/HealthBars/HealthBarForecastRegistry.cs
@@ -24,7 +24,10 @@ namespace STS2RitsuLib.Combat.HealthBars
     ///     One forecast overlay segment for a creature health bar.
     /// </summary>
     /// <param name="Amount">HP amount represented by this segment.</param>
-    /// <param name="Color">Overlay tint.</param>
+    /// <param name="Color">
+    ///     Lethal HP label theming; also used as the forecast nine-patch <see cref="CanvasItem.SelfModulate" /> when
+    ///     <see cref="OverlaySelfModulate" /> is null.
+    /// </param>
     /// <param name="Direction">Which edge the segment grows from.</param>
     /// <param name="Order">
     ///     Lower values are rendered earlier in the chain.
@@ -35,18 +38,39 @@ namespace STS2RitsuLib.Combat.HealthBars
     /// <param name="OverlayMaterial">
     ///     Optional Godot material (e.g. shader like vanilla doom). When null, only <see cref="Color" /> tint applies.
     /// </param>
+    /// <param name="OverlaySelfModulate">
+    ///     Optional <see cref="CanvasItem.SelfModulate" /> for the forecast nine-patch. When null, <see cref="Color" /> is
+    ///     used
+    ///     for both overlay tint and lethal HP label; when set, <see cref="Color" /> is still used for lethal label theming.
+    /// </param>
     public readonly record struct HealthBarForecastSegment(
         int Amount,
         Color Color,
         HealthBarForecastGrowthDirection Direction,
         int Order,
-        Material? OverlayMaterial)
+        Material? OverlayMaterial,
+        Color? OverlaySelfModulate = null)
     {
         /// <summary>
-        ///     Overload for mods built against the original four-parameter constructor (no custom material).
+        ///     Initializes a segment without overlay material or separate overlay modulate.
         /// </summary>
-        public HealthBarForecastSegment(int amount, Color color, HealthBarForecastGrowthDirection direction, int order = 0)
-            : this(amount, color, direction, order, null)
+        public HealthBarForecastSegment(int amount, Color color, HealthBarForecastGrowthDirection direction,
+            int order = 0)
+            : this(amount, color, direction, order, null, null)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a segment with an optional <see cref="OverlayMaterial" /> and default overlay modulate.
+        /// </summary>
+        // ReSharper disable once RedundantOverload.Global
+        public HealthBarForecastSegment(
+            int amount,
+            Color color,
+            HealthBarForecastGrowthDirection direction,
+            int order,
+            Material? overlayMaterial)
+            : this(amount, color, direction, order, overlayMaterial, null)
         {
         }
     }

--- a/Combat/HealthBars/HealthBarForecastRegistry.cs
+++ b/Combat/HealthBars/HealthBarForecastRegistry.cs
@@ -111,6 +111,9 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// <summary>
         ///     Registers or replaces a forecast provider for <paramref name="modId" />.
         /// </summary>
+        /// <typeparam name="TSource">Concrete <see cref="IHealthBarForecastSource" /> with a parameterless constructor.</typeparam>
+        /// <param name="modId">Owning mod identifier.</param>
+        /// <param name="sourceId">Optional unique id; defaults to the type full name.</param>
         public static void Register<TSource>(string modId, string? sourceId = null)
             where TSource : IHealthBarForecastSource, new()
         {
@@ -120,6 +123,9 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// <summary>
         ///     Registers or replaces a forecast source instance for <paramref name="modId" />.
         /// </summary>
+        /// <param name="modId">Owning mod identifier.</param>
+        /// <param name="sourceId">Unique id for this source within the mod.</param>
+        /// <param name="source">Provider instance.</param>
         public static void Register(
             string modId,
             string sourceId,
@@ -143,6 +149,9 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// <summary>
         ///     Removes a previously registered provider.
         /// </summary>
+        /// <param name="modId">Mod identifier used at registration.</param>
+        /// <param name="sourceId">Source id used at registration.</param>
+        /// <returns><see langword="true" /> if an entry was removed.</returns>
         public static bool Unregister(string modId, string sourceId)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(modId);
@@ -154,6 +163,10 @@ namespace STS2RitsuLib.Combat.HealthBars
             }
         }
 
+        /// <summary>
+        ///     Collects segments from powers implementing <see cref="IHealthBarForecastSource" /> and registered providers.
+        /// </summary>
+        /// <param name="creature">Creature whose bar is being evaluated.</param>
         internal static IReadOnlyList<RegisteredHealthBarForecastSegment> GetSegments(Creature creature)
         {
             ArgumentNullException.ThrowIfNull(creature);
@@ -213,6 +226,11 @@ namespace STS2RitsuLib.Combat.HealthBars
             }
         }
 
+        /// <summary>
+        ///     Segment plus a sequence key for stable ordering when <see cref="HealthBarForecastSegment.Order" /> ties.
+        /// </summary>
+        /// <param name="Segment">Forecast data.</param>
+        /// <param name="SequenceOrder">Monotonic key (powers first, then registered sources).</param>
         internal readonly record struct RegisteredHealthBarForecastSegment(
             HealthBarForecastSegment Segment,
             long SequenceOrder);

--- a/Combat/HealthBars/HealthBarForecasts.cs
+++ b/Combat/HealthBars/HealthBarForecasts.cs
@@ -39,13 +39,24 @@ namespace STS2RitsuLib.Combat.HealthBars
             int amount,
             Color color,
             HealthBarForecastGrowthDirection direction,
-            int order = 0)
+            int order,
+            Material? overlayMaterial)
         {
             if (amount <= 0)
                 return [];
 
-            return [new(amount, color, direction, order)];
+            return [new(amount, color, direction, order, overlayMaterial)];
         }
+
+        /// <summary>
+        ///     Returns a single segment when <paramref name="amount" /> is positive, without a custom material.
+        /// </summary>
+        public static IEnumerable<HealthBarForecastSegment> Single(
+            int amount,
+            Color color,
+            HealthBarForecastGrowthDirection direction,
+            int order = 0)
+            => Single(amount, color, direction, order, null);
     }
 
     /// <summary>
@@ -62,18 +73,19 @@ namespace STS2RitsuLib.Combat.HealthBars
 
         /// <summary>
         ///     Appends a segment when <paramref name="amount" /> is positive.
-        ///     Consecutive segments with identical color/direction/order are merged.
+        ///     Consecutive segments with identical color/direction/order/material are merged.
         /// </summary>
         public HealthBarForecastSequenceBuilder Add(
             int amount,
             Color color,
             HealthBarForecastGrowthDirection direction,
-            int order = 0)
+            int order,
+            Material? overlayMaterial)
         {
             if (amount <= 0)
                 return this;
 
-            var segment = new HealthBarForecastSegment(amount, color, direction, order);
+            var segment = new HealthBarForecastSegment(amount, color, direction, order, overlayMaterial);
             if (_segments.Count > 0)
             {
                 var last = _segments[^1];
@@ -89,21 +101,42 @@ namespace STS2RitsuLib.Combat.HealthBars
         }
 
         /// <summary>
+        ///     Appends a segment without a custom material.
+        /// </summary>
+        public HealthBarForecastSequenceBuilder Add(
+            int amount,
+            Color color,
+            HealthBarForecastGrowthDirection direction,
+            int order = 0)
+            => Add(amount, color, direction, order, null);
+
+        /// <summary>
         ///     Appends all positive amounts as consecutive segments.
         /// </summary>
         public HealthBarForecastSequenceBuilder AddRange(
             IEnumerable<int> amounts,
             Color color,
             HealthBarForecastGrowthDirection direction,
-            int order = 0)
+            int order,
+            Material? overlayMaterial)
         {
             ArgumentNullException.ThrowIfNull(amounts);
 
             foreach (var amount in amounts)
-                Add(amount, color, direction, order);
+                Add(amount, color, direction, order, overlayMaterial);
 
             return this;
         }
+
+        /// <summary>
+        ///     Appends all positive amounts as consecutive segments without a custom material.
+        /// </summary>
+        public HealthBarForecastSequenceBuilder AddRange(
+            IEnumerable<int> amounts,
+            Color color,
+            HealthBarForecastGrowthDirection direction,
+            int order = 0)
+            => AddRange(amounts, color, direction, order, null);
 
         /// <summary>
         ///     Appends segments that trigger at the start of <paramref name="triggerSide" />'s turn.
@@ -165,7 +198,8 @@ namespace STS2RitsuLib.Combat.HealthBars
         {
             return left.Color == right.Color &&
                    left.Direction == right.Direction &&
-                   left.Order == right.Order;
+                   left.Order == right.Order &&
+                   ReferenceEquals(left.OverlayMaterial, right.OverlayMaterial);
         }
     }
 
@@ -183,22 +217,34 @@ namespace STS2RitsuLib.Combat.HealthBars
         public HealthBarForecastSequenceBuilder Sequence { get; } = sequence;
 
         /// <summary>
-        ///     Appends a segment with explicit <paramref name="order" />.
+        ///     Appends a segment with explicit <paramref name="order" /> and optional <paramref name="overlayMaterial" />.
         /// </summary>
-        public HealthBarForecastLaneBuilder Add(int amount, int order = 0)
+        public HealthBarForecastLaneBuilder Add(int amount, int order, Material? overlayMaterial)
         {
-            Sequence.Add(amount, color, direction, order);
+            Sequence.Add(amount, color, direction, order, overlayMaterial);
             return this;
         }
 
         /// <summary>
-        ///     Appends multiple segments with the same <paramref name="order" />.
+        ///     Appends a segment without a custom material.
         /// </summary>
-        public HealthBarForecastLaneBuilder AddRange(IEnumerable<int> amounts, int order = 0)
+        public HealthBarForecastLaneBuilder Add(int amount, int order = 0)
+            => Add(amount, order, null);
+
+        /// <summary>
+        ///     Appends multiple segments with the same <paramref name="order" /> and optional <paramref name="overlayMaterial" />.
+        /// </summary>
+        public HealthBarForecastLaneBuilder AddRange(IEnumerable<int> amounts, int order, Material? overlayMaterial)
         {
-            Sequence.AddRange(amounts, color, direction, order);
+            Sequence.AddRange(amounts, color, direction, order, overlayMaterial);
             return this;
         }
+
+        /// <summary>
+        ///     Appends multiple segments without a custom material.
+        /// </summary>
+        public HealthBarForecastLaneBuilder AddRange(IEnumerable<int> amounts, int order = 0)
+            => AddRange(amounts, order, null);
 
         /// <summary>
         ///     Appends segments that trigger at the start of <paramref name="triggerSide" />'s turn.

--- a/Combat/HealthBars/HealthBarForecasts.cs
+++ b/Combat/HealthBars/HealthBarForecasts.cs
@@ -21,7 +21,25 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public static HealthBarForecastLaneBuilder FromRight(HealthBarForecastContext context, Color color)
         {
-            return new(For(context), color, HealthBarForecastGrowthDirection.FromRight);
+            return FromRight(context, color, null);
+        }
+
+        /// <summary>
+        ///     Starts a right-growing lane with separate optional <see cref="CanvasItem.SelfModulate" /> for the nine-patch
+        ///     overlay (e.g. white when <see cref="Godot.Material" /> carries tint).
+        /// </summary>
+        /// <param name="context">Forecast context.</param>
+        /// <param name="color">Lethal label color and fallback overlay modulate.</param>
+        /// <param name="overlaySelfModulate">
+        ///     When set, used as overlay <see cref="CanvasItem.SelfModulate" /> instead of
+        ///     <paramref name="color" />.
+        /// </param>
+        public static HealthBarForecastLaneBuilder FromRight(
+            HealthBarForecastContext context,
+            Color color,
+            Color? overlaySelfModulate)
+        {
+            return new(For(context), color, HealthBarForecastGrowthDirection.FromRight, overlaySelfModulate);
         }
 
         /// <summary>
@@ -29,11 +47,20 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public static HealthBarForecastLaneBuilder FromLeft(HealthBarForecastContext context, Color color)
         {
-            return new(For(context), color, HealthBarForecastGrowthDirection.FromLeft);
+            return FromLeft(context, color, null);
+        }
+
+        /// <inheritdoc cref="FromRight(HealthBarForecastContext, Color, Color?)" />
+        public static HealthBarForecastLaneBuilder FromLeft(
+            HealthBarForecastContext context,
+            Color color,
+            Color? overlaySelfModulate)
+        {
+            return new(For(context), color, HealthBarForecastGrowthDirection.FromLeft, overlaySelfModulate);
         }
 
         /// <summary>
-        ///     Returns a single segment when <paramref name="amount" /> is positive.
+        ///     Returns a single segment when <paramref name="amount" /> is positive, with optional material only.
         /// </summary>
         public static IEnumerable<HealthBarForecastSegment> Single(
             int amount,
@@ -42,10 +69,31 @@ namespace STS2RitsuLib.Combat.HealthBars
             int order,
             Material? overlayMaterial)
         {
+            return Single(amount, color, direction, order, overlayMaterial, null);
+        }
+
+        /// <summary>
+        ///     Returns a single segment when <paramref name="amount" /> is positive, with optional material and overlay
+        ///     <see cref="CanvasItem.SelfModulate" />.
+        /// </summary>
+        /// <param name="amount">HP chunk size.</param>
+        /// <param name="color">Lethal label color and fallback modulate.</param>
+        /// <param name="direction">Growth direction.</param>
+        /// <param name="order">Sort order among segments.</param>
+        /// <param name="overlayMaterial">Optional segment material.</param>
+        /// <param name="overlaySelfModulate">When set, stored on <see cref="HealthBarForecastSegment.OverlaySelfModulate" />.</param>
+        public static IEnumerable<HealthBarForecastSegment> Single(
+            int amount,
+            Color color,
+            HealthBarForecastGrowthDirection direction,
+            int order,
+            Material? overlayMaterial,
+            Color? overlaySelfModulate)
+        {
             if (amount <= 0)
                 return [];
 
-            return [new(amount, color, direction, order, overlayMaterial)];
+            return [new(amount, color, direction, order, overlayMaterial, overlaySelfModulate)];
         }
 
         /// <summary>
@@ -56,7 +104,9 @@ namespace STS2RitsuLib.Combat.HealthBars
             Color color,
             HealthBarForecastGrowthDirection direction,
             int order = 0)
-            => Single(amount, color, direction, order, null);
+        {
+            return Single(amount, color, direction, order, null, null);
+        }
     }
 
     /// <summary>
@@ -73,7 +123,7 @@ namespace STS2RitsuLib.Combat.HealthBars
 
         /// <summary>
         ///     Appends a segment when <paramref name="amount" /> is positive.
-        ///     Consecutive segments with identical color/direction/order/material are merged.
+        ///     Consecutive segments with identical color, direction, order, material reference, and overlay modulate are merged.
         /// </summary>
         public HealthBarForecastSequenceBuilder Add(
             int amount,
@@ -82,10 +132,33 @@ namespace STS2RitsuLib.Combat.HealthBars
             int order,
             Material? overlayMaterial)
         {
+            return Add(amount, color, direction, order, overlayMaterial, null);
+        }
+
+        /// <summary>
+        ///     Appends a segment when <paramref name="amount" /> is positive, with explicit overlay modulate.
+        /// </summary>
+        /// <param name="amount">HP chunk size.</param>
+        /// <param name="color">Lethal label color and fallback modulate.</param>
+        /// <param name="direction">Growth direction.</param>
+        /// <param name="order">Sort order among segments.</param>
+        /// <param name="overlayMaterial">Optional segment material.</param>
+        /// <param name="overlaySelfModulate">
+        ///     Optional overlay <see cref="CanvasItem.SelfModulate" />; null uses <paramref name="color" />.
+        /// </param>
+        public HealthBarForecastSequenceBuilder Add(
+            int amount,
+            Color color,
+            HealthBarForecastGrowthDirection direction,
+            int order,
+            Material? overlayMaterial,
+            Color? overlaySelfModulate)
+        {
             if (amount <= 0)
                 return this;
 
-            var segment = new HealthBarForecastSegment(amount, color, direction, order, overlayMaterial);
+            var segment =
+                new HealthBarForecastSegment(amount, color, direction, order, overlayMaterial, overlaySelfModulate);
             if (_segments.Count > 0)
             {
                 var last = _segments[^1];
@@ -108,7 +181,9 @@ namespace STS2RitsuLib.Combat.HealthBars
             Color color,
             HealthBarForecastGrowthDirection direction,
             int order = 0)
-            => Add(amount, color, direction, order, null);
+        {
+            return Add(amount, color, direction, order, null, null);
+        }
 
         /// <summary>
         ///     Appends all positive amounts as consecutive segments.
@@ -120,10 +195,30 @@ namespace STS2RitsuLib.Combat.HealthBars
             int order,
             Material? overlayMaterial)
         {
+            return AddRange(amounts, color, direction, order, overlayMaterial, null);
+        }
+
+        /// <summary>
+        ///     Appends all positive amounts as consecutive segments with explicit overlay modulate.
+        /// </summary>
+        /// <param name="amounts">HP chunk sizes.</param>
+        /// <param name="color">Lethal label color and fallback modulate.</param>
+        /// <param name="direction">Growth direction.</param>
+        /// <param name="order">Sort order among segments.</param>
+        /// <param name="overlayMaterial">Optional segment material.</param>
+        /// <param name="overlaySelfModulate">Optional overlay <see cref="CanvasItem.SelfModulate" /> shared by chunks.</param>
+        public HealthBarForecastSequenceBuilder AddRange(
+            IEnumerable<int> amounts,
+            Color color,
+            HealthBarForecastGrowthDirection direction,
+            int order,
+            Material? overlayMaterial,
+            Color? overlaySelfModulate)
+        {
             ArgumentNullException.ThrowIfNull(amounts);
 
             foreach (var amount in amounts)
-                Add(amount, color, direction, order, overlayMaterial);
+                Add(amount, color, direction, order, overlayMaterial, overlaySelfModulate);
 
             return this;
         }
@@ -136,7 +231,9 @@ namespace STS2RitsuLib.Combat.HealthBars
             Color color,
             HealthBarForecastGrowthDirection direction,
             int order = 0)
-            => AddRange(amounts, color, direction, order, null);
+        {
+            return AddRange(amounts, color, direction, order, null, null);
+        }
 
         /// <summary>
         ///     Appends segments that trigger at the start of <paramref name="triggerSide" />'s turn.
@@ -175,7 +272,13 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public HealthBarForecastLaneBuilder FromRight(Color color)
         {
-            return new(this, color, HealthBarForecastGrowthDirection.FromRight);
+            return FromRight(color, null);
+        }
+
+        /// <inheritdoc cref="HealthBarForecasts.FromRight(HealthBarForecastContext, Color, Color?)" />
+        public HealthBarForecastLaneBuilder FromRight(Color color, Color? overlaySelfModulate)
+        {
+            return new(this, color, HealthBarForecastGrowthDirection.FromRight, overlaySelfModulate);
         }
 
         /// <summary>
@@ -183,7 +286,13 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public HealthBarForecastLaneBuilder FromLeft(Color color)
         {
-            return new(this, color, HealthBarForecastGrowthDirection.FromLeft);
+            return FromLeft(color, null);
+        }
+
+        /// <inheritdoc cref="FromRight(Color, Color?)" />
+        public HealthBarForecastLaneBuilder FromLeft(Color color, Color? overlaySelfModulate)
+        {
+            return new(this, color, HealthBarForecastGrowthDirection.FromLeft, overlaySelfModulate);
         }
 
         /// <summary>
@@ -199,6 +308,7 @@ namespace STS2RitsuLib.Combat.HealthBars
             return left.Color == right.Color &&
                    left.Direction == right.Direction &&
                    left.Order == right.Order &&
+                   left.OverlaySelfModulate == right.OverlaySelfModulate &&
                    ReferenceEquals(left.OverlayMaterial, right.OverlayMaterial);
         }
     }
@@ -206,10 +316,15 @@ namespace STS2RitsuLib.Combat.HealthBars
     /// <summary>
     ///     Convenience wrapper for the common case of one fixed-color forecast lane.
     /// </summary>
+    /// <param name="sequence">Parent sequence builder.</param>
+    /// <param name="color">Lane label / fallback modulate color.</param>
+    /// <param name="direction">Growth edge for this lane.</param>
+    /// <param name="overlaySelfModulate">When set, used as <see cref="CanvasItem.SelfModulate" /> for segments in this lane.</param>
     public sealed class HealthBarForecastLaneBuilder(
         HealthBarForecastSequenceBuilder sequence,
         Color color,
-        HealthBarForecastGrowthDirection direction)
+        HealthBarForecastGrowthDirection direction,
+        Color? overlaySelfModulate = null)
     {
         /// <summary>
         ///     Parent sequence builder.
@@ -221,7 +336,7 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public HealthBarForecastLaneBuilder Add(int amount, int order, Material? overlayMaterial)
         {
-            Sequence.Add(amount, color, direction, order, overlayMaterial);
+            Sequence.Add(amount, color, direction, order, overlayMaterial, overlaySelfModulate);
             return this;
         }
 
@@ -229,14 +344,16 @@ namespace STS2RitsuLib.Combat.HealthBars
         ///     Appends a segment without a custom material.
         /// </summary>
         public HealthBarForecastLaneBuilder Add(int amount, int order = 0)
-            => Add(amount, order, null);
+        {
+            return Add(amount, order, null);
+        }
 
         /// <summary>
         ///     Appends multiple segments with the same <paramref name="order" /> and optional <paramref name="overlayMaterial" />.
         /// </summary>
         public HealthBarForecastLaneBuilder AddRange(IEnumerable<int> amounts, int order, Material? overlayMaterial)
         {
-            Sequence.AddRange(amounts, color, direction, order, overlayMaterial);
+            Sequence.AddRange(amounts, color, direction, order, overlayMaterial, overlaySelfModulate);
             return this;
         }
 
@@ -244,14 +361,17 @@ namespace STS2RitsuLib.Combat.HealthBars
         ///     Appends multiple segments without a custom material.
         /// </summary>
         public HealthBarForecastLaneBuilder AddRange(IEnumerable<int> amounts, int order = 0)
-            => AddRange(amounts, order, null);
+        {
+            return AddRange(amounts, order, null);
+        }
 
         /// <summary>
         ///     Appends segments that trigger at the start of <paramref name="triggerSide" />'s turn.
         /// </summary>
         public HealthBarForecastLaneBuilder AtSideTurnStart(CombatSide triggerSide, params int[] amounts)
         {
-            Sequence.AddSideTurnStart(triggerSide, color, direction, amounts);
+            var order = HealthBarForecastOrder.ForSideTurnStart(Sequence.Context.Creature, triggerSide);
+            Sequence.AddRange(amounts, color, direction, order, null, overlaySelfModulate);
             return this;
         }
 
@@ -260,7 +380,8 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public HealthBarForecastLaneBuilder AtSideTurnEnd(CombatSide triggerSide, params int[] amounts)
         {
-            Sequence.AddSideTurnEnd(triggerSide, color, direction, amounts);
+            var order = HealthBarForecastOrder.ForSideTurnEnd(Sequence.Context.Creature, triggerSide);
+            Sequence.AddRange(amounts, color, direction, order, null, overlaySelfModulate);
             return this;
         }
 
@@ -269,7 +390,7 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public HealthBarForecastLaneBuilder ThenFromRight(Color nextColor)
         {
-            return Sequence.FromRight(nextColor);
+            return Sequence.FromRight(nextColor, null);
         }
 
         /// <summary>
@@ -277,7 +398,7 @@ namespace STS2RitsuLib.Combat.HealthBars
         /// </summary>
         public HealthBarForecastLaneBuilder ThenFromLeft(Color nextColor)
         {
-            return Sequence.FromLeft(nextColor);
+            return Sequence.FromLeft(nextColor, null);
         }
 
         /// <summary>

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -1,5 +1,4 @@
 using Godot;
-using HarmonyLib;
 using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Models.Powers;
@@ -13,32 +12,6 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
     {
         private static readonly AttachedState<NHealthBar, HealthBarForecastUiState?> UiStates = new(() => null);
 
-        private static readonly AccessTools.FieldRef<NHealthBar, Control> HpForegroundContainerRef =
-            AccessTools.FieldRefAccess<NHealthBar, Control>("_hpForegroundContainer");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, Control> HpForegroundRef =
-            AccessTools.FieldRefAccess<NHealthBar, Control>("_hpForeground");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, Control> PoisonForegroundRef =
-            AccessTools.FieldRefAccess<NHealthBar, Control>("_poisonForeground");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, Control> DoomForegroundRef =
-            AccessTools.FieldRefAccess<NHealthBar, Control>("_doomForeground");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, Control> HpMiddlegroundRef =
-            AccessTools.FieldRefAccess<NHealthBar, Control>("_hpMiddleground");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, MegaLabel> HpLabelRef =
-            AccessTools.FieldRefAccess<NHealthBar, MegaLabel>("_hpLabel");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, Creature> CreatureRef =
-            AccessTools.FieldRefAccess<NHealthBar, Creature>("_creature");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, Tween?> MiddlegroundTweenRef =
-            AccessTools.FieldRefAccess<NHealthBar, Tween?>("_middlegroundTween");
-
-        private static readonly AccessTools.FieldRef<NHealthBar, float> ExpectedMaxFgWidthRef =
-            AccessTools.FieldRefAccess<NHealthBar, float>("_expectedMaxFgWidth");
         private static readonly Color DoomLethalTextColor = new("FB8DFF");
         private static readonly Color DoomLethalOutlineColor = new("2D1263");
 
@@ -48,7 +21,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             if (BaseLibHealthBarForecastBridge.ShouldRitsuRendererStandDown())
                 return;
 
-            var creature = CreatureRef(healthBar);
+            var creature = healthBar._creature;
             if (creature.CurrentHp <= 0 || creature.ShowsInfiniteHp)
             {
                 HideAllCustomSegments(healthBar);
@@ -68,7 +41,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             EnsureOverlayOrder(healthBar, state);
 
             var maxWidth = GetMaxFgWidth(healthBar);
-            var hpForeground = HpForegroundRef(healthBar);
+            var hpForeground = healthBar._hpForeground;
             var baseHp = Math.Clamp(HpFromOffsetRight(healthBar, hpForeground.OffsetRight), 0, creature.CurrentHp);
 
             var rightSegments = customSegments
@@ -126,7 +99,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                     hpForeground.Visible = false;
                 }
 
-                var doomForeground = DoomForegroundRef(healthBar);
+                var doomForeground = healthBar._doomForeground;
                 if (doomForeground.Visible)
                 {
                     if (remainingHp > 0)
@@ -195,22 +168,22 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             if (state == null || !state.LastRender.HasRightForecast)
                 return;
 
-            var creature = CreatureRef(healthBar);
+            var creature = healthBar._creature;
             if (creature.CurrentHp <= 0 || creature.ShowsInfiniteHp)
                 return;
 
-            var hpMiddleground = HpMiddlegroundRef(healthBar);
+            var hpMiddleground = healthBar._hpMiddleground;
             var targetOffsetRight = state.LastRender.RightForecastEdgeOffsetRight;
             var shouldAnimateImmediately = targetOffsetRight >= hpMiddleground.OffsetRight;
             hpMiddleground.OffsetRight += 1f;
 
-            MiddlegroundTweenRef(healthBar)?.Kill();
+            healthBar._middlegroundTween?.Kill();
             var tween = healthBar.CreateTween();
             tween.TweenProperty(hpMiddleground, "offset_right", targetOffsetRight - 2f, 1.0)
                 .SetDelay(shouldAnimateImmediately ? 0.0 : 1.0)
                 .SetEase(Tween.EaseType.Out)
                 .SetTrans(Tween.TransitionType.Expo);
-            MiddlegroundTweenRef(healthBar) = tween;
+            healthBar._middlegroundTween = tween;
         }
 
         public static void RefreshTextOverlay(NHealthBar healthBar)
@@ -222,12 +195,12 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             if (state == null)
                 return;
 
-            var creature = CreatureRef(healthBar);
+            var creature = healthBar._creature;
             if (creature.CurrentHp <= 0 || creature.ShowsInfiniteHp)
                 return;
 
             var lethalColor = state.LastRender.LethalRightColor ?? state.LastRender.LethalLeftColor;
-            var hpLabel = HpLabelRef(healthBar);
+            var hpLabel = healthBar._hpLabel;
             if (!lethalColor.HasValue)
             {
                 if (!IsDoomLethalAfterRight(healthBar, creature))
@@ -269,8 +242,8 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             if (UiStates[healthBar] != null)
                 return;
 
-            var poisonForeground = (NinePatchRect)PoisonForegroundRef(healthBar);
-            var doomForeground = (NinePatchRect)DoomForegroundRef(healthBar);
+            var poisonForeground = (NinePatchRect)healthBar._poisonForeground;
+            var doomForeground = (NinePatchRect)healthBar._doomForeground;
             var mask = poisonForeground.GetParent<Control>();
             var rightContainer = CreateContainer("RitsuForecastRightContainer");
             var leftContainer = CreateContainer("RitsuForecastLeftContainer");
@@ -309,9 +282,9 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
         private static void EnsureOverlayOrder(NHealthBar healthBar, HealthBarForecastUiState state)
         {
-            if (PoisonForegroundRef(healthBar) is not Control poisonForeground ||
-                HpForegroundRef(healthBar) is not Control hpForeground ||
-                DoomForegroundRef(healthBar) is not Control doomForeground ||
+            if (healthBar._poisonForeground is not Control poisonForeground ||
+                healthBar._hpForeground is not Control hpForeground ||
+                healthBar._doomForeground is not Control doomForeground ||
                 poisonForeground.GetParent() is not Control mask)
             {
                 return;
@@ -356,15 +329,15 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
         private static float GetMaxFgWidth(NHealthBar healthBar)
         {
-            var expectedMaxFgWidth = ExpectedMaxFgWidthRef(healthBar);
+            var expectedMaxFgWidth = healthBar._expectedMaxFgWidth;
             return expectedMaxFgWidth > 0f
                 ? expectedMaxFgWidth
-                : HpForegroundContainerRef(healthBar).Size.X;
+                : healthBar._hpForegroundContainer.Size.X;
         }
 
         private static float GetFgWidth(NHealthBar healthBar, int amount)
         {
-            var creature = CreatureRef(healthBar);
+            var creature = healthBar._creature;
             if (creature.MaxHp <= 0 || amount <= 0)
                 return 0f;
 
@@ -374,7 +347,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
         private static int HpFromOffsetRight(NHealthBar healthBar, float offsetRight)
         {
-            var creature = CreatureRef(healthBar);
+            var creature = healthBar._creature;
             if (creature.MaxHp <= 0)
                 return 0;
 
@@ -404,7 +377,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 return false;
 
             var hpAfterRight = Math.Clamp(
-                HpFromOffsetRight(healthBar, HpForegroundRef(healthBar).OffsetRight),
+                HpFromOffsetRight(healthBar, healthBar._hpForeground.OffsetRight),
                 0,
                 creature.CurrentHp);
             return hpAfterRight > 0 && doomAmount >= hpAfterRight;

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -72,7 +72,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 var leftWidth = GetFgWidth(healthBar, remainingHp);
                 var rightWidth = GetFgWidth(healthBar, previousHp);
                 node.Visible = true;
-                node.SelfModulate = segment.Color;
+                ApplyForecastSegmentAppearance(node, segment.Color, segment.OverlayMaterial);
                 node.OffsetLeft = remainingHp > 0 ? Math.Max(0f, leftWidth - node.PatchMarginLeft) : 0f;
                 node.OffsetRight = rightWidth - maxWidth;
 
@@ -142,7 +142,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 var endWidth = GetFgWidth(healthBar, leftAccumulated);
 
                 node.Visible = true;
-                node.SelfModulate = segment.Color;
+                ApplyForecastSegmentAppearance(node, segment.Color, segment.OverlayMaterial);
                 node.OffsetLeft = segmentStart > 0 ? Math.Max(0f, startWidth - node.PatchMarginLeft) : 0f;
                 var leftOffsetRight = Math.Min(0f, endWidth - maxWidth + node.PatchMarginRight);
                 if (rightIndex > 0)
@@ -225,7 +225,8 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                     registered.Segment.Color,
                     registered.Segment.Direction,
                     registered.Segment.Order,
-                    registered.SequenceOrder))
+                    registered.SequenceOrder,
+                    registered.Segment.OverlayMaterial))
                 .Where(segment => segment.Amount > 0)
                 .ToArray();
         }
@@ -331,7 +332,15 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                     continue;
 
                 segment.Visible = false;
+                segment.Material = null;
+                segment.SelfModulate = Colors.White;
             }
+        }
+
+        private static void ApplyForecastSegmentAppearance(NinePatchRect node, Color color, Material? overlayMaterial)
+        {
+            node.Material = overlayMaterial;
+            node.SelfModulate = color;
         }
 
         private static float GetMaxFgWidth(NHealthBar healthBar)
@@ -408,7 +417,8 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             Color Color,
             HealthBarForecastGrowthDirection Direction,
             int Order,
-            long SequenceOrder);
+            long SequenceOrder,
+            Material? OverlayMaterial);
 
         private readonly record struct HealthBarForecastRenderResult(
             bool HasRightForecast,

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -204,11 +204,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             if (!lethalColor.HasValue)
             {
                 if (!IsDoomLethalAfterRight(healthBar, creature))
-                {
-                    hpLabel.RemoveThemeColorOverride("font_color");
-                    hpLabel.RemoveThemeColorOverride("font_outline_color");
                     return;
-                }
                 hpLabel.AddThemeColorOverride("font_color", DoomLethalTextColor);
                 hpLabel.AddThemeColorOverride("font_outline_color", DoomLethalOutlineColor);
                 return;

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -2,6 +2,7 @@ using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Models.Powers;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using STS2RitsuLib.Patching.Models;
 using STS2RitsuLib.Utils;
@@ -21,6 +22,9 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
         private static readonly AccessTools.FieldRef<NHealthBar, Control> PoisonForegroundRef =
             AccessTools.FieldRefAccess<NHealthBar, Control>("_poisonForeground");
 
+        private static readonly AccessTools.FieldRef<NHealthBar, Control> DoomForegroundRef =
+            AccessTools.FieldRefAccess<NHealthBar, Control>("_doomForeground");
+
         private static readonly AccessTools.FieldRef<NHealthBar, Control> HpMiddlegroundRef =
             AccessTools.FieldRefAccess<NHealthBar, Control>("_hpMiddleground");
 
@@ -35,9 +39,15 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
         private static readonly AccessTools.FieldRef<NHealthBar, float> ExpectedMaxFgWidthRef =
             AccessTools.FieldRefAccess<NHealthBar, float>("_expectedMaxFgWidth");
+        private static readonly Color DoomLethalTextColor = new("FB8DFF");
+        private static readonly Color DoomLethalOutlineColor = new("2D1263");
 
         public static void RefreshForegroundOverlay(NHealthBar healthBar)
         {
+            BaseLibHealthBarForecastBridge.TryRegisterSecondary();
+            if (BaseLibHealthBarForecastBridge.ShouldRitsuRendererStandDown())
+                return;
+
             var creature = CreatureRef(healthBar);
             if (creature.CurrentHp <= 0 || creature.ShowsInfiniteHp)
             {
@@ -55,6 +65,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             EnsureUiState(healthBar);
             var state = UiStates[healthBar] ??
                         throw new InvalidOperationException("Missing health bar forecast UI state.");
+            EnsureOverlayOrder(healthBar, state);
 
             var maxWidth = GetMaxFgWidth(healthBar);
             var hpForeground = HpForegroundRef(healthBar);
@@ -80,7 +91,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 if (visibleAmount <= 0)
                     continue;
 
-                EnsureSegmentCount(state.RightSegments, state.RightContainer, rightIndex + 1, state.Template);
+                EnsureSegmentCount(state.RightSegments, state.RightContainer, rightIndex + 1, state.RightTemplate);
                 var node = state.RightSegments[rightIndex];
                 var previousHp = remainingHp;
                 remainingHp -= visibleAmount;
@@ -103,6 +114,28 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
             HideSegments(state.RightSegments, rightIndex);
 
+            if (rightIndex > 0)
+            {
+                if (remainingHp > 0)
+                {
+                    hpForeground.Visible = true;
+                    hpForeground.OffsetRight = GetFgWidth(healthBar, remainingHp) - maxWidth;
+                }
+                else
+                {
+                    hpForeground.Visible = false;
+                }
+
+                var doomForeground = DoomForegroundRef(healthBar);
+                if (doomForeground.Visible)
+                {
+                    if (remainingHp > 0)
+                        doomForeground.OffsetRight = Math.Min(doomForeground.OffsetRight, hpForeground.OffsetRight);
+                    else
+                        doomForeground.Visible = false;
+                }
+            }
+
             if (remainingHp <= 0)
             {
                 HideSegments(state.LeftSegments);
@@ -122,15 +155,15 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
             foreach (var segment in leftSegments)
             {
-                if (leftAccumulated >= creature.MaxHp)
+                if (leftAccumulated >= remainingHp)
                     break;
 
                 var segmentStart = leftAccumulated;
-                leftAccumulated = Math.Min(creature.MaxHp, leftAccumulated + segment.Amount);
+                leftAccumulated = Math.Min(remainingHp, leftAccumulated + segment.Amount);
                 if (leftAccumulated <= segmentStart)
                     continue;
 
-                EnsureSegmentCount(state.LeftSegments, state.LeftContainer, leftIndex + 1, state.Template);
+                EnsureSegmentCount(state.LeftSegments, state.LeftContainer, leftIndex + 1, state.LeftTemplate);
                 var node = state.LeftSegments[leftIndex];
                 var startWidth = GetFgWidth(healthBar, segmentStart);
                 var endWidth = GetFgWidth(healthBar, leftAccumulated);
@@ -138,7 +171,10 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 node.Visible = true;
                 node.SelfModulate = segment.Color;
                 node.OffsetLeft = segmentStart > 0 ? Math.Max(0f, startWidth - node.PatchMarginLeft) : 0f;
-                node.OffsetRight = Math.Min(0f, endWidth - maxWidth + node.PatchMarginRight);
+                var leftOffsetRight = Math.Min(0f, endWidth - maxWidth + node.PatchMarginRight);
+                if (rightIndex > 0)
+                    leftOffsetRight = Math.Min(leftOffsetRight, rightForecastEdgeOffsetRight);
+                node.OffsetRight = leftOffsetRight;
 
                 if (lethalLeftColor == null && leftAccumulated >= remainingHp)
                     lethalLeftColor = segment.Color;
@@ -152,6 +188,9 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
         public static void RefreshMiddlegroundOverlay(NHealthBar healthBar)
         {
+            if (BaseLibHealthBarForecastBridge.ShouldRitsuRendererStandDown())
+                return;
+
             var state = UiStates[healthBar];
             if (state == null || !state.LastRender.HasRightForecast)
                 return;
@@ -176,6 +215,9 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
         public static void RefreshTextOverlay(NHealthBar healthBar)
         {
+            if (BaseLibHealthBarForecastBridge.ShouldRitsuRendererStandDown())
+                return;
+
             var state = UiStates[healthBar];
             if (state == null)
                 return;
@@ -185,10 +227,15 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 return;
 
             var lethalColor = state.LastRender.LethalRightColor ?? state.LastRender.LethalLeftColor;
-            if (!lethalColor.HasValue)
-                return;
-
             var hpLabel = HpLabelRef(healthBar);
+            if (!lethalColor.HasValue)
+            {
+                if (!IsDoomLethalAfterRight(healthBar, creature))
+                    return;
+                hpLabel.AddThemeColorOverride("font_color", DoomLethalTextColor);
+                hpLabel.AddThemeColorOverride("font_outline_color", DoomLethalOutlineColor);
+                return;
+            }
             hpLabel.AddThemeColorOverride("font_color", lethalColor.Value);
             hpLabel.AddThemeColorOverride("font_outline_color", DarkenForOutline(lethalColor.Value));
         }
@@ -223,18 +270,19 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 return;
 
             var poisonForeground = (NinePatchRect)PoisonForegroundRef(healthBar);
+            var doomForeground = (NinePatchRect)DoomForegroundRef(healthBar);
             var mask = poisonForeground.GetParent<Control>();
             var rightContainer = CreateContainer("RitsuForecastRightContainer");
             var leftContainer = CreateContainer("RitsuForecastLeftContainer");
 
-            // Add custom overlays above vanilla layers, without mutating vanilla nodes.
             mask.AddChild(rightContainer);
             mask.AddChild(leftContainer);
 
             UiStates[healthBar] = new(
                 rightContainer,
                 leftContainer,
-                CreateSegmentTemplate(poisonForeground),
+                CreateSegmentTemplate(poisonForeground, "RitsuForecastRightTemplate"),
+                CreateSegmentTemplate(doomForeground, "RitsuForecastLeftTemplate"),
                 []);
         }
 
@@ -250,14 +298,32 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return container;
         }
 
-        private static NinePatchRect CreateSegmentTemplate(NinePatchRect template)
+        private static NinePatchRect CreateSegmentTemplate(NinePatchRect template, string name)
         {
             var duplicate = (NinePatchRect)template.Duplicate();
-            duplicate.Name = "RitsuForecastSegmentTemplate";
+            duplicate.Name = name;
             duplicate.Visible = false;
-            duplicate.Material = null;
             duplicate.SelfModulate = Colors.White;
             return duplicate;
+        }
+
+        private static void EnsureOverlayOrder(NHealthBar healthBar, HealthBarForecastUiState state)
+        {
+            if (PoisonForegroundRef(healthBar) is not Control poisonForeground ||
+                HpForegroundRef(healthBar) is not Control hpForeground ||
+                DoomForegroundRef(healthBar) is not Control doomForeground ||
+                poisonForeground.GetParent() is not Control mask)
+            {
+                return;
+            }
+
+            var poisonIndex = poisonForeground.GetIndex();
+            var hpIndex = hpForeground.GetIndex();
+            var rightTargetIndex = Math.Clamp(poisonIndex + 1, 0, hpIndex);
+            mask.MoveChild(state.RightContainer, rightTargetIndex);
+
+            var doomIndex = doomForeground.GetIndex();
+            mask.MoveChild(state.LeftContainer, doomIndex + 1);
         }
 
         private static void EnsureSegmentCount(
@@ -327,16 +393,34 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 Math.Clamp(color.G * 0.3f, 0f, 1f),
                 Math.Clamp(color.B * 0.3f, 0f, 1f));
         }
+        
+        private static bool IsDoomLethalAfterRight(NHealthBar healthBar, Creature creature)
+        {
+            if (!creature.HasPower<DoomPower>())
+                return false;
+
+            var doomAmount = creature.GetPowerAmount<DoomPower>();
+            if (doomAmount <= 0)
+                return false;
+
+            var hpAfterRight = Math.Clamp(
+                HpFromOffsetRight(healthBar, HpForegroundRef(healthBar).OffsetRight),
+                0,
+                creature.CurrentHp);
+            return hpAfterRight > 0 && doomAmount >= hpAfterRight;
+        }
 
         private sealed class HealthBarForecastUiState(
             Control rightContainer,
             Control leftContainer,
-            NinePatchRect template,
+            NinePatchRect rightTemplate,
+            NinePatchRect leftTemplate,
             List<NinePatchRect> rightSegments)
         {
             public Control RightContainer { get; } = rightContainer;
             public Control LeftContainer { get; } = leftContainer;
-            public NinePatchRect Template { get; } = template;
+            public NinePatchRect RightTemplate { get; } = rightTemplate;
+            public NinePatchRect LeftTemplate { get; } = leftTemplate;
             public List<NinePatchRect> RightSegments { get; } = rightSegments;
             public List<NinePatchRect> LeftSegments { get; } = [];
             public HealthBarForecastRenderResult LastRender { get; set; } = HealthBarForecastRenderResult.Empty;
@@ -370,10 +454,9 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "_Ready")];
         }
 
-        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
-            // Keep empty intentionally: do not alter vanilla hierarchy until needed.
+            BaseLibHealthBarForecastBridge.TryRegisterPrimary();
         }
     }
 
@@ -388,7 +471,6 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "RefreshForeground")];
         }
 
-        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
             NHealthBarForecastPatchHelper.RefreshForegroundOverlay(__instance);
@@ -406,7 +488,6 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "RefreshMiddleground")];
         }
 
-        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
             NHealthBarForecastPatchHelper.RefreshMiddlegroundOverlay(__instance);
@@ -424,7 +505,6 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "RefreshText")];
         }
 
-        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
             NHealthBarForecastPatchHelper.RefreshTextOverlay(__instance);

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -204,7 +204,11 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             if (!lethalColor.HasValue)
             {
                 if (!IsDoomLethalAfterRight(healthBar, creature))
+                {
+                    hpLabel.RemoveThemeColorOverride("font_color");
+                    hpLabel.RemoveThemeColorOverride("font_outline_color");
                     return;
+                }
                 hpLabel.AddThemeColorOverride("font_color", DoomLethalTextColor);
                 hpLabel.AddThemeColorOverride("font_outline_color", DoomLethalOutlineColor);
                 return;
@@ -277,6 +281,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             duplicate.Name = name;
             duplicate.Visible = false;
             duplicate.SelfModulate = Colors.White;
+            duplicate.Material = null;
             return duplicate;
         }
 
@@ -296,7 +301,9 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             mask.MoveChild(state.RightContainer, rightTargetIndex);
 
             var doomIndex = doomForeground.GetIndex();
-            mask.MoveChild(state.LeftContainer, doomIndex + 1);
+            var childCount = mask.GetChildCount();
+            var leftTargetIndex = Math.Clamp(doomIndex + 1, 0, Math.Max(0, childCount - 1));
+            mask.MoveChild(state.LeftContainer, leftTargetIndex);
         }
 
         private static void EnsureSegmentCount(

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -1,5 +1,4 @@
 using Godot;
-using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Models.Powers;
 using MegaCrit.Sts2.Core.Nodes.Combat;
@@ -10,6 +9,8 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 {
     internal static class NHealthBarForecastPatchHelper
     {
+        // ReSharper disable InconsistentNaming
+
         private static readonly AttachedState<NHealthBar, HealthBarForecastUiState?> UiStates = new(() => null);
 
         private static readonly Color DoomLethalTextColor = new("FB8DFF");
@@ -72,7 +73,11 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 var leftWidth = GetFgWidth(healthBar, remainingHp);
                 var rightWidth = GetFgWidth(healthBar, previousHp);
                 node.Visible = true;
-                ApplyForecastSegmentAppearance(node, segment.Color, segment.OverlayMaterial);
+                ApplyForecastSegmentAppearance(
+                    node,
+                    segment.Color,
+                    segment.OverlayMaterial,
+                    segment.OverlaySelfModulate);
                 node.OffsetLeft = remainingHp > 0 ? Math.Max(0f, leftWidth - node.PatchMarginLeft) : 0f;
                 node.OffsetRight = rightWidth - maxWidth;
 
@@ -142,7 +147,11 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 var endWidth = GetFgWidth(healthBar, leftAccumulated);
 
                 node.Visible = true;
-                ApplyForecastSegmentAppearance(node, segment.Color, segment.OverlayMaterial);
+                ApplyForecastSegmentAppearance(
+                    node,
+                    segment.Color,
+                    segment.OverlayMaterial,
+                    segment.OverlaySelfModulate);
                 node.OffsetLeft = segmentStart > 0 ? Math.Max(0f, startWidth - node.PatchMarginLeft) : 0f;
                 var leftOffsetRight = Math.Min(0f, endWidth - maxWidth + node.PatchMarginRight);
                 if (rightIndex > 0)
@@ -209,6 +218,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 hpLabel.AddThemeColorOverride("font_outline_color", DoomLethalOutlineColor);
                 return;
             }
+
             hpLabel.AddThemeColorOverride("font_color", lethalColor.Value);
             hpLabel.AddThemeColorOverride("font_outline_color", DarkenForOutline(lethalColor.Value));
         }
@@ -222,7 +232,8 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                     registered.Segment.Direction,
                     registered.Segment.Order,
                     registered.SequenceOrder,
-                    registered.Segment.OverlayMaterial))
+                    registered.Segment.OverlayMaterial,
+                    registered.Segment.OverlaySelfModulate))
                 .Where(segment => segment.Amount > 0)
                 .ToArray();
         }
@@ -284,13 +295,11 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
 
         private static void EnsureOverlayOrder(NHealthBar healthBar, HealthBarForecastUiState state)
         {
-            if (healthBar._poisonForeground is not Control poisonForeground ||
-                healthBar._hpForeground is not Control hpForeground ||
-                healthBar._doomForeground is not Control doomForeground ||
+            if (healthBar._poisonForeground is not { } poisonForeground ||
+                healthBar._hpForeground is not { } hpForeground ||
+                healthBar._doomForeground is not { } doomForeground ||
                 poisonForeground.GetParent() is not Control mask)
-            {
                 return;
-            }
 
             var poisonIndex = poisonForeground.GetIndex();
             var hpIndex = hpForeground.GetIndex();
@@ -333,10 +342,18 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             }
         }
 
-        private static void ApplyForecastSegmentAppearance(NinePatchRect node, Color color, Material? overlayMaterial)
+        /// <summary>
+        ///     Applies segment material and <see cref="CanvasItem.SelfModulate" />; overlay uses
+        ///     <paramref name="overlaySelfModulate" /> when set, otherwise <paramref name="color" />.
+        /// </summary>
+        private static void ApplyForecastSegmentAppearance(
+            NinePatchRect node,
+            Color color,
+            Material? overlayMaterial,
+            Color? overlaySelfModulate)
         {
             node.Material = overlayMaterial;
-            node.SelfModulate = color;
+            node.SelfModulate = overlaySelfModulate ?? color;
         }
 
         private static float GetMaxFgWidth(NHealthBar healthBar)
@@ -378,7 +395,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
                 Math.Clamp(color.G * 0.3f, 0f, 1f),
                 Math.Clamp(color.B * 0.3f, 0f, 1f));
         }
-        
+
         private static bool IsDoomLethalAfterRight(NHealthBar healthBar, Creature creature)
         {
             var doomAmount = creature.GetPowerAmount<DoomPower>();
@@ -408,13 +425,17 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             public HealthBarForecastRenderResult LastRender { get; set; } = HealthBarForecastRenderResult.Empty;
         }
 
+        /// <summary>
+        ///     Snapshot of one registry segment plus render order for layout and lethal text resolution.
+        /// </summary>
         private readonly record struct CustomSegment(
             int Amount,
             Color Color,
             HealthBarForecastGrowthDirection Direction,
             int Order,
             long SequenceOrder,
-            Material? OverlayMaterial);
+            Material? OverlayMaterial,
+            Color? OverlaySelfModulate);
 
         private readonly record struct HealthBarForecastRenderResult(
             bool HasRightForecast,
@@ -424,6 +445,8 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
         {
             public static HealthBarForecastRenderResult Empty => new(false, 0f, null, null);
         }
+
+        // ReSharper restore InconsistentNaming
     }
 
     internal sealed class NHealthBarReadyForecastPatch : IPatchMethod
@@ -437,6 +460,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "_Ready")];
         }
 
+        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
             BaseLibHealthBarForecastBridge.TryRegisterPrimary();
@@ -454,6 +478,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "RefreshForeground")];
         }
 
+        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
             NHealthBarForecastPatchHelper.RefreshForegroundOverlay(__instance);
@@ -471,6 +496,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "RefreshMiddleground")];
         }
 
+        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
             NHealthBarForecastPatchHelper.RefreshMiddlegroundOverlay(__instance);
@@ -488,6 +514,7 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
             return [new(typeof(NHealthBar), "RefreshText")];
         }
 
+        // ReSharper disable once InconsistentNaming
         public static void Postfix(NHealthBar __instance)
         {
             NHealthBarForecastPatchHelper.RefreshTextOverlay(__instance);

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -7,6 +7,10 @@ using STS2RitsuLib.Utils;
 
 namespace STS2RitsuLib.Combat.HealthBars.Patches
 {
+    /// <summary>
+    ///     Standalone forecast overlay logic for <see cref="NHealthBar" /> when BaseLib interop is unavailable or has not
+    ///     taken over rendering.
+    /// </summary>
     internal static class NHealthBarForecastPatchHelper
     {
         // ReSharper disable InconsistentNaming

--- a/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
+++ b/Combat/HealthBars/Patches/NHealthBarForecastPatches.cs
@@ -369,9 +369,6 @@ namespace STS2RitsuLib.Combat.HealthBars.Patches
         
         private static bool IsDoomLethalAfterRight(NHealthBar healthBar, Creature creature)
         {
-            if (!creature.HasPower<DoomPower>())
-                return false;
-
             var doomAmount = creature.GetPowerAmount<DoomPower>();
             if (doomAmount <= 0)
                 return false;

--- a/RitsuLibFramework.cs
+++ b/RitsuLibFramework.cs
@@ -184,6 +184,7 @@ namespace STS2RitsuLib
 
                     IsInitialized = true;
                     IsActive = true;
+                    BaseLibHealthBarForecastBridge.TryRegister();
 
                     var frameworkInitializedEvent = new FrameworkInitializedEvent(
                         Const.ModId,

--- a/Utils/MaterialUtils.cs
+++ b/Utils/MaterialUtils.cs
@@ -44,6 +44,10 @@ namespace STS2RitsuLib.Utils
         ///     Builds a <c>ShaderMaterial</c> using the game's doom health bar shader (<c>doom_bar.gdshader</c>) with the same
         ///     noise settings as <c>health_bar.tscn</c> and a caller-supplied gradient.
         /// </summary>
+        /// <remarks>
+        ///     Typical use: <see cref="Combat.HealthBars.HealthBarForecastSegment.OverlayMaterial" /> on custom forecast
+        ///     overlays so they read like the vanilla doom strip (see also <c>CreateVanillaDoomBarGradientTexture</c>).
+        /// </remarks>
         public static ShaderMaterial CreateDoomBarShaderMaterial(GradientTexture1D gradientTexture)
         {
             ArgumentNullException.ThrowIfNull(gradientTexture);

--- a/Utils/MaterialUtils.cs
+++ b/Utils/MaterialUtils.cs
@@ -5,9 +5,19 @@ namespace STS2RitsuLib.Utils
     /// <summary>
     ///     Factory helpers for Godot materials that mirror vanilla game shaders.
     /// </summary>
-    public class MaterialUtils
+    public static class MaterialUtils
     {
-        private static Shader? GameHsvShader => (Shader?)GD.Load<Shader>("res://shaders/hsv.gdshader")?.Duplicate();
+        private const string HsvShaderPath = "res://shaders/hsv.gdshader";
+        private const string DoomBarShaderPath = "res://scenes/combat/doom_bar.gdshader";
+
+        private static NoiseTexture2D? _vanillaDoomBarNoiseTexture;
+
+        private static Shader? GameHsvShader => (Shader?)GD.Load<Shader>(HsvShaderPath)?.Duplicate();
+
+        private static Shader? GameDoomBarShader => (Shader?)GD.Load<Shader>(DoomBarShaderPath)?.Duplicate();
+
+        private static NoiseTexture2D VanillaDoomBarNoiseTexture =>
+            _vanillaDoomBarNoiseTexture ??= CreateVanillaDoomBarNoiseTexture();
 
         /// <summary>
         ///     Builds a <c>ShaderMaterial</c> using the game's HSV shader with the given parameters.
@@ -16,7 +26,7 @@ namespace STS2RitsuLib.Utils
         {
             var shader = GameHsvShader;
             if (shader == null)
-                throw new("Failed to load HSV shader.");
+                throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
 
             var material = new ShaderMaterial
             {
@@ -28,6 +38,50 @@ namespace STS2RitsuLib.Utils
             material.SetShaderParameter("v", v);
 
             return material;
+        }
+
+        /// <summary>
+        ///     Builds a <c>ShaderMaterial</c> using the game's doom health bar shader (<c>doom_bar.gdshader</c>) with the same
+        ///     noise settings as <c>health_bar.tscn</c> and a caller-supplied gradient.
+        /// </summary>
+        public static ShaderMaterial CreateDoomBarShaderMaterial(GradientTexture1D gradientTexture)
+        {
+            ArgumentNullException.ThrowIfNull(gradientTexture);
+
+            var shader = GameDoomBarShader;
+            if (shader == null)
+                throw new InvalidOperationException($"Failed to load doom bar shader ({DoomBarShaderPath}).");
+
+            var material = new ShaderMaterial { Shader = shader };
+            material.SetShaderParameter("noise_tex", VanillaDoomBarNoiseTexture);
+            material.SetShaderParameter("gradient_tex", gradientTexture);
+            return material;
+        }
+
+        /// <summary>
+        ///     Gradient texture matching the vanilla doom bar segment in <c>health_bar.tscn</c>.
+        /// </summary>
+        public static GradientTexture1D CreateVanillaDoomBarGradientTexture()
+        {
+            var gradient = new Gradient();
+            gradient.AddPoint(0f, new(0.300863f, 0.162626f, 0.528347f));
+            gradient.AddPoint(0.514583f, new(0.513726f, 0.254902f, 0.505882f));
+            gradient.AddPoint(1f, new(0.354657f, 0.0421873f, 0.437114f));
+            return new() { Gradient = gradient };
+        }
+
+        /// <summary>
+        ///     Noise texture matching <c>health_bar.tscn</c> (Perlin, frequency 0.0383).
+        /// </summary>
+        public static NoiseTexture2D CreateVanillaDoomBarNoiseTexture()
+        {
+            var noise = new FastNoiseLite
+            {
+                NoiseType = FastNoiseLite.NoiseTypeEnum.Perlin,
+                Frequency = 0.0383f,
+            };
+
+            return new() { Noise = noise };
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a compatibility bridge for health bar forecast rendering with BaseLib and refactors the custom health bar overlay logic to use direct field access instead of reflection. It also improves the rendering logic for overlays, especially around lethal damage and doom effects, and ensures proper overlay ordering. These changes collectively enhance compatibility, maintainability, and visual correctness of health bar overlays.

**BaseLib Compatibility Integration**
* Added `BaseLibHealthBarForecastBridge` to detect and register interop with BaseLib's forecast API, allowing the custom renderer to stand down when BaseLib provides its own implementation.
* Updated patch hooks to attempt registration with BaseLib at appropriate lifecycle moments.

**Refactoring for Maintainability**
* Replaced all `AccessTools` reflection-based field accesses with direct field usage (e.g., `healthBar._hpForeground`), simplifying the code and improving performance. [[1]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bL15-R24) [[2]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bR41-R44) [[3]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bR164-R211) [[4]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bL225-R258) [[5]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bL293-R340) [[6]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bL311-R350)

**Overlay Rendering and Visual Improvements**
* Improved overlay rendering logic to handle lethal and doom effects more accurately, including new color cues for doom-lethal scenarios and better handling of overlay visibility and positioning. [[1]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bR90-R111) [[2]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bL125-R150) [[3]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bR164-R211) [[4]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bR370-R393)
* Ensured overlay containers are inserted in the correct visual order relative to vanilla health bar elements.

**UI State and Template Handling**
* Refactored UI state to use separate templates for left and right overlays, supporting more flexible and correct rendering for both sides of the health bar. [[1]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bL225-R258) [[2]](diffhunk://#diff-cd408e66c8ec0435a297c670155f27afd340334bc684d919223f086790d7be3bR370-R393)

These changes significantly improve integration with other mods, reduce code complexity, and enhance the clarity and accuracy of health bar overlays.