### PR TITLE
Implement chunked payload system for reliable data transfer

### DIFF
--- a/Multiplayer/ChunkedPayload/ChunkedPayloadChannel.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedPayloadChannel.cs
@@ -1,0 +1,459 @@
+using System.Diagnostics;
+using MegaCrit.Sts2.Core.Multiplayer.Game;
+
+namespace STS2RitsuLib.Multiplayer.ChunkedPayload
+{
+    /// <summary>
+    ///     Multiplexed reliable chunked binary channel on top of <see cref="INetGameService" />.
+    /// </summary>
+    public interface IChunkedPayloadChannel : IDisposable
+    {
+        /// <summary>Logical sub-channel id (multiplexing).</summary>
+        ushort StreamId { get; }
+
+        /// <inheritdoc cref="ChunkedPayloadChannel.Send" />
+        ChunkedPayloadSendResult Send(ReadOnlySpan<byte> payload, ulong? targetPeerId = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>Fired when a payload is fully received and CRC-checked.</summary>
+        event EventHandler<ChunkedPayloadReceivedEventArgs>? Received;
+
+        /// <summary>Fired when a transfer is aborted (timeout, CRC, limits, etc.).</summary>
+        event EventHandler<ChunkedPayloadFailedEventArgs>? Failed;
+    }
+
+    /// <summary>
+    ///     Registers <see cref="RitsuLibChunkedNetFragmentMessage" />, reassembles fragments with timeout and CRC checks,
+    ///     and exposes a simple send API. Thread-safe; handlers may run on the game’s networking thread.
+    /// </summary>
+    /// <inheritdoc cref="IChunkedPayloadChannel" />
+    public sealed class ChunkedPayloadChannel : IChunkedPayloadChannel
+    {
+        private readonly MessageHandlerDelegate<RitsuLibChunkedNetFragmentMessage> _handler;
+        private readonly INetGameService _net;
+        private readonly ChunkedTransferOptions _options;
+        private readonly Lock _sessionLock = new();
+
+        private readonly Dictionary<TransferKey, ReassemblySession> _sessions = new();
+
+        private bool _disposed;
+
+        private long _reassemblyBytesReserved;
+
+        /// <summary>
+        ///     Subscribes to <see cref="RitsuLibChunkedNetFragmentMessage" /> immediately; call <see cref="Dispose" /> to
+        ///     unregister.
+        /// </summary>
+        public ChunkedPayloadChannel(INetGameService netService, ushort streamId,
+            ChunkedTransferOptions? options = null)
+        {
+            _net = netService ?? throw new ArgumentNullException(nameof(netService));
+            StreamId = streamId;
+            _options = options ?? new ChunkedTransferOptions();
+            ValidateOptions(_options);
+            _handler = OnFragmentReceived;
+            _net.RegisterMessageHandler(_handler);
+        }
+
+        /// <inheritdoc />
+        public ushort StreamId { get; }
+
+        /// <inheritdoc />
+        public event EventHandler<ChunkedPayloadReceivedEventArgs>? Received;
+
+        /// <inheritdoc />
+        public event EventHandler<ChunkedPayloadFailedEventArgs>? Failed;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _net.UnregisterMessageHandler(_handler);
+            lock (_sessionLock)
+            {
+                _sessions.Clear();
+                _reassemblyBytesReserved = 0;
+            }
+        }
+
+        /// <summary>
+        ///     Sends a payload split across multiple <see cref="RitsuLibChunkedNetFragmentMessage" /> packets.
+        /// </summary>
+        /// <param name="payload">Data to send; CRC covers the full span.</param>
+        /// <param name="targetPeerId">Host only: send to one client. Omit to broadcast to ready clients.</param>
+        /// <param name="cancellationToken">Checked between fragments.</param>
+        public ChunkedPayloadSendResult Send(ReadOnlySpan<byte> payload, ulong? targetPeerId = null,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            if (!_net.IsConnected)
+                return ChunkedPayloadSendResult.Fail(ChunkedTransferFailureReason.NotConnected);
+
+            if (_net.Type == NetGameType.Client && targetPeerId.HasValue)
+                return ChunkedPayloadSendResult.Fail(ChunkedTransferFailureReason.InvalidSendTarget,
+                    "Clients must send without targetPeerId (traffic goes to the host).");
+
+            var maxFrag = _options.MaxFragmentPayloadBytes;
+            var maxTotal = _options.MaxTotalPayloadBytes;
+            if (payload.Length > maxTotal)
+                return ChunkedPayloadSendResult.Fail(ChunkedTransferFailureReason.PayloadTooLarge,
+                    $"Length {payload.Length} exceeds MaxTotalPayloadBytes ({maxTotal}).");
+
+            if (maxFrag is < 256 or > 65535)
+                return ChunkedPayloadSendResult.Fail(ChunkedTransferFailureReason.InvalidLayout,
+                    "MaxFragmentPayloadBytes must be in [256, 65535].");
+
+            var crc = RitsuLibChunkedNetFragmentMessage.ComputePayloadCrc32(payload);
+            var transferId = NextTransferId();
+            var chunkCount = ComputeChunkCount(payload.Length, maxFrag);
+            if (chunkCount > ComputeChunkCount(maxTotal, maxFrag))
+                return ChunkedPayloadSendResult.Fail(ChunkedTransferFailureReason.InvalidLayout,
+                    "Chunk count overflow.");
+
+            var delay = _options.InterFragmentDelay;
+            var sent = 0;
+            try
+            {
+                for (var i = 0; i < chunkCount; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var offset = i * maxFrag;
+                    var len = Math.Min(maxFrag, payload.Length - offset);
+                    var fragment = new byte[len];
+                    if (len > 0)
+                        payload.Slice(offset, len).CopyTo(fragment);
+
+                    var message = new RitsuLibChunkedNetFragmentMessage
+                    {
+                        SchemaVersion = RitsuLibChunkedNetFragmentMessage.SupportedSchemaVersion,
+                        StreamId = StreamId,
+                        DeclaredMaxFragmentBytes = (ushort)maxFrag,
+                        TransferId = transferId,
+                        TotalPayloadLength = (uint)payload.Length,
+                        ChunkIndex = (uint)i,
+                        ChunkCount = (uint)chunkCount,
+                        PayloadCrc32 = crc,
+                        Fragment = fragment,
+                    };
+
+                    if (_net.Type == NetGameType.Host)
+                    {
+                        if (targetPeerId.HasValue)
+                            _net.SendMessage(message, targetPeerId.Value);
+                        else
+                            _net.SendMessage(message);
+                    }
+                    else
+                    {
+                        _net.SendMessage(message);
+                    }
+
+                    sent++;
+                    if (i < chunkCount - 1 && delay > TimeSpan.Zero)
+                        DelayWithCancellation(delay, cancellationToken);
+                }
+
+                return ChunkedPayloadSendResult.Success(sent);
+            }
+            catch (OperationCanceledException)
+            {
+                return ChunkedPayloadSendResult.Fail(ChunkedTransferFailureReason.Cancelled, null, sent);
+            }
+        }
+
+        private static void DelayWithCancellation(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < delay)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Thread.Sleep(1);
+            }
+        }
+
+        private void OnFragmentReceived(RitsuLibChunkedNetFragmentMessage msg, ulong senderId)
+        {
+            if (_disposed || msg.StreamId != StreamId)
+                return;
+
+            CleanupExpiredSessions();
+
+            if (msg.SchemaVersion != RitsuLibChunkedNetFragmentMessage.SupportedSchemaVersion)
+            {
+                RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.UnsupportedOrCorrupt,
+                    $"Schema {msg.SchemaVersion} is not supported.");
+                return;
+            }
+
+            var maxFrag = msg.DeclaredMaxFragmentBytes;
+            // ReSharper disable once PatternIsRedundant
+            if (maxFrag is < 256 or > 65535)
+            {
+                RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.UnsupportedOrCorrupt,
+                    "DeclaredMaxFragmentBytes out of range.");
+                return;
+            }
+
+            if (msg.TotalPayloadLength > (uint)_options.MaxTotalPayloadBytes)
+            {
+                RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.PayloadTooLarge,
+                    "Header TotalPayloadLength exceeds local MaxTotalPayloadBytes.");
+                return;
+            }
+
+            var totalLen = (int)msg.TotalPayloadLength;
+            var chunkCount = (int)msg.ChunkCount;
+            if (chunkCount <= 0 || msg.ChunkIndex >= msg.ChunkCount)
+            {
+                RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.InvalidLayout,
+                    "Invalid chunk index or count.");
+                return;
+            }
+
+            var expectedChunks = ComputeChunkCount(totalLen, maxFrag);
+            if (expectedChunks != chunkCount)
+            {
+                RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.InvalidLayout,
+                    "ChunkCount does not match TotalPayloadLength and fragment size.");
+                return;
+            }
+
+            var expectedLen = ExpectedFragmentLength((int)msg.ChunkIndex, chunkCount, totalLen, maxFrag);
+            if (msg.Fragment.Length != expectedLen)
+            {
+                RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.InvalidLayout,
+                    $"Fragment length {msg.Fragment.Length} != expected {expectedLen}.");
+                return;
+            }
+
+            if (msg.Fragment.Length > _options.MaxFragmentPayloadBytes)
+            {
+                RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.InvalidLayout,
+                    "Fragment exceeds local MaxFragmentPayloadBytes.");
+                return;
+            }
+
+            List<Action>? afterLock = null;
+
+            lock (_sessionLock)
+            {
+                var key = new TransferKey(senderId, msg.TransferId);
+                if (!_sessions.TryGetValue(key, out var session))
+                {
+                    if (_sessions.Count >= _options.MaxConcurrentIncomingTransfers)
+                    {
+                        Defer(() => RaiseFailed(senderId, msg.TransferId,
+                            ChunkedTransferFailureReason.TooManyConcurrentTransfers, null));
+                        goto flush;
+                    }
+
+                    var need = (long)totalLen;
+                    if (_reassemblyBytesReserved + need > _options.MaxReassemblyBytesInFlight)
+                    {
+                        Defer(() => RaiseFailed(senderId, msg.TransferId,
+                            ChunkedTransferFailureReason.ReassemblyMemoryCap, null));
+                        goto flush;
+                    }
+
+                    session = new()
+                    {
+                        SenderNetId = senderId,
+                        StreamId = StreamId,
+                        TransferId = msg.TransferId,
+                        TotalLength = totalLen,
+                        ChunkCount = chunkCount,
+                        MaxFragment = maxFrag,
+                        ExpectedCrc = msg.PayloadCrc32,
+                        Buffer = new byte[totalLen],
+                        ReceivedMarks = new bool[chunkCount],
+                        DeadlineUtc = DateTime.UtcNow + _options.TransferTimeout,
+                        ReservedBytes = need,
+                    };
+                    _sessions[key] = session;
+                    _reassemblyBytesReserved += need;
+                }
+                else
+                {
+                    if (session.TotalLength != totalLen || session.ChunkCount != chunkCount ||
+                        session.MaxFragment != maxFrag || session.ExpectedCrc != msg.PayloadCrc32)
+                    {
+                        RemoveSessionUnlocked(key, session);
+                        Defer(() => RaiseFailed(senderId, msg.TransferId,
+                            ChunkedTransferFailureReason.InvalidLayout,
+                            "Conflicting continuation for the same TransferId."));
+                        goto flush;
+                    }
+                }
+
+                if (DateTime.UtcNow > session.DeadlineUtc)
+                {
+                    RemoveSessionUnlocked(key, session);
+                    Defer(() => RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.TimedOut, null));
+                    goto flush;
+                }
+
+                var idx = (int)msg.ChunkIndex;
+                if (session.ReceivedMarks[idx])
+                    goto flush;
+
+                var start = idx * session.MaxFragment;
+                if (msg.Fragment.Length > 0)
+                    Array.Copy(msg.Fragment, 0, session.Buffer, start, msg.Fragment.Length);
+                session.ReceivedMarks[idx] = true;
+                session.ReceivedCount++;
+
+                if (session.ReceivedCount < session.ChunkCount)
+                    goto flush;
+
+                _sessions.Remove(key);
+                _reassemblyBytesReserved -= session.ReservedBytes;
+
+                var crc = RitsuLibChunkedNetFragmentMessage.ComputePayloadCrc32(session.Buffer);
+                if (crc != session.ExpectedCrc)
+                {
+                    Defer(() => RaiseFailed(senderId, msg.TransferId, ChunkedTransferFailureReason.CrcMismatch, null));
+                    goto flush;
+                }
+
+                var payload = session.Buffer;
+                var sid = senderId;
+                var tid = msg.TransferId;
+                Defer(() => DispatchCompleted(sid, tid, payload));
+            }
+
+            flush:
+            if (afterLock == null)
+                return;
+            foreach (var a in afterLock)
+                a();
+            return;
+
+            void Defer(Action a)
+            {
+                (afterLock ??= []).Add(a);
+            }
+        }
+
+        private void DispatchCompleted(ulong senderId, ulong transferId, byte[] payload)
+        {
+            if (_options.CompletionDispatcher != null)
+                _options.CompletionDispatcher(Invoke);
+            else
+                Invoke();
+            return;
+
+            void Invoke()
+            {
+                Received?.Invoke(this, new(senderId, StreamId, transferId, payload));
+            }
+        }
+
+        private void RaiseFailed(ulong? senderId, ulong? transferId, ChunkedTransferFailureReason reason,
+            string? detail)
+        {
+            var args = new ChunkedPayloadFailedEventArgs(senderId, StreamId, transferId, reason, detail);
+            _options.TransferFailed?.Invoke(this, args);
+            Failed?.Invoke(this, args);
+        }
+
+        private void RemoveSessionUnlocked(TransferKey key, ReassemblySession session)
+        {
+            if (_sessions.Remove(key))
+                _reassemblyBytesReserved -= session.ReservedBytes;
+        }
+
+        private void CleanupExpiredSessions()
+        {
+            var now = DateTime.UtcNow;
+            List<(ulong SenderNetId, ulong TransferId)>? timedOut = null;
+            lock (_sessionLock)
+            {
+                foreach (var kv in new List<KeyValuePair<TransferKey, ReassemblySession>>(_sessions)
+                             .Where(kv => now > kv.Value.DeadlineUtc))
+                {
+                    RemoveSessionUnlocked(kv.Key, kv.Value);
+                    timedOut ??= [];
+                    timedOut.Add((kv.Value.SenderNetId, kv.Value.TransferId));
+                }
+            }
+
+            if (timedOut == null)
+                return;
+            foreach (var (sid, tid) in timedOut)
+                RaiseFailed(sid, tid, ChunkedTransferFailureReason.TimedOut, null);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (!_disposed) return;
+            throw new ObjectDisposedException(nameof(ChunkedPayloadChannel));
+        }
+
+        private static void ValidateOptions(ChunkedTransferOptions o)
+        {
+            if (o.MaxFragmentPayloadBytes is < 256 or > 65535)
+                throw new ArgumentOutOfRangeException(nameof(o), o.MaxFragmentPayloadBytes,
+                    $"{nameof(ChunkedTransferOptions.MaxFragmentPayloadBytes)} must be within [256, 65535].");
+            if (o.MaxTotalPayloadBytes < 0)
+                throw new ArgumentOutOfRangeException(nameof(o), o.MaxTotalPayloadBytes,
+                    $"{nameof(ChunkedTransferOptions.MaxTotalPayloadBytes)} cannot be negative.");
+            if (o.MaxConcurrentIncomingTransfers <= 0)
+                throw new ArgumentOutOfRangeException(nameof(o), o.MaxConcurrentIncomingTransfers,
+                    $"{nameof(ChunkedTransferOptions.MaxConcurrentIncomingTransfers)} must be positive.");
+            if (o.MaxReassemblyBytesInFlight <= 0)
+                throw new ArgumentOutOfRangeException(nameof(o), o.MaxReassemblyBytesInFlight,
+                    $"{nameof(ChunkedTransferOptions.MaxReassemblyBytesInFlight)} must be positive.");
+            if (o.TransferTimeout <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(o), o.TransferTimeout,
+                    $"{nameof(ChunkedTransferOptions.TransferTimeout)} must be greater than zero.");
+        }
+
+        private static int ComputeChunkCount(int totalLen, int maxFrag)
+        {
+            if (totalLen == 0)
+                return 1;
+            return (totalLen + maxFrag - 1) / maxFrag;
+        }
+
+        internal static int ExpectedFragmentLength(int chunkIndex, int chunkCount, int totalLen, int maxFrag)
+        {
+            var offset = chunkIndex * maxFrag;
+            return Math.Min(maxFrag, totalLen - offset);
+        }
+
+        private static ulong NextTransferId()
+        {
+            return unchecked((ulong)Random.Shared.NextInt64());
+        }
+
+        private readonly record struct TransferKey(ulong SenderNetId, ulong TransferId);
+
+        private sealed class ReassemblySession
+        {
+            public required byte[] Buffer;
+
+            public required int ChunkCount;
+
+            public required DateTime DeadlineUtc;
+
+            public required uint ExpectedCrc;
+
+            public required int MaxFragment;
+
+            public int ReceivedCount;
+
+            public required bool[] ReceivedMarks;
+
+            public required long ReservedBytes;
+            public required ulong SenderNetId;
+
+            public required ushort StreamId;
+
+            public required int TotalLength;
+
+            public required ulong TransferId;
+        }
+    }
+}

