### PR TITLE
Enhance timeline expansion and mod epoch integration features

### DIFF
--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -259,6 +259,8 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<AscensionEpochRevealCompatibilityPatch>();
             patcher.RegisterPatch<ProgressSaveManagerGetRevealableEpochsModTemplatePatch>();
             patcher.RegisterPatch<QueueTimelineExpansionSyncEpochIdListPatch>();
+            patcher.RegisterPatch<NeowEpochQueueUnlocksCoExpansionScopePatch>();
+            patcher.RegisterPatch<QueueTimelineExpansionUnlockModSlotsAfterNeowPatch>();
             patcher.RegisterPatch<NUnlockTimelineScreenExpansionSlotSortPatch>();
             patcher.RegisterPatch<NTimelineScreenAddEpochSlotsMergeModTemplatesPatch>();
             RegisterFrameworkPatcher(FrameworkPatcherArea.Unlocks, patcher);

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -257,6 +257,7 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<AscensionOneEpochCompatibilityPatch>();
             patcher.RegisterPatch<PostRunCharacterUnlockEpochCompatibilityPatch>();
             patcher.RegisterPatch<AscensionEpochRevealCompatibilityPatch>();
+            patcher.RegisterPatch<ProgressSaveManagerGetRevealableEpochsModTemplatePatch>();
             patcher.RegisterPatch<QueueTimelineExpansionSyncEpochIdListPatch>();
             patcher.RegisterPatch<NUnlockTimelineScreenExpansionSlotSortPatch>();
             patcher.RegisterPatch<NTimelineScreenAddEpochSlotsMergeModTemplatesPatch>();

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -12,6 +12,7 @@ using STS2RitsuLib.Scaffolding.Cards.HandOutline.Patches;
 using STS2RitsuLib.Scaffolding.Characters.Patches;
 using STS2RitsuLib.Scaffolding.Content.Patches;
 using STS2RitsuLib.Settings.Patches;
+using STS2RitsuLib.Timeline.Patches;
 using STS2RitsuLib.Unlocks.Patches;
 using STS2RitsuLib.Utils.Persistence.Patches;
 
@@ -256,6 +257,8 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<AscensionOneEpochCompatibilityPatch>();
             patcher.RegisterPatch<PostRunCharacterUnlockEpochCompatibilityPatch>();
             patcher.RegisterPatch<AscensionEpochRevealCompatibilityPatch>();
+            patcher.RegisterPatch<QueueTimelineExpansionSyncEpochIdListPatch>();
+            patcher.RegisterPatch<NUnlockTimelineScreenExpansionSlotSortPatch>();
             RegisterFrameworkPatcher(FrameworkPatcherArea.Unlocks, patcher);
         }
 

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -259,6 +259,7 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<AscensionEpochRevealCompatibilityPatch>();
             patcher.RegisterPatch<QueueTimelineExpansionSyncEpochIdListPatch>();
             patcher.RegisterPatch<NUnlockTimelineScreenExpansionSlotSortPatch>();
+            patcher.RegisterPatch<NTimelineScreenAddEpochSlotsMergeModTemplatesPatch>();
             RegisterFrameworkPatcher(FrameworkPatcherArea.Unlocks, patcher);
         }
 

--- a/Scaffolding/Content/ModContentPackBuilder.cs
+++ b/Scaffolding/Content/ModContentPackBuilder.cs
@@ -448,6 +448,47 @@ namespace STS2RitsuLib.Scaffolding.Content
         }
 
         /// <summary>
+        ///     Queues <see cref="ModTimelineLayoutRegistry.RegisterTimelineSlot" /> for a <see cref="ModEpochTemplate" />
+        ///     when not using <see cref="TimelineColumnPackEntry{TStory}" />.
+        /// </summary>
+        public ModContentPackBuilder ModEpochTimelineSlot<TEpoch>(EpochEra era, int eraPosition)
+            where TEpoch : ModEpochTemplate
+        {
+            return AddStep(ctx =>
+                ModTimelineLayoutRegistry.RegisterTimelineSlot(typeof(TEpoch), era, eraPosition, ctx.ModId));
+        }
+
+        /// <summary>
+        ///     Queues <see cref="ModTimelineLayoutRegistry.RegisterAutoTimelineSlot" /> for a <see cref="ModEpochTemplate" />.
+        /// </summary>
+        public ModContentPackBuilder ModEpochAutoTimelineSlot<TEpoch>(EpochEra era)
+            where TEpoch : ModEpochTemplate
+        {
+            return AddStep(ctx => ModTimelineLayoutRegistry.RegisterAutoTimelineSlot(typeof(TEpoch), era, ctx.ModId));
+        }
+
+        /// <summary>
+        ///     Queues <see cref="ModTimelineLayoutRegistry.RegisterAutoTimelineSlotBeforeEraColumn" />.
+        /// </summary>
+        public ModContentPackBuilder ModEpochAutoTimelineSlotBeforeColumn<TEpoch>(EpochEra anchorEra)
+            where TEpoch : ModEpochTemplate
+        {
+            return AddStep(ctx =>
+                ModTimelineLayoutRegistry.RegisterAutoTimelineSlotBeforeEraColumn(typeof(TEpoch), anchorEra,
+                    ctx.ModId));
+        }
+
+        /// <summary>
+        ///     Queues <see cref="ModTimelineLayoutRegistry.RegisterAutoTimelineSlotAfterEraColumn" />.
+        /// </summary>
+        public ModContentPackBuilder ModEpochAutoTimelineSlotAfterColumn<TEpoch>(EpochEra anchorEra)
+            where TEpoch : ModEpochTemplate
+        {
+            return AddStep(ctx =>
+                ModTimelineLayoutRegistry.RegisterAutoTimelineSlotAfterEraColumn(typeof(TEpoch), anchorEra, ctx.ModId));
+        }
+
+        /// <summary>
         ///     Queues <see cref="TimelineColumnPackEntry{TStory}" /> — one fluent block for column order + per-epoch unlock
         ///     bindings (recommended over many separate pack entry types).
         /// </summary>

--- a/Scaffolding/Content/TimelineColumnPackEntry.cs
+++ b/Scaffolding/Content/TimelineColumnPackEntry.cs
@@ -56,10 +56,11 @@ namespace STS2RitsuLib.Scaffolding.Content
 
         /// <summary>
         ///     Registers <typeparamref name="TEpoch" /> on the story column, then optional slot configuration (pool defaults,
-        ///     gated lists, etc.). For <see cref="ModEpochTemplate" /> epochs you must call
+        ///     gated lists, etc.). For <see cref="ModEpochTemplate" /> epochs, timeline layout must be registered before freeze;
+        ///     when using this builder, the typical approach is to call
         ///     <see cref="EpochSlotBuilder{TEpoch}.TimelineSlot" /> or <see cref="EpochSlotBuilder{TEpoch}.AutoTimelineSlot" />
-        ///     inside <paramref name="slot" /> so placement is registered before freeze (conflicts with vanilla throw at apply
-        ///     time).
+        ///     inside <paramref name="slot" /> (or register elsewhere before freeze, e.g. ModContentPackBuilder ModEpoch*
+        ///     helpers), so apply-time validation can run (conflicts with vanilla throw at apply time).
         ///     Execution order matches call order; later <c>RequireEpoch</c> for the same model overrides earlier ones.
         /// </summary>
         public TimelineColumnBuilder<TStory> Epoch<TEpoch>(Action<EpochSlotBuilder<TEpoch>>? slot = null)

--- a/Scaffolding/Content/TimelineColumnPackEntry.cs
+++ b/Scaffolding/Content/TimelineColumnPackEntry.cs
@@ -56,18 +56,24 @@ namespace STS2RitsuLib.Scaffolding.Content
 
         /// <summary>
         ///     Registers <typeparamref name="TEpoch" /> on the story column, then optional slot configuration (pool defaults,