--- a/Multiplayer/ChunkedPayload/ChunkedPayloadChannel.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedPayloadChannel.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using MegaCrit.Sts2.Core.Multiplayer.Game;
 
 namespace STS2RitsuLib.Multiplayer.ChunkedPayload
@@ -8,17 +7,23 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
     /// </summary>
     public interface IChunkedPayloadChannel : IDisposable
     {
-        /// <summary>Logical sub-channel id (multiplexing).</summary>
+        /// <summary>
+        ///     Logical sub-channel id (multiplexing).
+        /// </summary>
         ushort StreamId { get; }
 
         /// <inheritdoc cref="ChunkedPayloadChannel.Send" />
         ChunkedPayloadSendResult Send(ReadOnlySpan<byte> payload, ulong? targetPeerId = null,
             CancellationToken cancellationToken = default);
 
-        /// <summary>Fired when a payload is fully received and CRC-checked.</summary>
+        /// <summary>
+        ///     Fired when a payload is fully received and CRC-checked.
+        /// </summary>
         event EventHandler<ChunkedPayloadReceivedEventArgs>? Received;
 
-        /// <summary>Fired when a transfer is aborted (timeout, CRC, limits, etc.).</summary>
+        /// <summary>
+        ///     Fired when a transfer is aborted (timeout, CRC, limits, etc.).
+        /// </summary>
         event EventHandler<ChunkedPayloadFailedEventArgs>? Failed;
     }
 