-        ///     gated lists, etc.). Execution order matches call order; later <c>RequireEpoch</c> for the same model overrides
-        ///     earlier ones.
+        ///     gated lists, etc.). For <see cref="ModEpochTemplate" /> epochs you must call
+        ///     <see cref="EpochSlotBuilder{TEpoch}.TimelineSlot" /> or <see cref="EpochSlotBuilder{TEpoch}.AutoTimelineSlot" />
+        ///     inside <paramref name="slot" /> so placement is registered before freeze (conflicts with vanilla throw at apply
+        ///     time).
+        ///     Execution order matches call order; later <c>RequireEpoch</c> for the same model overrides earlier ones.
         /// </summary>
         public TimelineColumnBuilder<TStory> Epoch<TEpoch>(Action<EpochSlotBuilder<TEpoch>>? slot = null)
             where TEpoch : EpochModel, new()
         {
-            _steps.Add(() => _context.Timeline.RegisterStoryEpoch<TStory, TEpoch>());
-            if (slot == null) return this;
-            var b = new EpochSlotBuilder<TEpoch>(_context);
-            slot(b);
-            _steps.AddRange(b.DrainSteps());
+            if (slot != null)
+            {
+                var b = new EpochSlotBuilder<TEpoch>(_context);
+                slot(b);
+                foreach (var step in b.DrainSteps())
+                    _steps.Add(step);
+            }
 
+            _steps.Add(() => _context.Timeline.RegisterStoryEpoch<TStory, TEpoch>());
             return this;
         }
 
@@ -129,16 +135,89 @@ namespace STS2RitsuLib.Scaffolding.Content
     {
         private readonly ModContentPackContext _context;
         private readonly List<Action> _pending = [];
+        private Action? _layoutRegistration;
 
         internal EpochSlotBuilder(ModContentPackContext context)
         {
             _context = context;
         }
 
+        /// <summary>
+        ///     Reserves a fixed <see cref="EpochEra" /> column and <c>EraPosition</c> for this epoch. Conflicts with vanilla
+        ///     or other mods throw at registration time.
+        /// </summary>
+        public EpochSlotBuilder<TEpoch> TimelineSlot(EpochEra era, int eraPosition)
+        {
+            var modId = _context.ModId;
+            _layoutRegistration = () =>
+                ModTimelineLayoutRegistry.RegisterTimelineSlot(typeof(TEpoch), era, eraPosition, modId);
+            return this;
+        }
+
+        /// <summary>
+        ///     Reserves the lowest free <c>EraPosition</c> in <paramref name="era" /> after seeding vanilla occupancy.
+        /// </summary>
+        public EpochSlotBuilder<TEpoch> AutoTimelineSlot(EpochEra era)
+        {
+            var modId = _context.ModId;
+            _layoutRegistration = () =>
+                ModTimelineLayoutRegistry.RegisterAutoTimelineSlot(typeof(TEpoch), era, modId);
+            return this;
+        }
+
+        /// <summary>
+        ///     Reserves a column strictly to the left of <paramref name="anchorEra" /> (smaller era int), preferring a new
+        ///     root cell at position 0 — use for a mod story “root” before the rest of your column content.
+        /// </summary>
+        public EpochSlotBuilder<TEpoch> AutoTimelineSlotBeforeColumn(EpochEra anchorEra)
+        {
+            var modId = _context.ModId;
+            _layoutRegistration = () =>
+                ModTimelineLayoutRegistry.RegisterAutoTimelineSlotBeforeEraColumn(typeof(TEpoch), anchorEra, modId);
+            return this;
+        }
+
+        /// <inheritdoc cref="ModTimelineLayoutRegistry.RegisterAutoTimelineSlotBeforeEpochColumn" />
+        public EpochSlotBuilder<TEpoch> AutoTimelineSlotBeforeEpochColumn<TReferenceEpoch>()
+            where TReferenceEpoch : EpochModel, new()
+        {
+            var modId = _context.ModId;
+            _layoutRegistration = () =>
+                ModTimelineLayoutRegistry.RegisterAutoTimelineSlotBeforeEpochColumn(typeof(TEpoch),
+                    typeof(TReferenceEpoch), modId);
+            return this;
+        }
+
+        /// <summary>
+        ///     Reserves a column strictly to the right of <paramref name="anchorEra" /> (larger era int).
+        /// </summary>
+        public EpochSlotBuilder<TEpoch> AutoTimelineSlotAfterColumn(EpochEra anchorEra)
+        {
+            var modId = _context.ModId;
+            _layoutRegistration = () =>
+                ModTimelineLayoutRegistry.RegisterAutoTimelineSlotAfterEraColumn(typeof(TEpoch), anchorEra, modId);
+            return this;
+        }
+
+        /// <inheritdoc cref="ModTimelineLayoutRegistry.RegisterAutoTimelineSlotAfterEpochColumn" />
+        public EpochSlotBuilder<TEpoch> AutoTimelineSlotAfterEpochColumn<TReferenceEpoch>()
+            where TReferenceEpoch : EpochModel, new()
+        {
+            var modId = _context.ModId;
+            _layoutRegistration = () =>
+                ModTimelineLayoutRegistry.RegisterAutoTimelineSlotAfterEpochColumn(typeof(TEpoch),
+                    typeof(TReferenceEpoch), modId);
+            return this;
+        }
+
         internal List<Action> DrainSteps()
         {
-            var copy = _pending.ToList();
+            var copy = new List<Action>();
+            if (_layoutRegistration != null)
+                copy.Add(_layoutRegistration);
+            copy.AddRange(_pending);
             _pending.Clear();
+            _layoutRegistration = null;
             return copy;
         }
 

--- a/Timeline/ModTimelineLayoutRegistry.cs
+++ b/Timeline/ModTimelineLayoutRegistry.cs
@@ -1,0 +1,358 @@
+using System.Reflection;
+using MegaCrit.Sts2.Core.Timeline;
+using STS2RitsuLib.Timeline.Scaffolding;
+
+namespace STS2RitsuLib.Timeline
+{
+    /// <summary>
+    ///     Central registration for <see cref="ModEpochTemplate" /> timeline placement: <see cref="EpochEra" /> column and
+    ///     <c>EraPosition</c> within that column. Vanilla <see cref="EpochModel" /> instances are pre-seeded so mod slots
+    ///     cannot silently overlap base-game cells.
+    /// </summary>
+    public static class ModTimelineLayoutRegistry
+    {
+        private const int MaxAutoPositionScan = 128;
+
+        /// <summary>Scan downward when placing a column strictly before an anchor era (horizontal / enum int order).</summary>
+        private const int MinEraIntScan = -100_000;
+
+        /// <summary>Scan upward when placing a column strictly after an anchor era.</summary>
+        private const int MaxEraIntScan = 100_000;
+
+        private static readonly Lock Sync = new();
+
+        private static readonly Dictionary<Type, TimelineSlotAssignment> LayoutByEpochType = [];
+
+        private static readonly HashSet<(long EraKey, int Position)> Occupied = [];
+
+        private static bool _frozen;
+
+        private static bool _vanillaSeeded;
+
+        /// <summary>
+        ///     Registers an explicit slot. Throws if the cell is already used by vanilla or another mod registration.
+        /// </summary>
+        public static void RegisterTimelineSlot(Type epochType, EpochEra era, int eraPosition, string modId)
+        {
+            ArgumentNullException.ThrowIfNull(epochType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+
+            if (!typeof(ModEpochTemplate).IsAssignableFrom(epochType))
+                throw new ArgumentException(
+                    $"Type '{epochType.Name}' must inherit {nameof(ModEpochTemplate)} to use the layout registry.",
+                    nameof(epochType));
+
+            lock (Sync)
+            {
+                ThrowIfFrozen();
+                EnsureVanillaOccupancySeededLocked();
+
+                ThrowIfLayoutAlreadyRegistered(epochType);
+
+                var key = ToOccupancyKey(era, eraPosition);
+                if (!Occupied.Add(key))
+                    throw new InvalidOperationException(
+                        $"Timeline slot conflict: era={(int)era} position={eraPosition} is already occupied " +
+                        $"(cannot register '{epochType.Name}' for mod '{modId}'). " +
+                        "Pick another column (EpochEra) / position, or use AutoTimelineSlot for the first free slot in a column.");
+
+                LayoutByEpochType[epochType] = new(era, eraPosition);
+            }
+        }
+
+        /// <summary>
+        ///     Registers the lowest non-negative <c>EraPosition</c> in <paramref name="era" /> that is not occupied by
+        ///     vanilla or prior mod registrations.
+        /// </summary>
+        public static void RegisterAutoTimelineSlot(Type epochType, EpochEra era, string modId)
+        {
+            ArgumentNullException.ThrowIfNull(epochType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+
+            lock (Sync)
+            {
+                ThrowIfFrozen();
+                EnsureVanillaOccupancySeededLocked();
+
+                ThrowIfLayoutAlreadyRegistered(epochType);
+
+                for (var p = 0; p < MaxAutoPositionScan; p++)
+                {
+                    var key = ToOccupancyKey(era, p);
+                    if (!Occupied.Add(key))
+                        continue;
+
+                    LayoutByEpochType[epochType] = new(era, p);
+                    return;
+                }
+
+                throw new InvalidOperationException(
+                    $"No free timeline position in era {(int)era} for '{epochType.Name}' (mod '{modId}') within 0..{MaxAutoPositionScan - 1}.");
+            }
+        }
+
+        /// <summary>
+        ///     Places this epoch in the leftmost timeline column whose <see cref="EpochEra" /> integer is strictly less than
+        ///     <paramref name="anchorEra" />, preferring <c>EraPosition == 0</c> (a dedicated “root” column), then any free
+        ///     slot in that column. Matches vanilla <see cref="MegaCrit.Sts2.Core.Nodes.Screens.Timeline.NTimelineScreen" />
+        ///     column ordering (smaller era int = further left).
+        /// </summary>
+        public static void RegisterAutoTimelineSlotBeforeEraColumn(Type epochType, EpochEra anchorEra, string modId)
+        {
+            ArgumentNullException.ThrowIfNull(epochType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+            ThrowIfNotModEpochTemplate(epochType);
+
+            lock (Sync)
+            {
+                ThrowIfFrozen();
+                EnsureVanillaOccupancySeededLocked();
+                ThrowIfLayoutAlreadyRegistered(epochType);
+                RegisterAutoTimelineSlotBeforeEraColumnLocked(epochType, anchorEra, modId);
+            }
+        }
+
+        /// <summary>
+        ///     Same as <see cref="RegisterAutoTimelineSlotBeforeEraColumn" /> but the anchor is the reference epoch’s
+        ///     <see cref="EpochModel.Era" /> (its column).
+        /// </summary>
+        public static void RegisterAutoTimelineSlotBeforeEpochColumn(Type epochType, Type referenceEpochType,
+            string modId)
+        {
+            ArgumentNullException.ThrowIfNull(epochType);
+            ArgumentNullException.ThrowIfNull(referenceEpochType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+            ThrowIfNotModEpochTemplate(epochType);
+            if (referenceEpochType.IsAbstract || !typeof(EpochModel).IsAssignableFrom(referenceEpochType))
+                throw new ArgumentException(
+                    $"Type '{referenceEpochType.Name}' must be a concrete {nameof(EpochModel)}.",
+                    nameof(referenceEpochType));
+
+            lock (Sync)
+            {
+                ThrowIfFrozen();
+                EnsureVanillaOccupancySeededLocked();
+                ThrowIfLayoutAlreadyRegistered(epochType);
+                var reference = (EpochModel)Activator.CreateInstance(referenceEpochType)!;
+                RegisterAutoTimelineSlotBeforeEraColumnLocked(epochType, reference.Era, modId);
+            }
+        }
+
+        /// <summary>
+        ///     Places this epoch in the rightmost practical column with era int strictly greater than
+        ///     <paramref name="anchorEra" /> (scanning upward from <c>anchor + 1</c>), preferring position 0.
+        /// </summary>
+        public static void RegisterAutoTimelineSlotAfterEraColumn(Type epochType, EpochEra anchorEra, string modId)
+        {
+            ArgumentNullException.ThrowIfNull(epochType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+            ThrowIfNotModEpochTemplate(epochType);
+
+            lock (Sync)
+            {
+                ThrowIfFrozen();
+                EnsureVanillaOccupancySeededLocked();
+                ThrowIfLayoutAlreadyRegistered(epochType);
+                RegisterAutoTimelineSlotAfterEraColumnLocked(epochType, anchorEra, modId);
+            }
+        }
+
+        /// <summary>
+        ///     Anchor is <see cref="EpochModel.Era" /> of <paramref name="referenceEpochType" />.
+        /// </summary>
+        public static void RegisterAutoTimelineSlotAfterEpochColumn(Type epochType, Type referenceEpochType,
+            string modId)
+        {
+            ArgumentNullException.ThrowIfNull(epochType);
+            ArgumentNullException.ThrowIfNull(referenceEpochType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+            ThrowIfNotModEpochTemplate(epochType);
+            if (referenceEpochType.IsAbstract || !typeof(EpochModel).IsAssignableFrom(referenceEpochType))
+                throw new ArgumentException(
+                    $"Type '{referenceEpochType.Name}' must be a concrete {nameof(EpochModel)}.",
+                    nameof(referenceEpochType));
+
+            lock (Sync)
+            {
+                ThrowIfFrozen();
+                EnsureVanillaOccupancySeededLocked();
+                ThrowIfLayoutAlreadyRegistered(epochType);
+                var reference = (EpochModel)Activator.CreateInstance(referenceEpochType)!;
+                RegisterAutoTimelineSlotAfterEraColumnLocked(epochType, reference.Era, modId);
+            }
+        }
+
+        private static void RegisterAutoTimelineSlotBeforeEraColumnLocked(Type epochType, EpochEra anchorEra,
+            string modId)
+        {
+            var anchor = (int)anchorEra;
+            for (var ei = anchor - 1; ei >= MinEraIntScan; ei--)
+                if (TryClaimFirstFreeInColumnLocked(epochType, (EpochEra)ei, true))
+                    return;
+
+            for (var ei = anchor - 1; ei >= MinEraIntScan; ei--)
+                if (TryClaimFirstFreeInColumnLocked(epochType, (EpochEra)ei, false))
+                    return;
+
+            throw new InvalidOperationException(
+                $"No free timeline column before anchor era {anchor} for '{epochType.Name}' (mod '{modId}').");
+        }
+
+        private static void RegisterAutoTimelineSlotAfterEraColumnLocked(Type epochType, EpochEra anchorEra,
+            string modId)
+        {
+            var anchor = (int)anchorEra;
+            for (var ei = anchor + 1; ei <= MaxEraIntScan; ei++)
+                if (TryClaimFirstFreeInColumnLocked(epochType, (EpochEra)ei, true))
+                    return;
+
+            for (var ei = anchor + 1; ei <= MaxEraIntScan; ei++)
+                if (TryClaimFirstFreeInColumnLocked(epochType, (EpochEra)ei, false))
+                    return;
+
+            throw new InvalidOperationException(
+                $"No free timeline column after anchor era {anchor} for '{epochType.Name}' (mod '{modId}').");
+        }
+
+        private static void ThrowIfNotModEpochTemplate(Type epochType)
+        {
+            if (!typeof(ModEpochTemplate).IsAssignableFrom(epochType))
+                throw new ArgumentException(
+                    $"Type '{epochType.Name}' must inherit {nameof(ModEpochTemplate)} to use the layout registry.",
+                    nameof(epochType));
+        }
+
+        internal static EpochEra ResolveEra(Type epochType)
+        {
+            lock (Sync)
+            {
+                if (LayoutByEpochType.TryGetValue(epochType, out var layout))
+                    return layout.Era;
+            }
+
+            throw new InvalidOperationException(
+                $"No timeline layout registered for mod epoch type '{epochType?.Name}'. " +
+                "Declare .TimelineSlot(era, position), .AutoTimelineSlot(era), .AutoTimelineSlotBeforeColumn / AfterColumn, " +
+                "or BeforeEpoch / AfterEpoch inside TimelineColumnPackEntry.Epoch<TEpoch>(...), " +
+                $"or call the matching {nameof(ModTimelineLayoutRegistry)} methods before freeze.");
+        }
+
+        internal static int ResolveEraPosition(Type epochType)
+        {
+            lock (Sync)
+            {
+                if (LayoutByEpochType.TryGetValue(epochType, out var layout))
+                    return layout.EraPosition;
+            }
+
+            throw new InvalidOperationException(
+                $"No timeline layout registered for mod epoch type '{epochType?.Name}'.");
+        }
+
+        internal static void FreezeAndValidate()
+        {
+            lock (Sync)
+            {
+                if (_frozen)
+                    return;
+
+                EnsureVanillaOccupancySeededLocked();
+                AssertEveryModEpochTemplateHasLayoutLocked();
+                _frozen = true;
+            }
+        }
+
+        private static void ThrowIfFrozen()
+        {
+            if (_frozen)
+                throw new InvalidOperationException("Timeline layout registration is frozen.");
+        }
+
+        private static void EnsureVanillaOccupancySeededLocked()
+        {
+            if (_vanillaSeeded)
+                return;
+
+            foreach (var type in typeof(EpochModel).Assembly.GetTypes())
+            {
+                if (type is not { IsClass: true } || type.IsAbstract || !typeof(EpochModel).IsAssignableFrom(type))
+                    continue;
+
+                try
+                {
+                    var inst = (EpochModel)Activator.CreateInstance(type)!;
+                    Occupied.Add(ToOccupancyKey(inst.Era, inst.EraPosition));
+                }
+                catch
+                {
+                    // Source-generated or unusual epoch types may not be default-constructible; skip.
+                }
+            }
+
+            _vanillaSeeded = true;
+        }
+
+        private static void AssertEveryModEpochTemplateHasLayoutLocked()
+        {
+            foreach (var type in GetRegisteredEpochTypesFromGameDictionary())
+            {
+                if (!typeof(ModEpochTemplate).IsAssignableFrom(type))
+                    continue;
+
+                if (LayoutByEpochType.ContainsKey(type))
+                    continue;
+
+                throw new InvalidOperationException(
+                    $"Epoch type '{type.Name}' inherits {nameof(ModEpochTemplate)} but has no timeline layout. " +
+                    "Add .TimelineSlot, .AutoTimelineSlot, .AutoTimelineSlotBeforeColumn / AfterColumn, or BeforeEpoch / AfterEpoch in your timeline column pack.");
+            }
+        }
+
+        private static IEnumerable<Type> GetRegisteredEpochTypesFromGameDictionary()
+        {
+            var field = typeof(EpochModel).GetField("_typeToIdDictionary", BindingFlags.Static | BindingFlags.NonPublic)
+                        ?? throw new MissingFieldException(typeof(EpochModel).FullName, "_typeToIdDictionary");
+
+            return field.GetValue(null) is not Dictionary<Type, string> map
+                ? throw new InvalidOperationException("EpochModel._typeToIdDictionary is unavailable.")
+                : map.Keys;
+        }
+
+        private static void ThrowIfLayoutAlreadyRegistered(Type epochType)
+        {
+            if (LayoutByEpochType.ContainsKey(epochType))
+                throw new InvalidOperationException(
+                    $"Timeline layout for epoch type '{epochType.Name}' is already registered.");
+        }
+
+        /// <summary>
+        ///     Claims the first free slot in <paramref name="era" />; if <paramref name="preferPositionZeroOnly" />, only
+        ///     tries position 0.
+        /// </summary>
+        private static bool TryClaimFirstFreeInColumnLocked(Type epochType, EpochEra era, bool preferPositionZeroOnly)
+        {
+            var positions = preferPositionZeroOnly
+                ? (IEnumerable<int>)[0]
+                : Enumerable.Range(0, MaxAutoPositionScan);
+
+            foreach (var p in positions)
+            {
+                var key = ToOccupancyKey(era, p);
+                if (!Occupied.Add(key))
+                    continue;
+
+                LayoutByEpochType[epochType] = new(era, p);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static (long EraKey, int Position) ToOccupancyKey(EpochEra era, int position)
+        {
+            return ((int)era, position);
+        }
+
+        private readonly record struct TimelineSlotAssignment(EpochEra Era, int EraPosition);
+    }
+}

--- a/Timeline/ModTimelineLayoutRegistry.cs
+++ b/Timeline/ModTimelineLayoutRegistry.cs
@@ -68,6 +68,7 @@ namespace STS2RitsuLib.Timeline
         {
             ArgumentNullException.ThrowIfNull(epochType);
             ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+            ThrowIfNotModEpochTemplate(epochType);
 
             lock (Sync)
             {
@@ -233,8 +234,8 @@ namespace STS2RitsuLib.Timeline
             throw new InvalidOperationException(
                 $"No timeline layout registered for mod epoch type '{epochType?.Name}'. " +
                 "Declare .TimelineSlot(era, position), .AutoTimelineSlot(era), .AutoTimelineSlotBeforeColumn / AfterColumn, " +
-                "or BeforeEpoch / AfterEpoch inside TimelineColumnPackEntry.Epoch<TEpoch>(...), " +
-                $"or call the matching {nameof(ModTimelineLayoutRegistry)} methods before freeze.");
+                "or AutoTimelineSlotBeforeEpochColumn / AutoTimelineSlotAfterEpochColumn inside TimelineColumnPackEntry.Epoch<TEpoch>(...), " +
+                $"or use ModContentPackBuilder ModEpoch* timeline helpers / matching {nameof(ModTimelineLayoutRegistry)} methods before freeze.");
         }
 
         internal static int ResolveEraPosition(Type epochType)

--- a/Timeline/ModTimelineNeowCoExpansion.cs
+++ b/Timeline/ModTimelineNeowCoExpansion.cs
@@ -1,0 +1,160 @@
+using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
+using MegaCrit.Sts2.Core.Saves;
+using MegaCrit.Sts2.Core.Timeline;
+using MegaCrit.Sts2.Core.Timeline.Epochs;
+using STS2RitsuLib.Timeline.Scaffolding;
+
+namespace STS2RitsuLib.Timeline
+{
+    internal static class ModTimelineNeowCoExpansion
+    {
+        private static int _neowQueueUnlocksDepth;
+
+        private static int _pendingNeowAnimatedSlotMerge;
+
+        private static bool IsInsideNeowQueueUnlocks => Volatile.Read(ref _neowQueueUnlocksDepth) > 0;
+
+        internal static void EnterNeowQueueUnlocks()
+        {
+            Interlocked.Increment(ref _neowQueueUnlocksDepth);
+        }
+
+        internal static void ExitNeowQueueUnlocks()
+        {
+            Interlocked.Decrement(ref _neowQueueUnlocksDepth);
+        }
+
+        internal static bool TryConsumePendingNeowAnimatedSlotMerge()
+        {
+            return Interlocked.Exchange(ref _pendingNeowAnimatedSlotMerge, 0) != 0;
+        }
+
+        /// <summary>
+        ///     True once vanilla Neow&apos;s primary expansion has written at least one of its slots into progress (first slot is
+        ///     <see cref="Colorless1Epoch" />). Avoids painting every mod story column on cold open before that event.
+        /// </summary>
+        internal static bool HasVanillaNeowTimelineExpansionStarted(ProgressState? progress)
+        {
+            return progress != null && progress.HasEpoch(EpochModel.GetId<Colorless1Epoch>());
+        }
+
+        internal static bool IsNeowPrimaryTimelineExpansion(EpochModel[] epochs)
+        {
+            if (epochs is not { Length: >= 8 })
+                return false;
+
+            var ids = epochs.Select(e => e.Id).ToHashSet();
+            return ids.Contains(EpochModel.GetId<Colorless1Epoch>())
+                   && ids.Contains(EpochModel.GetId<Silent1Epoch>());
+        }
+
+        internal static bool IsNeowPrimaryTimelineExpansionSlots(IReadOnlyList<EpochSlotData> slots)
+        {
+            if (slots is not { Count: >= 8 })
+                return false;
+
+            var ids = slots.Select(s => s.Model.Id).ToHashSet();
+            return ids.Contains(EpochModel.GetId<Colorless1Epoch>())
+                   && ids.Contains(EpochModel.GetId<Silent1Epoch>());
+        }
+
+        internal static void MergeModEpochTemplateSlotsInto(List<EpochSlotData> slotsToAdd, ProgressState? progress)
+        {
+            var existing = new HashSet<string>(slotsToAdd.Count);
+            foreach (var s in slotsToAdd)
+                existing.Add(s.Model.Id);
+
+            foreach (var id in EpochModel.AllEpochIds)
+            {
+                if (existing.Contains(id))
+                    continue;
+
+                EpochModel model;
+                try
+                {
+                    model = EpochModel.Get(id);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (model is not ModEpochTemplate)
+                    continue;
+
+                slotsToAdd.Add(new(model, ResolveMergedModSlotState(id, progress)));
+                existing.Add(id);
+            }
+
+            SortEpochSlotsByEraThenPosition(slotsToAdd);
+        }
+
+        /// <summary>
+        ///     Called from <see cref="EpochModel.QueueTimelineExpansion" /> postfix only; runs mod
+        ///     <see cref="SaveManager.UnlockSlot" />
+        ///     when the expansion was triggered from <see cref="NeowEpoch.QueueUnlocks" />.
+        /// </summary>
+        internal static void OnQueueTimelineExpansionPostfix(EpochModel[] vanillaEpochs)
+        {
+            if (!IsInsideNeowQueueUnlocks)
+                return;
+            if (!IsNeowPrimaryTimelineExpansion(vanillaEpochs))
+                return;
+
+            UnlockModEpochSlotsCore(vanillaEpochs);
+            Interlocked.Exchange(ref _pendingNeowAnimatedSlotMerge, 1);
+        }
+
+        private static void UnlockModEpochSlotsCore(EpochModel[] vanillaEpochs)
+        {
+            var vanillaIds = vanillaEpochs.Select(e => e.Id).ToHashSet();
+            foreach (var id in EpochModel.AllEpochIds)
+            {
+                if (vanillaIds.Contains(id))
+                    continue;
+
+                EpochModel model;
+                try
+                {
+                    model = EpochModel.Get(id);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (model is not ModEpochTemplate)
+                    continue;
+
+                SaveManager.Instance.UnlockSlot(id);
+            }
+        }
+
+        private static EpochSlotState ResolveMergedModSlotState(string id, ProgressState? progress)
+        {
+            if (progress == null || !progress.HasEpoch(id))
+                return EpochSlotState.NotObtained;
+
+            var row = progress.Epochs.FirstOrDefault(e => e.Id == id);
+            if (row == null)
+                return EpochSlotState.NotObtained;
+
+            return row.State switch
+            {
+                EpochState.Revealed => EpochSlotState.Complete,
+                EpochState.Obtained => EpochSlotState.Obtained,
+                EpochState.ObtainedNoSlot => EpochSlotState.Obtained,
+                _ => EpochSlotState.NotObtained,
+            };
+        }
+
+        private static void SortEpochSlotsByEraThenPosition(List<EpochSlotData> slots)
+        {
+            slots.Sort((a, b) =>
+            {
+                var c = a.Era.CompareTo(b.Era);
+                return c != 0 ? c : a.EraPosition.CompareTo(b.EraPosition);
+            });
+        }
+    }
+}

--- a/Timeline/ModTimelineRegistry.cs
+++ b/Timeline/ModTimelineRegistry.cs
@@ -111,6 +111,19 @@ namespace STS2RitsuLib.Timeline
             }
         }
 
+        /// <summary>
+        ///     Rewrites <see cref="EpochModel.AllEpochIds" /> from the live <c>_epochTypeDictionary</c> so
+        ///     <see cref="EpochModel.IsValid" /> matches <see cref="EpochModel.Get" /> after third-party dictionary edits or
+        ///     early vanilla lazy-init of <c>_allEpochIds</c>.
+        /// </summary>
+        internal static void EnsureAllEpochIdsSyncedWithDictionary()
+        {
+            lock (SyncRoot)
+            {
+                RefreshAllEpochIdsSnapshotLocked();
+            }
+        }
+
         private void RegisterEpoch(Type epochType)
         {
             EnsureMutable($"register epoch '{epochType.Name}'");
@@ -139,8 +152,7 @@ namespace STS2RitsuLib.Timeline
 
                 epochTypeDictionary[epochId] = epochType;
                 typeToIdDictionary[epochType] = epochId;
-                SetStaticField(typeof(EpochModel), "_allEpochIds",
-                    epochTypeDictionary.Keys.OrderBy(id => id, StringComparer.Ordinal).ToArray());
+                RefreshAllEpochIdsSnapshotLocked();
             }
 
             _logger.Info($"[Timeline] Registered epoch: {epochType.Name} (id={epochId})");
@@ -231,6 +243,14 @@ namespace STS2RitsuLib.Timeline
                         ?? throw new MissingFieldException(ownerType.FullName, fieldName);
 
             field.SetValue(null, value);
+        }
+
+        private static void RefreshAllEpochIdsSnapshotLocked()
+        {
+            var epochTypeDictionary =
+                GetStaticField<Dictionary<string, Type>>(typeof(EpochModel), "_epochTypeDictionary");
+            SetStaticField(typeof(EpochModel), "_allEpochIds",
+                epochTypeDictionary.Keys.OrderBy(id => id, StringComparer.Ordinal).ToArray());
         }
     }
 }

--- a/Timeline/ModTimelineRegistry.cs
+++ b/Timeline/ModTimelineRegistry.cs
@@ -109,6 +109,8 @@ namespace STS2RitsuLib.Timeline
                 foreach (var registry in Registries.Values)
                     registry._freezeReason = reason;
             }
+
+            ModTimelineLayoutRegistry.FreezeAndValidate();
         }
 
         /// <summary>

--- a/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
+++ b/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
@@ -1,20 +1,22 @@
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Timeline;
+using MegaCrit.Sts2.Core.Timeline.Epochs;
 using STS2RitsuLib.Patching.Models;
-using STS2RitsuLib.Timeline.Scaffolding;
 
 namespace STS2RitsuLib.Timeline.Patches
 {
     /// <summary>
-    ///     Vanilla <see cref="NTimelineScreen.InitScreen" /> only passes epochs that already exist in
-    ///     <see cref="MegaCrit.Sts2.Core.Saves.ProgressState.Epochs" /> into <see cref="NTimelineScreen.AddEpochSlots" />.
+    ///     Vanilla <see cref="MegaCrit.Sts2.Core.Nodes.Screens.Timeline.NTimelineScreen.InitScreen" /> only passes epochs
+    ///     that already exist in <see cref="MegaCrit.Sts2.Core.Saves.ProgressState.Epochs" /> into
+    ///     <see cref="MegaCrit.Sts2.Core.Nodes.Screens.Timeline.NTimelineScreen.AddEpochSlots" />.
     ///     Mod story lines are not inserted into the save until gameplay or expansion runs
     ///     <see cref="MegaCrit.Sts2.Core.Saves.ProgressState.UnlockSlot" />, so mod columns would stay missing while the
-    ///     underlying unlock flow stays correct. This prefix only augments the in-memory list for the non-animated
-    ///     <see cref="NTimelineScreen.AddEpochSlots" /> call used by <c>InitScreen</c> (the only <c>isAnimated: false</c>
-    ///     caller), without writing placeholder rows into progress — so <see cref="EpochModel.QueueTimelineExpansion" />
-    ///     and <see cref="MegaCrit.Sts2.Core.Saves.ProgressState.UnlockSlot" /> behave like vanilla.
+    ///     underlying unlock flow stays correct. Cold open (<c>isAnimated: false</c>) merges only after vanilla Neow&apos;s
+    ///     primary expansion has started (see <see cref="ModTimelineNeowCoExpansion.HasVanillaNeowTimelineExpansionStarted" />
+    ///     ).
+    ///     Animated expansion merges only when <see cref="NeowEpoch.QueueUnlocks" /> just queued that batch (pending flag from
+    ///     <see cref="QueueTimelineExpansionUnlockModSlotsAfterNeowPatch" />).
     /// </summary>
     public sealed class NTimelineScreenAddEpochSlotsMergeModTemplatesPatch : IPatchMethod
     {
@@ -23,7 +25,7 @@ namespace STS2RitsuLib.Timeline.Patches
 
         /// <inheritdoc />
         public static string Description =>
-            "Merge ModEpochTemplate slots into InitScreen AddEpochSlots list without mutating Progress.Epochs";
+            "Merge ModEpochTemplate slots only after Neow primary expansion (cold) or same-session Neow QueueUnlocks (animated)";
 
         /// <inheritdoc />
         public static bool IsCritical => false;
@@ -33,67 +35,39 @@ namespace STS2RitsuLib.Timeline.Patches
         {
             return
             [
-                new(typeof(NTimelineScreen), nameof(NTimelineScreen.AddEpochSlots),
+                new(typeof(NTimelineScreen),
+                    nameof(NTimelineScreen.AddEpochSlots),
                     [typeof(List<EpochSlotData>), typeof(bool)]),
             ];
         }
 
         /// <summary>
-        ///     When <paramref name="isAnimated" /> is false (timeline init), append missing mod template slots and re-sort
-        ///     like vanilla <c>InitScreen</c> (<c>EraPosition</c> only).
+        ///     Cold: merge after Neow primary expansion has touched save. Animated: merge only with pending from Neow
+        ///     <see cref="NeowEpoch.QueueUnlocks" /> plus matching slot batch.
         /// </summary>
         public static void Prefix(List<EpochSlotData> slotsToAdd, bool isAnimated)
         {
-            if (isAnimated)
-                return;
-
             var progress = SaveManager.Instance?.Progress;
 
-            var existing = new HashSet<string>(slotsToAdd.Count);
-            foreach (var s in slotsToAdd)
-                existing.Add(s.Model.Id);
-
-            foreach (var id in EpochModel.AllEpochIds)
+            if (!isAnimated)
             {
-                if (existing.Contains(id))
-                    continue;
+                if (!ModTimelineNeowCoExpansion.HasVanillaNeowTimelineExpansionStarted(progress))
+                    return;
 
-                EpochModel model;
-                try
-                {
-                    model = EpochModel.Get(id);
-                }
-                catch
-                {
-                    continue;
-                }
-
-                if (model is not ModEpochTemplate)
-                    continue;
-
-                slotsToAdd.Add(new(model, ResolveMergedModSlotState(id, progress)));
-                existing.Add(id);
+                ModTimelineNeowCoExpansion.MergeModEpochTemplateSlotsInto(slotsToAdd, progress);
+                return;
             }
 
-            slotsToAdd.Sort((a, b) => a.EraPosition.CompareTo(b.EraPosition));
-        }
+            if (slotsToAdd.Count == 1 && slotsToAdd[0].Model.Id == EpochModel.GetId<NeowEpoch>())
+                return;
 
-        private static EpochSlotState ResolveMergedModSlotState(string id, ProgressState? progress)
-        {
-            if (progress == null || !progress.HasEpoch(id))
-                return EpochSlotState.NotObtained;
+            if (!ModTimelineNeowCoExpansion.TryConsumePendingNeowAnimatedSlotMerge())
+                return;
 
-            var row = progress.Epochs.FirstOrDefault(e => e.Id == id);
-            if (row == null)
-                return EpochSlotState.NotObtained;
+            if (!ModTimelineNeowCoExpansion.IsNeowPrimaryTimelineExpansionSlots(slotsToAdd))
+                return;
 
-            return row.State switch
-            {
-                EpochState.Revealed => EpochSlotState.Complete,
-                EpochState.Obtained => EpochSlotState.Obtained,
-                EpochState.ObtainedNoSlot => EpochSlotState.Obtained,
-                _ => EpochSlotState.NotObtained,
-            };
+            ModTimelineNeowCoExpansion.MergeModEpochTemplateSlotsInto(slotsToAdd, progress);
         }
     }
 }

--- a/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
+++ b/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
@@ -1,4 +1,5 @@
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
+using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Timeline;
 using STS2RitsuLib.Patching.Models;
 using STS2RitsuLib.Timeline.Scaffolding;
@@ -46,6 +47,8 @@ namespace STS2RitsuLib.Timeline.Patches
             if (isAnimated)
                 return;
 
+            var progress = SaveManager.Instance?.Progress;
+
             var existing = new HashSet<string>(slotsToAdd.Count);
             foreach (var s in slotsToAdd)
                 existing.Add(s.Model.Id);
@@ -68,11 +71,29 @@ namespace STS2RitsuLib.Timeline.Patches
                 if (model is not ModEpochTemplate)
                     continue;
 
-                slotsToAdd.Add(new(model, EpochSlotState.NotObtained));
+                slotsToAdd.Add(new(model, ResolveMergedModSlotState(id, progress)));
                 existing.Add(id);
             }
 
             slotsToAdd.Sort((a, b) => a.EraPosition.CompareTo(b.EraPosition));
+        }
+
+        private static EpochSlotState ResolveMergedModSlotState(string id, ProgressState? progress)
+        {
+            if (progress == null || !progress.HasEpoch(id))
+                return EpochSlotState.NotObtained;
+
+            var row = progress.Epochs.FirstOrDefault(e => e.Id == id);
+            if (row == null)
+                return EpochSlotState.NotObtained;
+
+            return row.State switch
+            {
+                EpochState.Revealed => EpochSlotState.Complete,
+                EpochState.Obtained => EpochSlotState.Obtained,
+                EpochState.ObtainedNoSlot => EpochSlotState.Obtained,
+                _ => EpochSlotState.NotObtained,
+            };
         }
     }
 }

--- a/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
+++ b/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
@@ -61,10 +61,10 @@ namespace STS2RitsuLib.Timeline.Patches
             if (slotsToAdd.Count == 1 && slotsToAdd[0].Model.Id == EpochModel.GetId<NeowEpoch>())
                 return;
 
-            if (!ModTimelineNeowCoExpansion.TryConsumePendingNeowAnimatedSlotMerge())
+            if (!ModTimelineNeowCoExpansion.IsNeowPrimaryTimelineExpansionSlots(slotsToAdd))
                 return;
 
-            if (!ModTimelineNeowCoExpansion.IsNeowPrimaryTimelineExpansionSlots(slotsToAdd))
+            if (!ModTimelineNeowCoExpansion.TryConsumePendingNeowAnimatedSlotMerge())
                 return;
 
             ModTimelineNeowCoExpansion.MergeModEpochTemplateSlotsInto(slotsToAdd, progress);

--- a/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
+++ b/Timeline/Patches/NTimelineScreenAddEpochSlotsMergeModTemplatesPatch.cs
@@ -1,0 +1,78 @@
+using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
+using MegaCrit.Sts2.Core.Timeline;
+using STS2RitsuLib.Patching.Models;
+using STS2RitsuLib.Timeline.Scaffolding;
+
+namespace STS2RitsuLib.Timeline.Patches
+{
+    /// <summary>
+    ///     Vanilla <see cref="NTimelineScreen.InitScreen" /> only passes epochs that already exist in
+    ///     <see cref="MegaCrit.Sts2.Core.Saves.ProgressState.Epochs" /> into <see cref="NTimelineScreen.AddEpochSlots" />.
+    ///     Mod story lines are not inserted into the save until gameplay or expansion runs
+    ///     <see cref="MegaCrit.Sts2.Core.Saves.ProgressState.UnlockSlot" />, so mod columns would stay missing while the
+    ///     underlying unlock flow stays correct. This prefix only augments the in-memory list for the non-animated
+    ///     <see cref="NTimelineScreen.AddEpochSlots" /> call used by <c>InitScreen</c> (the only <c>isAnimated: false</c>
+    ///     caller), without writing placeholder rows into progress — so <see cref="EpochModel.QueueTimelineExpansion" />
+    ///     and <see cref="MegaCrit.Sts2.Core.Saves.ProgressState.UnlockSlot" /> behave like vanilla.
+    /// </summary>
+    public sealed class NTimelineScreenAddEpochSlotsMergeModTemplatesPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "n_timeline_screen_add_epoch_slots_merge_mod_templates";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Merge ModEpochTemplate slots into InitScreen AddEpochSlots list without mutating Progress.Epochs";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(NTimelineScreen), nameof(NTimelineScreen.AddEpochSlots),
+                    [typeof(List<EpochSlotData>), typeof(bool)]),
+            ];
+        }
+
+        /// <summary>
+        ///     When <paramref name="isAnimated" /> is false (timeline init), append missing mod template slots and re-sort
+        ///     like vanilla <c>InitScreen</c> (<c>EraPosition</c> only).
+        /// </summary>
+        public static void Prefix(List<EpochSlotData> slotsToAdd, bool isAnimated)
+        {
+            if (isAnimated)
+                return;
+
+            var existing = new HashSet<string>(slotsToAdd.Count);
+            foreach (var s in slotsToAdd)
+                existing.Add(s.Model.Id);
+
+            foreach (var id in EpochModel.AllEpochIds)
+            {
+                if (existing.Contains(id))
+                    continue;
+
+                EpochModel model;
+                try
+                {
+                    model = EpochModel.Get(id);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (model is not ModEpochTemplate)
+                    continue;
+
+                slotsToAdd.Add(new(model, EpochSlotState.NotObtained));
+                existing.Add(id);
+            }
+
+            slotsToAdd.Sort((a, b) => a.EraPosition.CompareTo(b.EraPosition));
+        }
+    }
+}