@@ -165,12 +170,12 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
 
         private static void DelayWithCancellation(TimeSpan delay, CancellationToken cancellationToken)
         {
-            var sw = Stopwatch.StartNew();
-            while (sw.Elapsed < delay)
-            {
+            if (delay <= TimeSpan.Zero)
+                return;
+            cancellationToken.ThrowIfCancellationRequested();
+            // Single wait avoids 1 ms spin loops on the networking thread (Copilot PR review).
+            if (cancellationToken.WaitHandle.WaitOne(delay))
                 cancellationToken.ThrowIfCancellationRequested();
-                Thread.Sleep(1);
-            }
         }
 
         private void OnFragmentReceived(RitsuLibChunkedNetFragmentMessage msg, ulong senderId)
@@ -393,20 +398,47 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
 
         private static void ValidateOptions(ChunkedTransferOptions o)
         {
-            if (o.MaxFragmentPayloadBytes is < 256 or > 65535)
-                throw new ArgumentOutOfRangeException(nameof(o), o.MaxFragmentPayloadBytes,
+            ThrowIfMaxFragmentPayloadBytesInvalid(o.MaxFragmentPayloadBytes);
+            ThrowIfMaxTotalPayloadBytesInvalid(o.MaxTotalPayloadBytes);
+            ThrowIfMaxConcurrentIncomingTransfersInvalid(o.MaxConcurrentIncomingTransfers);
+            ThrowIfMaxReassemblyBytesInFlightInvalid(o.MaxReassemblyBytesInFlight);
+            ThrowIfTransferTimeoutInvalid(o.TransferTimeout);
+        }
+
+        private static void ThrowIfMaxFragmentPayloadBytesInvalid(int maxFragmentPayloadBytes)
+        {
+            if (maxFragmentPayloadBytes is < 256 or > 65535)
+                throw new ArgumentOutOfRangeException(nameof(maxFragmentPayloadBytes), maxFragmentPayloadBytes,
                     $"{nameof(ChunkedTransferOptions.MaxFragmentPayloadBytes)} must be within [256, 65535].");
-            if (o.MaxTotalPayloadBytes < 0)
-                throw new ArgumentOutOfRangeException(nameof(o), o.MaxTotalPayloadBytes,
+        }
+
+        private static void ThrowIfMaxTotalPayloadBytesInvalid(int maxTotalPayloadBytes)
+        {
+            if (maxTotalPayloadBytes < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxTotalPayloadBytes), maxTotalPayloadBytes,
                     $"{nameof(ChunkedTransferOptions.MaxTotalPayloadBytes)} cannot be negative.");
-            if (o.MaxConcurrentIncomingTransfers <= 0)
-                throw new ArgumentOutOfRangeException(nameof(o), o.MaxConcurrentIncomingTransfers,
+        }
+
+        private static void ThrowIfMaxConcurrentIncomingTransfersInvalid(int maxConcurrentIncomingTransfers)
+        {
+            if (maxConcurrentIncomingTransfers <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxConcurrentIncomingTransfers),
+                    maxConcurrentIncomingTransfers,
                     $"{nameof(ChunkedTransferOptions.MaxConcurrentIncomingTransfers)} must be positive.");
-            if (o.MaxReassemblyBytesInFlight <= 0)
-                throw new ArgumentOutOfRangeException(nameof(o), o.MaxReassemblyBytesInFlight,
+        }
+
+        private static void ThrowIfMaxReassemblyBytesInFlightInvalid(long maxReassemblyBytesInFlight)
+        {
+            if (maxReassemblyBytesInFlight <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxReassemblyBytesInFlight),
+                    maxReassemblyBytesInFlight,
                     $"{nameof(ChunkedTransferOptions.MaxReassemblyBytesInFlight)} must be positive.");
-            if (o.TransferTimeout <= TimeSpan.Zero)
-                throw new ArgumentOutOfRangeException(nameof(o), o.TransferTimeout,
+        }
+
+        private static void ThrowIfTransferTimeoutInvalid(TimeSpan transferTimeout)
+        {
+            if (transferTimeout <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(transferTimeout), transferTimeout,
                     $"{nameof(ChunkedTransferOptions.TransferTimeout)} must be greater than zero.");
         }
 

--- a/Multiplayer/ChunkedPayload/ChunkedPayloadEventArgs.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedPayloadEventArgs.cs
@@ -1,0 +1,66 @@
+namespace STS2RitsuLib.Multiplayer.ChunkedPayload
+{
+    /// <summary>
+    ///     Fired when a full payload is available. The buffer is owned for the duration of the event; copy if you need it
+    ///     beyond the handler.
+    /// </summary>
+    public sealed class ChunkedPayloadReceivedEventArgs : EventArgs
+    {
+        /// <summary>Creates event args for a completed transfer.</summary>
+        public ChunkedPayloadReceivedEventArgs(ulong senderNetId, ushort streamId, ulong transferId, byte[] payload)
+        {
+            SenderNetId = senderNetId;
+            StreamId = streamId;
+            TransferId = transferId;
+            Payload = payload;
+        }
+
+        /// <summary>Peer that originated the transfer.</summary>
+        public ulong SenderNetId { get; }
+
+        /// <summary>Logical channel.</summary>
+        public ushort StreamId { get; }
+
+        /// <summary>Transfer id from wire.</summary>
+        public ulong TransferId { get; }
+
+        /// <summary>Reassembled, CRC-verified buffer.</summary>
+        public byte[] Payload { get; }
+    }
+
+    /// <summary>
+    ///     Fired when a transfer is abandoned after partial progress or when send validation fails.
+    /// </summary>
+    public sealed class ChunkedPayloadFailedEventArgs : EventArgs
+    {
+        /// <summary>Creates failure args.</summary>
+        public ChunkedPayloadFailedEventArgs(
+            ulong? senderNetId,
+            ushort streamId,
+            ulong? transferId,
+            ChunkedTransferFailureReason reason,
+            string? detail = null)
+        {
+            SenderNetId = senderNetId;
+            StreamId = streamId;
+            TransferId = transferId;
+            Reason = reason;
+            Detail = detail;
+        }
+
+        /// <summary>Peer, if known.</summary>
+        public ulong? SenderNetId { get; }
+
+        /// <summary>Logical channel.</summary>
+        public ushort StreamId { get; }
+
+        /// <summary>Transfer id, if known.</summary>
+        public ulong? TransferId { get; }
+
+        /// <summary>Failure classification.</summary>
+        public ChunkedTransferFailureReason Reason { get; }
+
+        /// <summary>Optional diagnostic text.</summary>
+        public string? Detail { get; }
+    }
+}

--- a/Multiplayer/ChunkedPayload/ChunkedPayloadEventArgs.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedPayloadEventArgs.cs
@@ -6,7 +6,9 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
     /// </summary>
     public sealed class ChunkedPayloadReceivedEventArgs : EventArgs
     {
-        /// <summary>Creates event args for a completed transfer.</summary>
+        /// <summary>
+        ///     Creates event args for a completed transfer.
+        /// </summary>
         public ChunkedPayloadReceivedEventArgs(ulong senderNetId, ushort streamId, ulong transferId, byte[] payload)
         {
             SenderNetId = senderNetId;
@@ -15,16 +17,24 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
             Payload = payload;
         }
 
-        /// <summary>Peer that originated the transfer.</summary>
+        /// <summary>
+        ///     Peer that originated the transfer.
+        /// </summary>
         public ulong SenderNetId { get; }
 
-        /// <summary>Logical channel.</summary>
+        /// <summary>
+        ///     Logical channel.
+        /// </summary>
         public ushort StreamId { get; }
 
-        /// <summary>Transfer id from wire.</summary>
+        /// <summary>
+        ///     Transfer id from wire.
+        /// </summary>
         public ulong TransferId { get; }
 
-        /// <summary>Reassembled, CRC-verified buffer.</summary>
+        /// <summary>
+        ///     Reassembled, CRC-verified buffer.
+        /// </summary>
         public byte[] Payload { get; }
     }
 
@@ -33,7 +43,9 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
     /// </summary>
     public sealed class ChunkedPayloadFailedEventArgs : EventArgs
     {
-        /// <summary>Creates failure args.</summary>
+        /// <summary>
+        ///     Creates failure args.
+        /// </summary>
         public ChunkedPayloadFailedEventArgs(
             ulong? senderNetId,
             ushort streamId,
@@ -48,19 +60,29 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
             Detail = detail;
         }
 
-        /// <summary>Peer, if known.</summary>
+        /// <summary>
+        ///     Peer, if known.
+        /// </summary>
         public ulong? SenderNetId { get; }
 
-        /// <summary>Logical channel.</summary>
+        /// <summary>
+        ///     Logical channel.
+        /// </summary>
         public ushort StreamId { get; }
 
-        /// <summary>Transfer id, if known.</summary>
+        /// <summary>
+        ///     Transfer id, if known.
+        /// </summary>
         public ulong? TransferId { get; }
 
-        /// <summary>Failure classification.</summary>
+        /// <summary>
+        ///     Failure classification.
+        /// </summary>
         public ChunkedTransferFailureReason Reason { get; }
 
-        /// <summary>Optional diagnostic text.</summary>
+        /// <summary>
+        ///     Optional diagnostic text.
+        /// </summary>
         public string? Detail { get; }
     }
 }

--- a/Multiplayer/ChunkedPayload/ChunkedPayloadGodotDispatch.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedPayloadGodotDispatch.cs
@@ -1,0 +1,19 @@
+using Godot;
+
+namespace STS2RitsuLib.Multiplayer.ChunkedPayload
+{
+    /// <summary>
+    ///     Bridges <see cref="ChunkedTransferOptions.CompletionDispatcher" /> to the Godot main thread using
+    ///     <c>Callable.From(…).CallDeferred()</c> (same pattern as other RitsuLib code).
+    /// </summary>
+    public static class ChunkedPayloadGodotDispatch
+    {
+        /// <summary>
+        ///     Returns a dispatcher that schedules work on Godot’s main thread message queue.
+        /// </summary>
+        public static Action<Action> ForMainThread()
+        {
+            return action => Callable.From(action).CallDeferred();
+        }
+    }
+}

--- a/Multiplayer/ChunkedPayload/ChunkedPayloadSendResult.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedPayloadSendResult.cs
@@ -5,7 +5,9 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
     /// </summary>
     public readonly struct ChunkedPayloadSendResult
     {
-        /// <summary>Creates a result value.</summary>
+        /// <summary>
+        ///     Creates a result value.
+        /// </summary>
         public ChunkedPayloadSendResult(bool ok, int fragmentsSent, ChunkedTransferFailureReason? failure,
             string? detail = null)
         {
@@ -15,25 +17,37 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
             Detail = detail;
         }
 
-        /// <summary>True if every fragment was accepted by the transport.</summary>
+        /// <summary>
+        ///     True if every fragment was accepted by the transport.
+        /// </summary>
         public bool Ok { get; }
 
-        /// <summary>Fragments successfully queued (partial count on cancellation).</summary>
+        /// <summary>
+        ///     Fragments successfully queued (partial count on cancellation).
+        /// </summary>
         public int FragmentsSent { get; }
 
-        /// <summary>Set when <see cref="Ok" /> is false.</summary>
+        /// <summary>
+        ///     Set when <see cref="Ok" /> is false.
+        /// </summary>
         public ChunkedTransferFailureReason? Failure { get; }
 
-        /// <summary>Optional diagnostic when <see cref="Ok" /> is false.</summary>
+        /// <summary>
+        ///     Optional diagnostic when <see cref="Ok" /> is false.
+        /// </summary>
         public string? Detail { get; }
 
-        /// <summary>Successful send.</summary>
+        /// <summary>
+        ///     Successful send.
+        /// </summary>
         public static ChunkedPayloadSendResult Success(int fragments)
         {
             return new(true, fragments, null);
         }
 
-        /// <summary>Failed send.</summary>
+        /// <summary>
+        ///     Failed send.
+        /// </summary>
         public static ChunkedPayloadSendResult Fail(ChunkedTransferFailureReason reason, string? detail = null,
             int sent = 0)
         {

--- a/Multiplayer/ChunkedPayload/ChunkedPayloadSendResult.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedPayloadSendResult.cs
@@ -1,0 +1,43 @@
+namespace STS2RitsuLib.Multiplayer.ChunkedPayload
+{
+    /// <summary>
+    ///     Result of a synchronous multi-fragment send.
+    /// </summary>
+    public readonly struct ChunkedPayloadSendResult
+    {
+        /// <summary>Creates a result value.</summary>
+        public ChunkedPayloadSendResult(bool ok, int fragmentsSent, ChunkedTransferFailureReason? failure,
+            string? detail = null)
+        {
+            Ok = ok;
+            FragmentsSent = fragmentsSent;
+            Failure = failure;
+            Detail = detail;
+        }
+
+        /// <summary>True if every fragment was accepted by the transport.</summary>
+        public bool Ok { get; }
+
+        /// <summary>Fragments successfully queued (partial count on cancellation).</summary>
+        public int FragmentsSent { get; }
+
+        /// <summary>Set when <see cref="Ok" /> is false.</summary>
+        public ChunkedTransferFailureReason? Failure { get; }
+
+        /// <summary>Optional diagnostic when <see cref="Ok" /> is false.</summary>
+        public string? Detail { get; }
+
+        /// <summary>Successful send.</summary>
+        public static ChunkedPayloadSendResult Success(int fragments)
+        {
+            return new(true, fragments, null);
+        }
+
+        /// <summary>Failed send.</summary>
+        public static ChunkedPayloadSendResult Fail(ChunkedTransferFailureReason reason, string? detail = null,
+            int sent = 0)
+        {
+            return new(false, sent, reason, detail);
+        }
+    }
+}

--- a/Multiplayer/ChunkedPayload/ChunkedTransferFailureReason.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedTransferFailureReason.cs
@@ -1,0 +1,38 @@
+namespace STS2RitsuLib.Multiplayer.ChunkedPayload
+{
+    /// <summary>
+    ///     Why an incoming transfer was abandoned or a send was rejected.
+    /// </summary>
+    public enum ChunkedTransferFailureReason
+    {
+        /// <summary>Caller cancelled the send via <see cref="System.Threading.CancellationToken" />.</summary>
+        Cancelled,
+
+        /// <summary>Payload exceeds <see cref="ChunkedTransferOptions.MaxTotalPayloadBytes" />.</summary>
+        PayloadTooLarge,
+
+        /// <summary>Computed chunk count or wire header is inconsistent with options.</summary>
+        InvalidLayout,
+
+        /// <summary>Reassembled bytes did not match the declared CRC32.</summary>
+        CrcMismatch,
+
+        /// <summary>No progress until <see cref="ChunkedTransferOptions.TransferTimeout" /> elapsed.</summary>
+        TimedOut,
+
+        /// <summary>Too many incomplete transfers from distinct peers / ids (memory protection).</summary>
+        TooManyConcurrentTransfers,
+
+        /// <summary>Sum of buffered incomplete transfers would exceed memory ceiling.</summary>
+        ReassemblyMemoryCap,
+
+        /// <summary>Schema or stream mismatch (unsupported protocol version).</summary>
+        UnsupportedOrCorrupt,
+
+        /// <summary>Not connected; cannot send.</summary>
+        NotConnected,
+
+        /// <summary>Client peers cannot address a specific <c>targetPeerId</c>; use host-only sends.</summary>
+        InvalidSendTarget,
+    }
+}

--- a/Multiplayer/ChunkedPayload/ChunkedTransferFailureReason.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedTransferFailureReason.cs
@@ -5,34 +5,54 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
     /// </summary>
     public enum ChunkedTransferFailureReason
     {
-        /// <summary>Caller cancelled the send via <see cref="System.Threading.CancellationToken" />.</summary>
+        /// <summary>
+        ///     Caller cancelled the send via <see cref="System.Threading.CancellationToken" />.
+        /// </summary>
         Cancelled,
 
-        /// <summary>Payload exceeds <see cref="ChunkedTransferOptions.MaxTotalPayloadBytes" />.</summary>
+        /// <summary>
+        ///     Payload exceeds <see cref="ChunkedTransferOptions.MaxTotalPayloadBytes" />.
+        /// </summary>
         PayloadTooLarge,
 
-        /// <summary>Computed chunk count or wire header is inconsistent with options.</summary>
+        /// <summary>
+        ///     Computed chunk count or wire header is inconsistent with options.
+        /// </summary>
         InvalidLayout,
 
-        /// <summary>Reassembled bytes did not match the declared CRC32.</summary>
+        /// <summary>
+        ///     Reassembled bytes did not match the declared CRC32.
+        /// </summary>
         CrcMismatch,
 
-        /// <summary>No progress until <see cref="ChunkedTransferOptions.TransferTimeout" /> elapsed.</summary>
+        /// <summary>
+        ///     No progress until <see cref="ChunkedTransferOptions.TransferTimeout" /> elapsed.
+        /// </summary>
         TimedOut,
 
-        /// <summary>Too many incomplete transfers from distinct peers / ids (memory protection).</summary>
+        /// <summary>
+        ///     Too many incomplete transfers from distinct peers / ids (memory protection).
+        /// </summary>
         TooManyConcurrentTransfers,
 
-        /// <summary>Sum of buffered incomplete transfers would exceed memory ceiling.</summary>
+        /// <summary>
+        ///     Sum of buffered incomplete transfers would exceed memory ceiling.
+        /// </summary>
         ReassemblyMemoryCap,
 
-        /// <summary>Schema or stream mismatch (unsupported protocol version).</summary>
+        /// <summary>
+        ///     Schema or stream mismatch (unsupported protocol version).
+        /// </summary>
         UnsupportedOrCorrupt,
 
-        /// <summary>Not connected; cannot send.</summary>
+        /// <summary>
+        ///     Not connected; cannot send.
+        /// </summary>
         NotConnected,
 
-        /// <summary>Client peers cannot address a specific <c>targetPeerId</c>; use host-only sends.</summary>
+        /// <summary>
+        ///     Client peers cannot address a specific <c>targetPeerId</c>; use host-only sends.
+        /// </summary>
         InvalidSendTarget,
     }
 }

--- a/Multiplayer/ChunkedPayload/ChunkedTransferOptions.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedTransferOptions.cs
@@ -1,0 +1,48 @@
+namespace STS2RitsuLib.Multiplayer.ChunkedPayload
+{
+    /// <summary>
+    ///     Tunables for chunk sizing, timeouts, pacing, and resource limits.
+    /// </summary>
+    public sealed class ChunkedTransferOptions
+    {
+        /// <summary>
+        ///     When set, successful payloads are dispatched through this delegate (e.g. Godot main thread).
+        ///     If null, <see cref="ChunkedPayloadReceivedEventArgs" /> is raised synchronously on the net thread.
+        /// </summary>
+        public Action<Action>? CompletionDispatcher;
+
+        /// <summary>
+        ///     Invoked on the same thread as the net message bus unless <see cref="CompletionDispatcher" /> is set.
+        /// </summary>
+        public EventHandler<ChunkedPayloadFailedEventArgs>? TransferFailed;
+
+        /// <summary>
+        ///     Maximum size of each fragment’s raw payload (excluding outer net message framing).
+        ///     Smaller values reduce loss impact and ease congestion on poor links; larger values reduce overhead.
+        /// </summary>
+        public int MaxFragmentPayloadBytes { get; init; } = 6144;
+
+        /// <summary>Upper bound on a single logical payload after reassembly.</summary>
+        public int MaxTotalPayloadBytes { get; init; } = 16 * 1024 * 1024;
+
+        /// <summary>
+        ///     Wall-clock timeout for an incomplete transfer after the first fragment is seen.
+        /// </summary>
+        public TimeSpan TransferTimeout { get; init; } = TimeSpan.FromSeconds(45);
+
+        /// <summary>
+        ///     Optional delay between sending fragments to avoid bursting the reliable channel on bad networks.
+        /// </summary>
+        public TimeSpan InterFragmentDelay { get; init; } = TimeSpan.Zero;
+
+        /// <summary>
+        ///     Maximum number of incomplete incoming transfers (distinct sender + transfer id) tracked at once.
+        /// </summary>
+        public int MaxConcurrentIncomingTransfers { get; init; } = 32;
+
+        /// <summary>
+        ///     Approximate cap on bytes reserved for incomplete reassembly buffers (excluding overhead).
+        /// </summary>
+        public long MaxReassemblyBytesInFlight { get; init; } = 64 * 1024 * 1024;
+    }
+}

--- a/Multiplayer/ChunkedPayload/ChunkedTransferOptions.cs
+++ b/Multiplayer/ChunkedPayload/ChunkedTransferOptions.cs
@@ -22,7 +22,9 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
         /// </summary>
         public int MaxFragmentPayloadBytes { get; init; } = 6144;
 
-        /// <summary>Upper bound on a single logical payload after reassembly.</summary>
+        /// <summary>
+        ///     Upper bound on a single logical payload after reassembly.
+        /// </summary>
         public int MaxTotalPayloadBytes { get; init; } = 16 * 1024 * 1024;
 
         /// <summary>

--- a/Multiplayer/ChunkedPayload/RitsuLibChunkedNetFragmentMessage.cs
+++ b/Multiplayer/ChunkedPayload/RitsuLibChunkedNetFragmentMessage.cs
@@ -1,0 +1,97 @@
+using System.Buffers.Binary;
+using System.IO.Hashing;
+using MegaCrit.Sts2.Core.Logging;
+using MegaCrit.Sts2.Core.Multiplayer.Serialization;
+using MegaCrit.Sts2.Core.Multiplayer.Transport;
+
+namespace STS2RitsuLib.Multiplayer.ChunkedPayload
+{
+    /// <summary>
+    ///     Single reliable fragment for <see cref="ChunkedPayloadChannel" />. Registered with the game net stack via
+    ///     mod type discovery; all players must load RitsuLib (same assembly) for compatible IDs.
+    /// </summary>
+    public sealed class RitsuLibChunkedNetFragmentMessage : INetMessage
+    {
+        /// <summary>Current wire schema; bump when changing <see cref="Serialize" /> layout.</summary>
+        public const byte SupportedSchemaVersion = 1;
+
+        /// <summary>Total fragments for this transfer.</summary>
+        public uint ChunkCount;
+
+        /// <summary>Zero-based index.</summary>
+        public uint ChunkIndex;
+
+        /// <summary>Must match sender <see cref="ChunkedTransferOptions.MaxFragmentPayloadBytes" />.</summary>
+        public ushort DeclaredMaxFragmentBytes;
+
+        /// <summary>CRC32 (IEEE) of the full payload before splitting.</summary>
+        public uint PayloadCrc32;
+
+        /// <summary>Wire schema of this instance.</summary>
+        public byte SchemaVersion = SupportedSchemaVersion;
+
+        /// <summary>Multiplex key; must match the receiving <see cref="ChunkedPayloadChannel.StreamId" />.</summary>
+        public ushort StreamId;
+
+        /// <summary>Final reassembled size in bytes.</summary>
+        public uint TotalPayloadLength;
+
+        /// <summary>Random id scoped per send operation.</summary>
+        public ulong TransferId;
+
+        /// <summary>Raw bytes for this chunk.</summary>
+        public byte[] Fragment { get; set; } = [];
+
+        /// <inheritdoc />
+        public bool ShouldBroadcast => false;
+
+        /// <inheritdoc />
+        public NetTransferMode Mode => NetTransferMode.Reliable;
+
+        /// <inheritdoc />
+        public LogLevel LogLevel => LogLevel.VeryDebug;
+
+        /// <inheritdoc />
+        public void Serialize(PacketWriter writer)
+        {
+            writer.WriteByte(SchemaVersion);
+            writer.WriteUShort(StreamId);
+            writer.WriteUShort(DeclaredMaxFragmentBytes);
+            writer.WriteULong(TransferId);
+            writer.WriteUInt(TotalPayloadLength);
+            writer.WriteUInt(ChunkIndex);
+            writer.WriteUInt(ChunkCount);
+            writer.WriteUInt(PayloadCrc32);
+            writer.WriteInt(Fragment.Length);
+            if (Fragment.Length > 0)
+                writer.WriteBytes(Fragment, Fragment.Length);
+        }
+
+        /// <inheritdoc />
+        public void Deserialize(PacketReader reader)
+        {
+            SchemaVersion = reader.ReadByte();
+            StreamId = reader.ReadUShort();
+            DeclaredMaxFragmentBytes = reader.ReadUShort();
+            TransferId = reader.ReadULong();
+            TotalPayloadLength = reader.ReadUInt();
+            ChunkIndex = reader.ReadUInt();
+            ChunkCount = reader.ReadUInt();
+            PayloadCrc32 = reader.ReadUInt();
+            var len = reader.ReadInt();
+            if (len < 0)
+                throw new InvalidOperationException("Negative fragment length.");
+            Fragment = len == 0 ? [] : new byte[len];
+            if (len > 0)
+                reader.ReadBytes(Fragment, len);
+        }
+
+        /// <summary>Computes CRC32 (IEEE polynomial) for a full payload.</summary>
+        public static uint ComputePayloadCrc32(ReadOnlySpan<byte> payload)
+        {
+            Span<byte> dest = stackalloc byte[4];
+            Crc32.Hash(payload, dest);
+            return BinaryPrimitives.ReadUInt32LittleEndian(dest);
+        }
+    }
+}

--- a/Multiplayer/ChunkedPayload/RitsuLibChunkedNetFragmentMessage.cs
+++ b/Multiplayer/ChunkedPayload/RitsuLibChunkedNetFragmentMessage.cs
@@ -12,34 +12,54 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
     /// </summary>
     public sealed class RitsuLibChunkedNetFragmentMessage : INetMessage
     {
-        /// <summary>Current wire schema; bump when changing <see cref="Serialize" /> layout.</summary>
+        /// <summary>
+        ///     Current wire schema; bump when changing <see cref="Serialize" /> layout.
+        /// </summary>
         public const byte SupportedSchemaVersion = 1;
 
-        /// <summary>Total fragments for this transfer.</summary>
+        /// <summary>
+        ///     Total fragments for this transfer.
+        /// </summary>
         public uint ChunkCount;
 
-        /// <summary>Zero-based index.</summary>
+        /// <summary>
+        ///     Zero-based index.
+        /// </summary>
         public uint ChunkIndex;
 
-        /// <summary>Must match sender <see cref="ChunkedTransferOptions.MaxFragmentPayloadBytes" />.</summary>
+        /// <summary>
+        ///     Must match sender <see cref="ChunkedTransferOptions.MaxFragmentPayloadBytes" />.
+        /// </summary>
         public ushort DeclaredMaxFragmentBytes;
 
-        /// <summary>CRC32 (IEEE) of the full payload before splitting.</summary>
+        /// <summary>
+        ///     CRC32 (IEEE) of the full payload before splitting.
+        /// </summary>
         public uint PayloadCrc32;
 
-        /// <summary>Wire schema of this instance.</summary>
+        /// <summary>
+        ///     Wire schema of this instance.
+        /// </summary>
         public byte SchemaVersion = SupportedSchemaVersion;
 
-        /// <summary>Multiplex key; must match the receiving <see cref="ChunkedPayloadChannel.StreamId" />.</summary>
+        /// <summary>
+        ///     Multiplex key; must match the receiving <see cref="ChunkedPayloadChannel.StreamId" />.
+        /// </summary>
         public ushort StreamId;
 
-        /// <summary>Final reassembled size in bytes.</summary>
+        /// <summary>
+        ///     Final reassembled size in bytes.
+        /// </summary>
         public uint TotalPayloadLength;
 
-        /// <summary>Random id scoped per send operation.</summary>
+        /// <summary>
+        ///     Random id scoped per send operation.
+        /// </summary>
         public ulong TransferId;
 
-        /// <summary>Raw bytes for this chunk.</summary>
+        /// <summary>
+        ///     Raw bytes for this chunk.
+        /// </summary>
         public byte[] Fragment { get; set; } = [];
 
         /// <inheritdoc />
@@ -79,14 +99,25 @@ namespace STS2RitsuLib.Multiplayer.ChunkedPayload
             ChunkCount = reader.ReadUInt();
             PayloadCrc32 = reader.ReadUInt();
             var len = reader.ReadInt();
-            if (len < 0)
-                throw new InvalidOperationException("Negative fragment length.");
+            switch (len)
+            {
+                case < 0:
+                    throw new InvalidOperationException("Negative fragment length.");
+                case > ushort.MaxValue:
+                    throw new InvalidOperationException($"Fragment length {len} exceeds {ushort.MaxValue}.");
+            }
+
+            if (len > DeclaredMaxFragmentBytes)
+                throw new InvalidOperationException(
+                    $"Fragment length {len} exceeds declared maximum {DeclaredMaxFragmentBytes}.");
             Fragment = len == 0 ? [] : new byte[len];
             if (len > 0)
                 reader.ReadBytes(Fragment, len);
         }
 
-        /// <summary>Computes CRC32 (IEEE polynomial) for a full payload.</summary>
+        /// <summary>
+        ///     Computes CRC32 (IEEE polynomial) for a full payload.
+        /// </summary>
         public static uint ComputePayloadCrc32(ReadOnlySpan<byte> payload)
         {
             Span<byte> dest = stackalloc byte[4];


### PR DESCRIPTION
This pull request introduces several new types and utility classes to support chunked payload transfer in the `STS2RitsuLib.Multiplayer.ChunkedPayload` namespace. The changes lay the groundwork for reliable, multi-fragment payload transmission, including event argument types, transfer options, failure reasons, result reporting, a Godot main-thread dispatcher, and the wire message format.

The most important changes are:

**Core chunked payload transfer types:**

* Added `ChunkedPayloadReceivedEventArgs` and `ChunkedPayloadFailedEventArgs` classes to encapsulate event data for successful and failed chunked payload transfers, respectively.
* Introduced the `ChunkedTransferFailureReason` enum to classify reasons for transfer failure or rejection, such as cancellation, payload too large, CRC mismatch, and protocol errors.
* Added the `ChunkedPayloadSendResult` struct to represent the outcome of a multi-fragment send, including fragment counts and failure details.

**Configuration and dispatch:**

* Implemented the `ChunkedTransferOptions` class to provide tunable parameters for chunk sizing, timeouts, pacing, resource limits, and event dispatching.
* Added the `ChunkedPayloadGodotDispatch` static class to bridge completion dispatching to the Godot main thread using `Callable.From().CallDeferred()`.

**Wire message definition:**

* Created the `RitsuLibChunkedNetFragmentMessage` class, defining the wire format for individual reliable fragments, including serialization/deserialization logic and CRC32 computation.