--- a/Timeline/Patches/NeowEpochQueueUnlocksCoExpansionScopePatch.cs
+++ b/Timeline/Patches/NeowEpochQueueUnlocksCoExpansionScopePatch.cs
@@ -1,0 +1,46 @@
+using MegaCrit.Sts2.Core.Timeline.Epochs;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.Timeline.Patches
+{
+    /// <summary>
+    ///     Scopes mod timeline co-expansion to vanilla <see cref="NeowEpoch.QueueUnlocks" /> so other
+    ///     <see cref="MegaCrit.Sts2.Core.Timeline.EpochModel.QueueTimelineExpansion" /> callers (character lines, relic rows,
+    ///     etc.) do not unlock or animate every <see cref="STS2RitsuLib.Timeline.Scaffolding.ModEpochTemplate" />.
+    /// </summary>
+    public sealed class NeowEpochQueueUnlocksCoExpansionScopePatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "neow_epoch_queue_unlocks_co_expansion_scope";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Track NeowEpoch.QueueUnlocks so QueueTimelineExpansion postfix only co-unlocks mod slots in that flow";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NeowEpoch), nameof(NeowEpoch.QueueUnlocks), Type.EmptyTypes)];
+        }
+
+        /// <summary>
+        ///     Increments depth before Neow&apos;s unlock queue runs.
+        /// </summary>
+        public static void Prefix()
+        {
+            ModTimelineNeowCoExpansion.EnterNeowQueueUnlocks();
+        }
+
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        ///     Always decrements depth, even when <see cref="NeowEpoch.QueueUnlocks" /> throws.
+        /// </summary>
+        public static void Finalizer(Exception? __exception)
+        {
+            ModTimelineNeowCoExpansion.ExitNeowQueueUnlocks();
+        }
+    }
+}

--- a/Timeline/Patches/TimelineExpansionUnlockFlowPatches.cs
+++ b/Timeline/Patches/TimelineExpansionUnlockFlowPatches.cs
@@ -2,6 +2,7 @@ using HarmonyLib;
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline.UnlockScreens;
 using MegaCrit.Sts2.Core.Timeline;
 using STS2RitsuLib.Patching.Models;
+using STS2RitsuLib.Timeline.Scaffolding;
 
 namespace STS2RitsuLib.Timeline.Patches
 {
@@ -85,6 +86,45 @@ namespace STS2RitsuLib.Timeline.Patches
 
             var ordered = eras.OrderBy(a => a.Era).ThenBy(a => a.EraPosition).ToList();
             field.SetValue(__instance, ordered);
+        }
+    }
+
+    /// <summary>
+    ///     When <c>NeowEpoch.QueueUnlocks</c> runs (scoped by <see cref="NeowEpochQueueUnlocksCoExpansionScopePatch" />),
+    ///     after vanilla <see cref="EpochModel.QueueTimelineExpansion" /> unlocks the twelve base rows, also
+    ///     <see cref="MegaCrit.Sts2.Core.Saves.SaveManager.UnlockSlot" /> for every <see cref="ModEpochTemplate" /> not in
+    ///     that batch, and signal the
+    ///     animated <see cref="MegaCrit.Sts2.Core.Nodes.Screens.Timeline.NTimelineScreen.AddEpochSlots" /> prefix to merge the
+    ///     same mod slots in-session.
+    /// </summary>
+    public sealed class QueueTimelineExpansionUnlockModSlotsAfterNeowPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "queue_timeline_expansion_unlock_mod_slots_after_neow";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "After Neow primary timeline expansion, UnlockSlot for ModEpochTemplate ids not in the vanilla batch";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(EpochModel), nameof(EpochModel.QueueTimelineExpansion), [typeof(EpochModel[])]),
+            ];
+        }
+
+        /// <summary>
+        ///     Runs after vanilla queues the expansion list and unlocks vanilla slots.
+        /// </summary>
+        public static void Postfix(EpochModel[] epochs)
+        {
+            ArgumentNullException.ThrowIfNull(epochs);
+            ModTimelineNeowCoExpansion.OnQueueTimelineExpansionPostfix(epochs);
         }
     }
 }

--- a/Timeline/Patches/TimelineExpansionUnlockFlowPatches.cs
+++ b/Timeline/Patches/TimelineExpansionUnlockFlowPatches.cs
@@ -1,0 +1,90 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Screens.Timeline.UnlockScreens;
+using MegaCrit.Sts2.Core.Timeline;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.Timeline.Patches
+{
+    /// <summary>
+    ///     Before the timeline queues expansion slots, align <see cref="EpochModel.AllEpochIds" /> with
+    ///     <c>EpochModel._epochTypeDictionary</c>. Otherwise <see cref="MegaCrit.Sts2.Core.Saves.ProgressState" />
+    ///     <c>FilterAndSortEpochs</c> may strip mod expansion ids (IsValid false) immediately after
+    ///     <see cref="MegaCrit.Sts2.Core.Saves.SaveManager.UnlockSlot" />, so the live expansion UI breaks while a cold
+    ///     reload still shows slots once the cache matches the dictionary.
+    /// </summary>
+    public class QueueTimelineExpansionSyncEpochIdListPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "queue_timeline_expansion_sync_epoch_id_list";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Sync EpochModel.AllEpochIds with the epoch type dictionary before QueueTimelineExpansion runs UnlockSlot";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(EpochModel), nameof(EpochModel.QueueTimelineExpansion), [typeof(EpochModel[])]),
+            ];
+        }
+
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        ///     Ensures <see cref="EpochModel.IsValid" /> sees every id present in <see cref="EpochModel.Get" />.
+        /// </summary>
+        public static void Prefix(EpochModel[] epochs)
+        {
+            ArgumentNullException.ThrowIfNull(epochs);
+            ModTimelineRegistry.EnsureAllEpochIdsSyncedWithDictionary();
+        }
+    }
+
+    /// <summary>
+    ///     Vanilla <see cref="NUnlockTimelineScreen.SetUnlocks" /> sorts only by <see cref="EpochSlotData.EraPosition" />,
+    ///     which collides across <see cref="EpochEra" /> values — common for mod timelines. Expansion animation then
+    ///     feeds <see cref="MegaCrit.Sts2.Core.Nodes.Screens.Timeline.NTimelineScreen.AddEpochSlots" /> in the wrong era
+    ///     order.
+    /// </summary>
+    public class NUnlockTimelineScreenExpansionSlotSortPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "n_unlock_timeline_screen_expansion_slot_sort";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Sort timeline expansion slots by Era then EraPosition for mod-compatible column ordering";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(NUnlockTimelineScreen), nameof(NUnlockTimelineScreen.SetUnlocks),
+                    [typeof(List<EpochSlotData>)]),
+            ];
+        }
+
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        ///     Replaces the vanilla <c>_erasToUnlock</c> ordering with era-stable sorting.
+        /// </summary>
+        public static void Postfix(NUnlockTimelineScreen __instance, List<EpochSlotData> eras)
+        {
+            ArgumentNullException.ThrowIfNull(eras);
+            var field = AccessTools.Field(typeof(NUnlockTimelineScreen), "_erasToUnlock");
+            if (field == null)
+                return;
+
+            var ordered = eras.OrderBy(a => a.Era).ThenBy(a => a.EraPosition).ToList();
+            field.SetValue(__instance, ordered);
+        }
+    }
+}

--- a/Timeline/Scaffolding/ModEpochTemplate.cs
+++ b/Timeline/Scaffolding/ModEpochTemplate.cs
@@ -11,6 +11,12 @@ namespace STS2RitsuLib.Timeline.Scaffolding
     public abstract class ModEpochTemplate : EpochModel, IModEpochAssetOverrides
     {
         /// <inheritdoc />
+        public sealed override EpochEra Era => ModTimelineLayoutRegistry.ResolveEra(GetType());
+
+        /// <inheritdoc />
+        public sealed override int EraPosition => ModTimelineLayoutRegistry.ResolveEraPosition(GetType());
+
+        /// <inheritdoc />
         public virtual EpochAssetProfile AssetProfile => EpochAssetProfile.Empty;
 
         /// <inheritdoc />

--- a/Unlocks/Patches/ProgressSaveManagerGetRevealableEpochsModTemplatePatch.cs
+++ b/Unlocks/Patches/ProgressSaveManagerGetRevealableEpochsModTemplatePatch.cs
@@ -1,0 +1,77 @@
+using MegaCrit.Sts2.Core.Saves;
+using MegaCrit.Sts2.Core.Saves.Managers;
+using MegaCrit.Sts2.Core.Timeline;
+using STS2RitsuLib.Patching.Models;
+using STS2RitsuLib.Timeline.Scaffolding;
+
+namespace STS2RitsuLib.Unlocks.Patches
+{
+    /// <summary>
+    ///     Vanilla <see cref="ProgressSaveManager.GetRevealableEpochs" /> only marks epochs reachable from Neow via
+    ///     <see cref="EpochModel.GetTimelineExpansion" /> BFS. Mod story roots are not in that graph, so obtained mod slots
+    ///     never count for <see cref="SaveManager.GetDiscoveredEpochCount" />, main-menu timeline cues, or related UX even
+    ///     when the UI slot is already in the obtained (click-to-reveal) state.
+    /// </summary>
+    public sealed class ProgressSaveManagerGetRevealableEpochsModTemplatePatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "progress_save_manager_get_revealable_epochs_mod_template";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Union ModEpochTemplate rows in Obtained/ObtainedNoSlot into GetRevealableEpochs when vanilla omits them";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(ProgressSaveManager), nameof(ProgressSaveManager.GetRevealableEpochs), Type.EmptyTypes)];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Appends mod template epochs that satisfy vanilla's satisfied-state filter but were dropped for lack of
+        ///     reachability from Neow.
+        /// </summary>
+        public static IEnumerable<SerializableEpoch> Postfix(
+                IEnumerable<SerializableEpoch> __result,
+                ProgressSaveManager __instance)
+            // ReSharper restore InconsistentNaming
+        {
+            var list = __result.ToList();
+            var seen = new HashSet<string>(list.Select(e => e.Id));
+
+            foreach (var epoch in __instance.Progress.Epochs)
+            {
+                var st = epoch.State;
+                if (st != EpochState.Obtained && st != EpochState.ObtainedNoSlot)
+                    continue;
+                if (!seen.Add(epoch.Id))
+                    continue;
+
+                EpochModel model;
+                try
+                {
+                    model = EpochModel.Get(epoch.Id);
+                }
+                catch
+                {
+                    seen.Remove(epoch.Id);
+                    continue;
+                }
+
+                if (model is not ModEpochTemplate)
+                {
+                    seen.Remove(epoch.Id);
+                    continue;
+                }
+
+                list.Add(epoch);
+            }
+
+            return list;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive system for explicit and automatic mod epoch timeline slot registration, ensuring modded epochs are placed in the timeline without conflicting with vanilla or other modded epochs. It adds new APIs for timeline slot specification, enforces validation, and updates the patcher setup to support these features.

**New Timeline Slot Registration System**

* [`Timeline/ModTimelineLayoutRegistry.cs`](diffhunk://#diff-3960bbe3a544befc8967705d8d6f0dc264d907a37fe7fcc7445ff137a7884efdR1-R358): Introduces `ModTimelineLayoutRegistry`, a central registry for managing timeline slot assignments for `ModEpochTemplate` epochs. It provides APIs for explicit slot registration and several strategies for automatic placement relative to vanilla or other modded epochs, with robust conflict detection and validation.
* [`Scaffolding/Content/ModContentPackBuilder.cs`](diffhunk://#diff-a2e925851147ff684cfca87c121af74b6bccd5e66e4cf81f7f89c419bf64124fR450-R490): Adds new fluent methods (`ModEpochTimelineSlot`, `ModEpochAutoTimelineSlot`, etc.) to queue timeline slot registrations for mod epochs, making it easier for mod authors to specify timeline placement.
* [`Scaffolding/Content/TimelineColumnPackEntry.cs`](diffhunk://#diff-ddbb2b3caa22523beec0d4ba002012b54c57fb5de2a6bb72969b55c903189473L59-R76): Updates the `Epoch` method and introduces new methods in `EpochSlotBuilder` to support the new slot registration system. Ensures slot registration occurs before timeline freeze and clarifies usage in documentation. [[1]](diffhunk://#diff-ddbb2b3caa22523beec0d4ba002012b54c57fb5de2a6bb72969b55c903189473L59-R76) [[2]](diffhunk://#diff-ddbb2b3caa22523beec0d4ba002012b54c57fb5de2a6bb72969b55c903189473R138-R220)

**Framework and Patch Integration**

* [`RitsuLibFramework.PatcherSetup.cs`](diffhunk://#diff-f7c0678c3622ade8d1972d710bec2ab5c166e38d57fff28bcad4146cf0a31466R15): Integrates the new timeline patch system by importing the new patch namespace and registering several timeline-related patches in the unlock patch registration pipeline. [[1]](diffhunk://#diff-f7c0678c3622ade8d1972d710bec2ab5c166e38d57fff28bcad4146cf0a31466R15) [[2]](diffhunk://#diff-f7c0678c3622ade8d1972d710bec2ab5c166e38d57fff28bcad4146cf0a31466R260-R265)

These changes provide a robust and extensible foundation for mod timeline management, preventing slot conflicts and making mod development more reliable and user-friendly.