### PR TITLE
Enhance animation system with state machines, queueing, and documentation

### DIFF
--- a/Audio/AudioHandleBase.cs
+++ b/Audio/AudioHandleBase.cs
@@ -182,6 +182,8 @@ namespace STS2RitsuLib.Audio
             TryRelease();
             AudioLifecycleRegistry.Shared.Detach(this);
             AudioChannelRegistry.Shared.Detach(this);
+
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/Audio/Internal/GuidMappedNaudioStudioProxy.cs
+++ b/Audio/Internal/GuidMappedNaudioStudioProxy.cs
@@ -17,7 +17,7 @@ namespace STS2RitsuLib.Audio.Internal
         internal static bool IsMappedPath(string? path)
         {
             return !string.IsNullOrEmpty(path) &&
-                   FmodStudioGuidPathTable.TryGetStudioGuidForEventPath(path!, out _);
+                   FmodStudioGuidPathTable.TryGetStudioGuidForEventPath(path, out _);
         }
 
         internal static void StopAllMappedLoops()

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -26,6 +26,7 @@
 | [Timeline & Unlocks](en/TimelineAndUnlocks.md) | Story / epoch registration, progression rules, and compatibility bridges |
 | [Asset Profiles & Fallbacks](en/AssetProfilesAndFallbacks.md) | Character placeholder fallback, content profiles, and path diagnostics |
 | [Godot Scene Authoring](en/GodotSceneAuthoring.md) | Scene-script wrappers, editor caveats, and runtime script registration |
+| [Creature Visuals & Animation](en/CreatureVisualsAndAnimation.md) | Creature visuals / animator factories and the non-Spine `ModAnimStateMachine` pipeline |
 | [Mod Settings](en/ModSettings.md) | Settings UI architecture, bindings, supported controls, and page composition |
 
 ### Localization
@@ -69,6 +70,7 @@
 | [时间线与解锁](zh/TimelineAndUnlocks.md) | Story / Epoch 注册、进度规则与兼容桥接 |
 | [资源配置与回退规则](zh/AssetProfilesAndFallbacks.md) | 角色 Placeholder、内容 Profile 与路径诊断 |
 | [Godot 场景编写说明](zh/GodotSceneAuthoring.md) | 场景脚本包装、编辑器问题与运行时脚本注册 |
+| [生物体视觉与动画](zh/CreatureVisualsAndAnimation.md) | 生物视觉 / animator 工厂接口与非 Spine `ModAnimStateMachine` 管线 |
 | [Mod 设置界面](zh/ModSettings.md) | 设置 UI 架构、绑定方式、支持控件与页面组合 |
 
 ### 本地化

--- a/Docs/en/CreatureVisualsAndAnimation.md
+++ b/Docs/en/CreatureVisualsAndAnimation.md
@@ -1,0 +1,338 @@
+# Creature Visuals & Animation
+
+This document covers the runtime-Godot factory interfaces that let mod creatures
+replace vanilla `CreateVisuals` / `GenerateAnimator`, and the backend-agnostic
+animation state machine (`ModAnimStateMachine`) that drives non-Spine combat
+visuals (`AnimatedSprite2D`, Godot `AnimationPlayer`, or cue frame sequences)
+through the same trigger protocol Spine creatures use.
+
+For content pack registration, see [Content Packs & Registries](ContentPacksAndRegistries.md).
+For character assembly, see [Character & Unlock Templates](CharacterAndUnlockScaffolding.md).
+For Harmony patch wiring in general, see [Patching Guide](PatchingGuide.md).
+
+---
+
+## Overview
+
+Vanilla binds a `MonsterModel` or `CharacterModel` to combat visuals through:
+
+- `Model.CreateVisuals()` — returns an `NCreatureVisuals` (the scene root under
+  the combat creature node).
+- `Model.GenerateAnimator(MegaSprite controller)` — returns a `CreatureAnimator`
+  wrapping a Spine skeleton with an idle / hit / attack / cast / die / relaxed
+  state graph.
+- `NCreature.SetAnimationTrigger(trigger)` — dispatches triggers
+  (`Idle`, `Attack`, `Cast`, `Hit`, `Dead`, `Revive`, ...) into that animator at
+  runtime.
+
+Mods commonly need one or more of:
+
+- supplying `NCreatureVisuals` from code (not a path);
+- replacing the Spine state graph with a mod-authored one;
+- animating creatures **without** a Spine skeleton (sprite sheets, frame
+  sequences, Godot `AnimationPlayer`).
+
+RitsuLib exposes three orthogonal factory interfaces for those hooks and one
+state machine abstraction for the non-Spine case. All four interfaces are
+creature-agnostic (players **and** monsters) and do not require subclassing any
+template.
+
+| Interface | Purpose | Vanilla entry point |
+|---|---|---|
+| `IModCreatureVisualsFactory` | Build `NCreatureVisuals` from code | `CharacterModel.CreateVisuals`, `MonsterModel.CreateVisuals` |
+| `IModCreatureAnimatorFactory` | Build Spine `CreatureAnimator` from code | `CharacterModel.GenerateAnimator`, `MonsterModel.GenerateAnimator` |
+| `IModNonSpineAnimationStateMachineFactory` | Build `ModAnimStateMachine` for non-Spine visuals | `NCreature.SetAnimationTrigger` (routing patch) |
+| `IModCharacterMerchantAnimationStateMachineFactory` | Build `ModAnimStateMachine` for merchant / rest-site character visuals | Merchant scene setup |
+
+The merchant factory is character-specific because monsters never appear in
+merchant / rest-site scenes; the other three apply to any
+`MegaCrit.Sts2.Core.Models.AbstractModel`.
+
+---
+
+## Creature Visuals Factory
+
+`IModCreatureVisualsFactory` replaces the path-based
+`(Character|Monster)Model.CreateVisuals` when it returns a non-null
+`NCreatureVisuals`. `null` defers to `CustomVisualsPath` / vanilla resolution.
+
+```csharp
+public class MyCharacter : ModCharacterTemplate<...>
+{
+    // IModCreatureVisualsFactory is already implemented by the template,
+    // forwarding to this protected virtual:
+    protected override NCreatureVisuals? TryCreateCreatureVisuals()
+    {
+        var scene = GD.Load<PackedScene>(
+            "res://MyMod/scenes/my_character/my_character_visuals.tscn");
+        return scene.Instantiate<NCreatureVisuals>();
+    }
+}
+```
+
+For mods that do not use `ModCharacterTemplate` / `ModMonsterTemplate`, implement
+the interface directly on your `CharacterModel` / `MonsterModel`:
+
+```csharp
+public class MyRawCharacter : CharacterModel, IModCreatureVisualsFactory
+{
+    public NCreatureVisuals? TryCreateCreatureVisuals() => ...;
+}
+```
+
+The routing patches (`CharacterCreatureVisualsRuntimeFactoryPatch`,
+`MonsterCreatureVisualsRuntimeFactoryPatch`) run at Harmony `Priority.First`, so
+they take effect before the vanilla path-based loader.
+
+---
+
+## Creature Animator Factory (Spine)
+
+`IModCreatureAnimatorFactory` replaces `GenerateAnimator` for Spine visuals.
+Prefer `ModAnimStateMachines.Standard` to match the vanilla state shape:
+
+```csharp
+public class MySpineCharacter : ModCharacterTemplate<...>
+{
+    protected override CreatureAnimator? SetupCustomCreatureAnimator(MegaSprite controller) =>
+        ModAnimStateMachines.Standard(
+            controller,
+            idleName: "idle_loop",
+            deadName: "die",
+            hitName: "hit",
+            attackName: "attack",
+            castName: "cast",
+            relaxedName: "relaxed");
+}
+```
+
+`ModAnimStateMachines.Standard` returns a `CreatureAnimator` wired with any-state
+triggers for `Idle`, `Dead`, `Hit`, `Attack`, `Cast`, `Relaxed`. Terminal states
+(`Dead`) leave `NextState` unset so playback does not loop back to idle.
+
+The routing patches (`CharacterCreatureAnimatorRuntimeFactoryPatch`,
+`MonsterCreatureAnimatorRuntimeFactoryPatch`) honour non-null factory output;
+`null` defers to vanilla `GenerateAnimator`.
+
+---
+
+## Non-Spine State Machine
+
+For creatures whose combat visuals are **not** Spine (no `MegaSprite` controller),
+implement `IModNonSpineAnimationStateMachineFactory` and return a
+`ModAnimStateMachine` bound to the visuals root. The
+`ModCreatureNonSpineAnimationPlaybackPatch` routes
+`NCreature.SetAnimationTrigger(trigger)` into `ModAnimStateMachine.SetTrigger`,
+so the non-Spine path receives the **same trigger stream** as Spine creatures.
+
+### Opting in
+
+```csharp
+public class MyWolf : ModMonsterTemplate
+{
+    // IModNonSpineAnimationStateMachineFactory is already implemented by the
+    // template, forwarding to this protected virtual:
+    protected override ModAnimStateMachine? SetupCustomNonSpineAnimationStateMachine(
+        Node visualsRoot, MonsterModel monster)
+    {
+        if (visualsRoot is not MyWolfVisuals wolfVisuals)
+            return null;
+
+        var backend = new AnimatedSprite2DBackend(wolfVisuals.GetAnimatedSprite());
+
+        return ModAnimStateMachineBuilder.Create()
+            .AddState("idle", loop: true).AsInitial().Done()
+            .AddState("attack").WithNext("idle").Done()
+            .AddState("hurt").WithNext("idle").Done()
+            .AddState("die").Done()                     // terminal: no NextState
+            .AddAnyState("Idle",   "idle")
+            .AddAnyState("Attack", "attack")
+            .AddAnyState("Hit",    "hurt")
+            .AddAnyState("Dead",   "die")
+            .Build(backend);
+    }
+}
+```
+
+Equivalent if you do not use a template:
+
+```csharp
+public class MyRawMonster : MonsterModel, IModNonSpineAnimationStateMachineFactory
+{
+    public ModAnimStateMachine? TryCreateNonSpineAnimationStateMachine(Node visualsRoot)
+        => /* same builder code */;
+}
+```
+
+### Routing behaviour
+
+`ModCreatureNonSpineAnimationPlaybackPatch` is a prefix on
+`NCreature.SetAnimationTrigger`:
+
+1. If the creature has a Spine animator, skip (vanilla path runs).
+2. Look up the creature's model (`Entity.Player?.Character` or `Entity.Monster`).
+3. If either implements `IModNonSpineAnimationStateMachineFactory` and
+   returns a non-null state machine, dispatch the trigger via
+   `ModAnimStateMachine.SetTrigger` and return.
+4. Otherwise, fall back to single-shot cue playback
+   (`ModCreatureVisualPlayback.TryPlayFromCreatureAnimatorTrigger`).
+
+State machines are **cached per visuals root** with a
+`ConditionalWeakTable<Node, StateMachineSlot>`, so the factory runs at most once
+per combat lifetime and is automatically released when the visuals node is
+freed.
+
+### Shorthand: `ModAnimStateMachines.StandardCue`
+
+For visuals that follow the vanilla idle / dead / hit / attack / cast / relaxed
+shape, `ModAnimStateMachines.StandardCue` builds the state graph for you. It
+uses `CompositeBackendFactory` to pick the best backend per state (cue frame
+sequences first, Godot `AnimationPlayer` or `AnimatedSprite2D` if they resolve
+the animation id) and returns a ready-to-use `ModAnimStateMachine`.
+
+---
+
+## Animation Backends
+
+`IAnimationBackend` is the uniform driver surface consumed by
+`ModAnimStateMachine`. Each backend wraps a Godot animation subsystem and
+reports `Started` / `Completed` / `Interrupted` events.
+
+| Backend | Drives | Used for |
+|---|---|---|
+| `AnimatedSprite2DBackend` | `AnimatedSprite2D` | Frame-based sprite animation |
+| `GodotAnimationPlayerBackend` | `AnimationPlayer` | Godot `.tres` animation library |
+| `CueAnimationBackend` | `VisualCueSet` (cue frame sequences, cue textures) | Per-cue static textures / sequence playback |
+| `SpineAnimationBackend` | `MegaSprite` | Spine skeletal animation |
+| `CompositeAnimationBackend` | Any mix | Multi-backend dispatch (one state plays via sprite, another via animation player, etc.) |
+
+### Event contract
+
+| Event | When it fires |
+|---|---|
+| `Started(id)` | Playback for `id` has started |
+| `Completed(id)` | One-shot finished, or a loop cycle ended |
+| `Interrupted(id)` | Playback was replaced before completion |
+
+`ModAnimState.NextState` advances on `Completed`, so backends must emit it
+accurately for non-looping states (`attack -> idle` etc.).
+
+### Queue semantics
+
+`Queue(id, loop)` is semantically "play this after the currently active
+animation finishes". Backends implement it differently:
+
+| Backend | `Queue` behaviour |
+|---|---|
+| `SpineAnimationBackend` | True native Spine queue (`AddAnimation` on the track) |
+| `AnimatedSprite2DBackend` | Stores pending id, plays on next `animation_finished` signal |
+| `GodotAnimationPlayerBackend` | Uses `AnimationPlayer.Queue` |
+| `CueAnimationBackend` | Stores pending id, plays on sequence completion |
+
+In all cases, calling `Play` clears any pending queued animation.
+
+### `Stop()` and cross-backend transitions
+
+`IAnimationBackend.Stop()` (default interface method) halts the backend
+**silently** — it neither fires `Completed` nor `Interrupted`, and clears any
+queued animation. The primary consumer is `CompositeAnimationBackend` when
+transitioning from one child backend to another:
+
+1. The new state's backend differs from the active one.
+2. `Interrupted` is fired for the outgoing animation.
+3. The outgoing backend's `Stop()` is called to clear its internal state.
+4. The incoming backend's `Play` runs.
+
+Without `Stop()`, the outgoing backend could keep emitting `Completed` /
+`Interrupted` events bound to its old state id and confuse the state machine.
+
+---
+
+## Lifecycle Trigger Patches
+
+Vanilla `NCreature.StartDeathAnim` and `NCreature.StartReviveAnim` dispatch the
+`Dead` / `Revive` triggers only when `_spineAnimator != null`. Non-Spine
+creatures therefore never receive those triggers, so a custom state machine
+never sees the death animation play when the run is abandoned or the player
+dies.
+
+RitsuLib fixes this with two Postfix patches:
+
+- `NCreatureNonSpineDeathAnimationTriggerPatch` — dispatches `Dead` after
+  `StartDeathAnim`.
+- `NCreatureNonSpineReviveAnimationTriggerPatch` — dispatches `Revive` after
+  `StartReviveAnim`.
+
+### Scope gate
+
+The patches are **opt-in**: they only fire when the creature has no Spine
+animator and the model opts into the RitsuLib visuals pipeline. Specifically,
+`NonSpineAnimationTriggerScope.AppliesTo(NCreature)` returns `true` only when
+**one** of the following holds for the creature's model:
+
+| Model slot | Interface | Notes |
+|---|---|---|
+| `Entity.Player?.Character` | `IModNonSpineAnimationStateMachineFactory` | State machine path |
+| `Entity.Monster` | `IModNonSpineAnimationStateMachineFactory` | State machine path |
+| `Entity.Player?.Character` | `IModCharacterAssetOverrides` | Cue-playback fallback (player-only) |
+
+Vanilla creatures and mods that do not opt into RitsuLib visuals are never
+affected. The gate is identical for the `Dead` and `Revive` patches.
+
+---
+
+## Migration & Deprecation
+
+Two factory interfaces were originally named after the creature kind. They are
+now unified and the old names marked `[Obsolete]`:
+
+| New (preferred) | Obsolete aliases |
+|---|---|
+| `IModCreatureVisualsFactory` | `IModMonsterCreatureVisualsFactory`, `IModCharacterCreatureVisualsFactory` |
+| `IModCreatureAnimatorFactory` | `IModCharacterCreatureAnimatorFactory` |
+
+### Compatibility guarantees
+
+- The routing patches check both the new and the obsolete interfaces on each
+  call, so mods that implement only the old interface continue to work without
+  any code change.
+- `ModCharacterTemplate` / `ModMonsterTemplate` implement **both** the new and
+  the obsolete aliases and forward to the same protected virtual hooks, so
+  external `is IModCharacterCreatureVisualsFactory` checks against a template
+  subclass still succeed.
+- Implementing an obsolete interface emits compiler warning **CS0618** to guide
+  migration. No runtime warning or behavioural change.
+
+### Migration steps
+
+1. Replace the old interface name in the `: Interfaces` list and in explicit
+   interface implementations:
+   - `IModMonsterCreatureVisualsFactory` → `IModCreatureVisualsFactory`
+   - `IModCharacterCreatureVisualsFactory` → `IModCreatureVisualsFactory`
+   - `IModCharacterCreatureAnimatorFactory` → `IModCreatureAnimatorFactory`
+2. The method signatures (`TryCreateCreatureVisuals()`,
+   `TryCreateCreatureAnimator(MegaSprite)`) are unchanged; only the declaring
+   interface name differs.
+3. Rebuild. CS0618 warnings disappear.
+
+No migration is required if you only subclass the templates and override the
+protected virtual hooks (`TryCreateCreatureVisuals`,
+`SetupCustomCreatureAnimator`); those hooks are unchanged.
+
+---
+
+## Summary Cheat-sheet
+
+```text
+Goal                                          Interface to implement
+---------------------------------------------------------------------------
+Replace CreateVisuals (players or monsters)   IModCreatureVisualsFactory
+Replace Spine GenerateAnimator                IModCreatureAnimatorFactory
+Drive a non-Spine state machine               IModNonSpineAnimationStateMachineFactory
+Drive merchant / rest-site state machine      IModCharacterMerchantAnimationStateMachineFactory
+```
+
+All four interfaces are honoured whether you inherit `ModCharacterTemplate` /
+`ModMonsterTemplate` or implement them directly on your `CharacterModel` /
+`MonsterModel`. The routing patches always run at Harmony `Priority.First` and
+defer to vanilla when the factory returns `null`.

--- a/Docs/zh/CreatureVisualsAndAnimation.md
+++ b/Docs/zh/CreatureVisualsAndAnimation.md
@@ -1,0 +1,318 @@
+# 生物体视觉与动画
+
+本文介绍一组 mod 可以接入的运行时 Godot 工厂接口（替换原版
+`CreateVisuals` / `GenerateAnimator`），以及后端无关的动画状态机
+`ModAnimStateMachine`。后者让非 Spine 的战斗视觉（`AnimatedSprite2D`、Godot
+`AnimationPlayer`、cue 帧序列）通过和 Spine 生物**相同的**触发协议驱动动画。
+
+内容包注册见 [内容包与注册器](ContentPacksAndRegistries.md)。
+角色装配见 [角色与解锁模板](CharacterAndUnlockScaffolding.md)。
+Harmony 补丁机制见 [补丁系统](PatchingGuide.md)。
+
+---
+
+## 概览
+
+原版将 `MonsterModel` / `CharacterModel` 绑定到战斗视觉的三个入口：
+
+- `Model.CreateVisuals()` — 返回一个 `NCreatureVisuals`（战斗生物节点下的视觉
+  根场景）。
+- `Model.GenerateAnimator(MegaSprite controller)` — 返回一个 `CreatureAnimator`，
+  内部封装 Spine 骨骼及 idle / hit / attack / cast / die / relaxed 状态图。
+- `NCreature.SetAnimationTrigger(trigger)` — 在运行时把触发器（`Idle`、
+  `Attack`、`Cast`、`Hit`、`Dead`、`Revive` 等）派发给这个 animator。
+
+Mod 常见的需求至少包括以下一种：
+
+- 用代码供给 `NCreatureVisuals`（而不是只用路径）；
+- 用 mod 自己写的状态图替换 Spine 状态图；
+- 给 **没有** Spine 骨骼的生物做动画（精灵表、帧序列、Godot `AnimationPlayer`）。
+
+RitsuLib 为这三种需求暴露了三个**彼此正交**的工厂接口，以及一个针对非 Spine
+场景的状态机抽象。四个接口都对生物类型无感（玩家角色与怪物通用），也不要求
+继承任何模板。
+
+| 接口 | 用途 | 对应原版入口 |
+|---|---|---|
+| `IModCreatureVisualsFactory` | 从代码构造 `NCreatureVisuals` | `CharacterModel.CreateVisuals`、`MonsterModel.CreateVisuals` |
+| `IModCreatureAnimatorFactory` | 从代码构造 Spine `CreatureAnimator` | `CharacterModel.GenerateAnimator`、`MonsterModel.GenerateAnimator` |
+| `IModNonSpineAnimationStateMachineFactory` | 为非 Spine 视觉构造 `ModAnimStateMachine` | `NCreature.SetAnimationTrigger`（路由补丁） |
+| `IModCharacterMerchantAnimationStateMachineFactory` | 为商人 / 休息站中的角色视觉构造 `ModAnimStateMachine` | 商人场景初始化流程 |
+
+商人工厂专属玩家角色，因为怪物从不会出现在商人 / 休息站场景中；其余三个接口对
+任意 `MegaCrit.Sts2.Core.Models.AbstractModel` 都适用。
+
+---
+
+## 生物视觉工厂
+
+`IModCreatureVisualsFactory` 在返回非 null 的 `NCreatureVisuals` 时，会替换
+`(Character|Monster)Model.CreateVisuals` 的原有行为；返回 `null` 则退回到
+`CustomVisualsPath` 等原版解析链路。
+
+```csharp
+public class MyCharacter : ModCharacterTemplate<...>
+{
+    // 模板已经实现了 IModCreatureVisualsFactory，并把调用转发到这个
+    // protected virtual；重写它即可：
+    protected override NCreatureVisuals? TryCreateCreatureVisuals()
+    {
+        var scene = GD.Load<PackedScene>(
+            "res://MyMod/scenes/my_character/my_character_visuals.tscn");
+        return scene.Instantiate<NCreatureVisuals>();
+    }
+}
+```
+
+如果不使用 `ModCharacterTemplate` / `ModMonsterTemplate`，直接在自己的
+`CharacterModel` / `MonsterModel` 上实现接口即可：
+
+```csharp
+public class MyRawCharacter : CharacterModel, IModCreatureVisualsFactory
+{
+    public NCreatureVisuals? TryCreateCreatureVisuals() => ...;
+}
+```
+
+路由补丁（`CharacterCreatureVisualsRuntimeFactoryPatch`、
+`MonsterCreatureVisualsRuntimeFactoryPatch`）以 Harmony `Priority.First` 运行，
+在原版基于路径的加载逻辑之前生效。
+
+---
+
+## Spine Animator 工厂
+
+`IModCreatureAnimatorFactory` 用来替换 `GenerateAnimator`，适用于 Spine 视觉。
+推荐使用 `ModAnimStateMachines.Standard` 以复用原版状态图的形状：
+
+```csharp
+public class MySpineCharacter : ModCharacterTemplate<...>
+{
+    protected override CreatureAnimator? SetupCustomCreatureAnimator(MegaSprite controller) =>
+        ModAnimStateMachines.Standard(
+            controller,
+            idleName: "idle_loop",
+            deadName: "die",
+            hitName: "hit",
+            attackName: "attack",
+            castName: "cast",
+            relaxedName: "relaxed");
+}
+```
+
+`ModAnimStateMachines.Standard` 返回一个已经布好 `Idle` / `Dead` / `Hit` /
+`Attack` / `Cast` / `Relaxed` any-state 触发器的 `CreatureAnimator`。终态
+（`Dead`）不设置 `NextState`，所以播放完不会自动回到 idle。
+
+路由补丁（`CharacterCreatureAnimatorRuntimeFactoryPatch`、
+`MonsterCreatureAnimatorRuntimeFactoryPatch`）接受非 null 的工厂返回值；返回
+`null` 则退回到原版 `GenerateAnimator`。
+
+---
+
+## 非 Spine 状态机
+
+如果生物的战斗视觉**不是** Spine（没有 `MegaSprite` 控制器），实现
+`IModNonSpineAnimationStateMachineFactory` 并返回绑定到视觉根节点的
+`ModAnimStateMachine`。`ModCreatureNonSpineAnimationPlaybackPatch` 把
+`NCreature.SetAnimationTrigger(trigger)` 路由到 `ModAnimStateMachine.SetTrigger`，
+因此非 Spine 生物会接收到与 Spine 生物**完全相同**的触发流。
+
+### 接入方式
+
+```csharp
+public class MyWolf : ModMonsterTemplate
+{
+    // 模板已经实现了 IModNonSpineAnimationStateMachineFactory，并把调用转发
+    // 到这个 protected virtual；重写它即可：
+    protected override ModAnimStateMachine? SetupCustomNonSpineAnimationStateMachine(
+        Node visualsRoot, MonsterModel monster)
+    {
+        if (visualsRoot is not MyWolfVisuals wolfVisuals)
+            return null;
+
+        var backend = new AnimatedSprite2DBackend(wolfVisuals.GetAnimatedSprite());
+
+        return ModAnimStateMachineBuilder.Create()
+            .AddState("idle", loop: true).AsInitial().Done()
+            .AddState("attack").WithNext("idle").Done()
+            .AddState("hurt").WithNext("idle").Done()
+            .AddState("die").Done()                     // 终态：不设置 NextState
+            .AddAnyState("Idle",   "idle")
+            .AddAnyState("Attack", "attack")
+            .AddAnyState("Hit",    "hurt")
+            .AddAnyState("Dead",   "die")
+            .Build(backend);
+    }
+}
+```
+
+不使用模板时同理：
+
+```csharp
+public class MyRawMonster : MonsterModel, IModNonSpineAnimationStateMachineFactory
+{
+    public ModAnimStateMachine? TryCreateNonSpineAnimationStateMachine(Node visualsRoot)
+        => /* 同上的 builder 代码 */;
+}
+```
+
+### 路由行为
+
+`ModCreatureNonSpineAnimationPlaybackPatch` 是 `NCreature.SetAnimationTrigger`
+上的 Prefix 补丁，流程如下：
+
+1. 如果生物已有 Spine animator，直接跳过（原版链路继续执行）。
+2. 定位生物对应的模型（`Entity.Player?.Character` 或 `Entity.Monster`）。
+3. 如果任一侧实现了 `IModNonSpineAnimationStateMachineFactory` 且返回非 null 的
+   状态机，调用 `ModAnimStateMachine.SetTrigger` 派发触发器，然后返回。
+4. 否则退回到单次 cue 播放
+   （`ModCreatureVisualPlayback.TryPlayFromCreatureAnimatorTrigger`）。
+
+状态机按视觉根节点缓存在 `ConditionalWeakTable<Node, StateMachineSlot>` 中，
+因此工厂在一次战斗生命周期内最多执行一次，节点释放时会自动回收。
+
+### 快捷方式：`ModAnimStateMachines.StandardCue`
+
+如果视觉遵循 vanilla 的 idle / dead / hit / attack / cast / relaxed 结构，
+直接使用 `ModAnimStateMachines.StandardCue` 即可由库内构建状态图。它会通过
+`CompositeBackendFactory` 为每个状态挑选最合适的后端（优先 cue 帧序列，其次
+Godot `AnimationPlayer` 或 `AnimatedSprite2D`），返回一个可直接使用的
+`ModAnimStateMachine`。
+
+---
+
+## 动画后端
+
+`IAnimationBackend` 是 `ModAnimStateMachine` 消费的统一驱动层。每个后端包装
+Godot 的一个动画子系统，并在对应时机发出 `Started` / `Completed` /
+`Interrupted` 事件。
+
+| 后端 | 驱动对象 | 适用场景 |
+|---|---|---|
+| `AnimatedSprite2DBackend` | `AnimatedSprite2D` | 基于帧的 sprite 动画 |
+| `GodotAnimationPlayerBackend` | `AnimationPlayer` | Godot `.tres` 动画库 |
+| `CueAnimationBackend` | `VisualCueSet`（cue 帧序列 / cue 贴图） | 单帧贴图或帧序列播放 |
+| `SpineAnimationBackend` | `MegaSprite` | Spine 骨骼动画 |
+| `CompositeAnimationBackend` | 任意组合 | 多后端派发（同一状态机内部分状态走 sprite，另一部分走 animation player 等） |
+
+### 事件契约
+
+| 事件 | 触发时机 |
+|---|---|
+| `Started(id)` | `id` 对应的播放已开始 |
+| `Completed(id)` | 单次播放结束，或一个循环周期结束 |
+| `Interrupted(id)` | 播放被新动画抢占，尚未自然结束 |
+
+`ModAnimState.NextState` 在 `Completed` 时推进，因此对非循环状态（`attack ->
+idle` 等），后端**必须**准确发出 `Completed`。
+
+### 队列语义
+
+`Queue(id, loop)` 的语义是「当前动画播完后再播这一个」。各后端实现略有差异：
+
+| 后端 | `Queue` 行为 |
+|---|---|
+| `SpineAnimationBackend` | Spine 原生队列（在 track 上 `AddAnimation`） |
+| `AnimatedSprite2DBackend` | 记录待播 id，在下一次 `animation_finished` 信号时播放 |
+| `GodotAnimationPlayerBackend` | 使用 `AnimationPlayer.Queue` |
+| `CueAnimationBackend` | 记录待播 id，在当前序列结束时播放 |
+
+任何后端上调用 `Play` 都会清空已排队的动画。
+
+### `Stop()` 与跨后端切换
+
+`IAnimationBackend.Stop()`（默认接口方法）会**静默**停止后端——既不发
+`Completed` 也不发 `Interrupted`，并清掉排队动画。它的主要使用方是
+`CompositeAnimationBackend`，在不同子后端之间切换时：
+
+1. 新状态使用的后端与当前活动的后端不同。
+2. 为即将离开的动画发出 `Interrupted`。
+3. 调用离开后端的 `Stop()` 清理其内部状态。
+4. 调用新进入后端的 `Play`。
+
+如果不调用 `Stop()`，离开的后端可能继续发出已失效状态 id 的 `Completed` /
+`Interrupted` 事件，干扰上层状态机。
+
+---
+
+## 生命周期触发补丁
+
+原版 `NCreature.StartDeathAnim` 和 `NCreature.StartReviveAnim` 只在
+`_spineAnimator != null` 时派发 `Dead` / `Revive` 触发器。非 Spine 生物因此
+收不到这两个触发器，自定义状态机在「弃置当前游戏」或玩家死亡时永远看不到
+死亡动画。
+
+RitsuLib 通过两个 Postfix 补丁修正这一缺陷：
+
+- `NCreatureNonSpineDeathAnimationTriggerPatch` — 在 `StartDeathAnim` 之后派发
+  `Dead`。
+- `NCreatureNonSpineReviveAnimationTriggerPatch` — 在 `StartReviveAnim` 之后
+  派发 `Revive`。
+
+### 作用域收敛
+
+这两个补丁是**opt-in**：只有当生物没有 Spine animator 且模型**显式**接入了
+RitsuLib 视觉链路时才会触发。具体而言，`NonSpineAnimationTriggerScope.AppliesTo(NCreature)`
+在以下任一条件成立时返回 `true`：
+
+| 模型槽位 | 接口 | 备注 |
+|---|---|---|
+| `Entity.Player?.Character` | `IModNonSpineAnimationStateMachineFactory` | 状态机路径 |
+| `Entity.Monster` | `IModNonSpineAnimationStateMachineFactory` | 状态机路径 |
+| `Entity.Player?.Character` | `IModCharacterAssetOverrides` | cue 播放回退（仅玩家） |
+
+原版生物、以及未接入 RitsuLib 视觉的其他 mod 都不会被影响。`Dead` 与 `Revive`
+两个补丁使用完全相同的 gate。
+
+---
+
+## 迁移与废弃
+
+两个工厂接口最初按生物种类分别命名，现在已统一，旧名称被标记为 `[Obsolete]`：
+
+| 新名称（推荐） | 已废弃的别名 |
+|---|---|
+| `IModCreatureVisualsFactory` | `IModMonsterCreatureVisualsFactory`、`IModCharacterCreatureVisualsFactory` |
+| `IModCreatureAnimatorFactory` | `IModCharacterCreatureAnimatorFactory` |
+
+### 兼容性保证
+
+- 路由补丁在每次调用时**同时**检查新接口和废弃接口，所以只实现旧接口的 mod
+  无需任何代码改动即可继续工作。
+- `ModCharacterTemplate` / `ModMonsterTemplate` **同时**实现新接口和废弃别名，
+  并把调用转发到同一批 protected virtual 钩子；外部对模板子类做
+  `is IModCharacterCreatureVisualsFactory` 之类的类型检查仍然成立。
+- 实现废弃接口会触发编译警告 **CS0618** 引导迁移。运行时行为不变、没有运行时
+  警告。
+
+### 迁移步骤
+
+1. 在 `: Interfaces` 列表和显式接口实现中把旧名替换为新名：
+   - `IModMonsterCreatureVisualsFactory` → `IModCreatureVisualsFactory`
+   - `IModCharacterCreatureVisualsFactory` → `IModCreatureVisualsFactory`
+   - `IModCharacterCreatureAnimatorFactory` → `IModCreatureAnimatorFactory`
+2. 方法签名（`TryCreateCreatureVisuals()`、
+   `TryCreateCreatureAnimator(MegaSprite)`）保持不变，变化只在声明接口的名字上。
+3. 重新编译，CS0618 警告消失。
+
+如果只是继承模板并重写 protected virtual 钩子
+（`TryCreateCreatureVisuals`、`SetupCustomCreatureAnimator`），无需任何迁移；
+这些钩子未变。
+
+---
+
+## 速查表
+
+```text
+目标                                        实现的接口
+---------------------------------------------------------------------------
+替换 CreateVisuals（玩家或怪物）             IModCreatureVisualsFactory
+替换 Spine GenerateAnimator                  IModCreatureAnimatorFactory
+驱动非 Spine 状态机                          IModNonSpineAnimationStateMachineFactory
+驱动商人 / 休息站状态机                       IModCharacterMerchantAnimationStateMachineFactory
+```
+
+无论你是继承 `ModCharacterTemplate` / `ModMonsterTemplate`，还是直接在
+`CharacterModel` / `MonsterModel` 上实现这些接口，路由补丁都会生效：它们以
+Harmony `Priority.First` 运行，且在工厂返回 `null` 时退回到原版行为。

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -230,6 +230,7 @@ namespace STS2RitsuLib
             var patcher = CreatePatcher(Const.ModId, "framework-character-assets", "character assets");
             patcher.RegisterPatch<CharacterIconOutlineTexturePathPatch>();
             patcher.RegisterPatch<ModModelRuntimeGodotFactoryPatches.CharacterCreatureVisualsRuntimeFactoryPatch>();
+            patcher.RegisterPatch<ModModelRuntimeGodotFactoryPatches.CharacterCreatureAnimatorRuntimeFactoryPatch>();
             patcher.RegisterPatch<CharacterVisualsPathPatch>();
             patcher.RegisterPatch<CharacterEnergyCounterRuntimeFactoryPatch>();
             patcher.RegisterPatch<CharacterEnergyCounterPathPatch>();

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -182,6 +182,7 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<ActAssetPathsBackgroundLayersPatch>();
 
             patcher.RegisterPatch<ModModelRuntimeGodotFactoryPatches.MonsterCreatureVisualsRuntimeFactoryPatch>();
+            patcher.RegisterPatch<ModModelRuntimeGodotFactoryPatches.MonsterCreatureAnimatorRuntimeFactoryPatch>();
             patcher.RegisterPatch<ModModelRuntimeGodotFactoryPatches.EncounterCombatSceneRuntimeFactoryPatch>();
             patcher.RegisterPatch<ModModelRuntimeGodotFactoryPatches.EventLayoutPackedSceneRuntimeFactoryPatch>();
             patcher.RegisterPatch<ModModelRuntimeGodotFactoryPatches.EventBackgroundPackedSceneRuntimeFactoryPatch>();
@@ -253,6 +254,8 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<CharacterGameOverScreenCompatibilityPatch>();
             patcher.RegisterPatch<CharacterVanillaSelectionPolicyPatches>();
             patcher.RegisterPatch<ModCreatureNonSpineAnimationPlaybackPatch>();
+            patcher.RegisterPatch<NCreatureNonSpineDeathAnimationTriggerPatch>();
+            patcher.RegisterPatch<NCreatureNonSpineReviveAnimationTriggerPatch>();
             patcher.RegisterPatch<ModMerchantCharacterVisualPlaybackPatch>();
             patcher.RegisterPatch<NMerchantRoomProceduralCharacterInstantiationPatch>();
             patcher.RegisterPatch<NRestSiteCharacterCreateProceduralPatch>();

--- a/RuntimeInput/RuntimeHotkeyParser.cs
+++ b/RuntimeInput/RuntimeHotkeyParser.cs
@@ -318,13 +318,13 @@ namespace STS2RitsuLib.RuntimeInput
         private static bool IsLeftSpecific(Key key)
         {
             var name = key.ToString().ToLowerInvariant();
-            return name.Contains("left") || name.StartsWith("l");
+            return name.Contains("left") || name.StartsWith('l');
         }
 
         private static bool IsRightSpecific(Key key)
         {
             var name = key.ToString().ToLowerInvariant();
-            return name.Contains("right") || name.StartsWith("r");
+            return name.Contains("right") || name.StartsWith('r');
         }
     }
 }

--- a/Scaffolding/Characters/ModCharacterTemplate.cs
+++ b/Scaffolding/Characters/ModCharacterTemplate.cs
@@ -1,9 +1,13 @@
+using Godot;
+using MegaCrit.Sts2.Core.Animation;
+using MegaCrit.Sts2.Core.Bindings.MegaSpine;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using STS2RitsuLib.Content;
 using STS2RitsuLib.Scaffolding.Characters.Visuals.Definition;
 using STS2RitsuLib.Scaffolding.Content;
 using STS2RitsuLib.Scaffolding.Visuals.Definition;
+using STS2RitsuLib.Scaffolding.Visuals.StateMachine;
 
 namespace STS2RitsuLib.Scaffolding.Characters
 {
@@ -225,8 +229,9 @@ namespace STS2RitsuLib.Scaffolding.Characters
     /// <typeparam name="TRelicPool">Concrete <see cref="RelicPoolModel" /> type registered for this character.</typeparam>
     /// <typeparam name="TPotionPool">Concrete <see cref="PotionPoolModel" /> type registered for this character.</typeparam>
     public abstract class ModCharacterTemplate<TCardPool, TRelicPool, TPotionPool> : CharacterModel
-        , IModCharacterAssetOverrides, IModCharacterCreatureVisualsFactory, IModCharacterEpochTimelineRequirement,
-        IModCharacterVanillaSelectionPolicy
+        , IModCharacterAssetOverrides, IModCharacterCreatureVisualsFactory, IModCharacterCreatureAnimatorFactory,
+        IModCharacterNonSpineAnimationStateMachineFactory, IModCharacterMerchantAnimationStateMachineFactory,
+        IModCharacterEpochTimelineRequirement, IModCharacterVanillaSelectionPolicy
         where TCardPool : CardPoolModel
         where TRelicPool : RelicPoolModel
         where TPotionPool : PotionPoolModel
@@ -501,6 +506,11 @@ namespace STS2RitsuLib.Scaffolding.Characters
         public virtual CharacterWorldProceduralVisualSet? WorldProceduralVisuals =>
             ResolvedAssetProfile.WorldProceduralVisuals;
 
+        CreatureAnimator? IModCharacterCreatureAnimatorFactory.TryCreateCreatureAnimator(MegaSprite controller)
+        {
+            return SetupCustomCreatureAnimator(controller);
+        }
+
         NCreatureVisuals? IModCharacterCreatureVisualsFactory.TryCreateCreatureVisuals()
         {
             return TryCreateCreatureVisuals();
@@ -508,6 +518,18 @@ namespace STS2RitsuLib.Scaffolding.Characters
 
         /// <inheritdoc />
         public virtual bool RequiresEpochAndTimeline => true;
+
+        ModAnimStateMachine? IModCharacterMerchantAnimationStateMachineFactory.
+            TryCreateMerchantAnimationStateMachine(Node merchantRoot, CharacterModel character)
+        {
+            return SetupCustomMerchantAnimationStateMachine(merchantRoot, character);
+        }
+
+        ModAnimStateMachine? IModCharacterNonSpineAnimationStateMachineFactory.
+            TryCreateNonSpineAnimationStateMachine(Node visualsRoot, CharacterModel character)
+        {
+            return SetupCustomNonSpineAnimationStateMachine(visualsRoot, character);
+        }
 
         /// <inheritdoc />
         public virtual bool HideFromVanillaCharacterSelect => false;
@@ -520,6 +542,43 @@ namespace STS2RitsuLib.Scaffolding.Characters
         ///     paths apply.
         /// </summary>
         protected virtual NCreatureVisuals? TryCreateCreatureVisuals()
+        {
+            return null;
+        }
+
+        /// <summary>
+        ///     Optional override producing a fully wired Spine <see cref="CreatureAnimator" /> (state graph for idle /
+        ///     hit / attack / cast / die / relaxed). Return <see langword="null" /> to defer to vanilla
+        ///     <see cref="CharacterModel.GenerateAnimator" />. Prefer <see cref="ModAnimStateMachines.Standard" /> to
+        ///     match baselib semantics.
+        /// </summary>
+        /// <param name="controller">Spine controller attached to the character's combat visuals.</param>
+        protected virtual CreatureAnimator? SetupCustomCreatureAnimator(MegaSprite controller)
+        {
+            return null;
+        }
+
+        /// <summary>
+        ///     Optional override producing a non-Spine <see cref="ModAnimStateMachine" /> for the character's combat
+        ///     visuals (cue frame sequences, Godot animation player, animated sprite). Return <see langword="null" />
+        ///     to defer to single-shot playback via <c>ModCreatureVisualPlayback</c>.
+        /// </summary>
+        /// <param name="visualsRoot">Combat visuals root node.</param>
+        /// <param name="character">Character model (always <see langword="this" />, exposed for convenience).</param>
+        protected virtual ModAnimStateMachine? SetupCustomNonSpineAnimationStateMachine(Node visualsRoot,
+            CharacterModel character)
+        {
+            return null;
+        }
+
+        /// <summary>
+        ///     Optional override producing a merchant / rest-site <see cref="ModAnimStateMachine" /> for the character.
+        ///     Return <see langword="null" /> to defer to single-shot playback via <c>ModCreatureVisualPlayback</c>.
+        /// </summary>
+        /// <param name="merchantRoot">Merchant character root node.</param>
+        /// <param name="character">Character model (always <see langword="this" />, exposed for convenience).</param>
+        protected virtual ModAnimStateMachine? SetupCustomMerchantAnimationStateMachine(Node merchantRoot,
+            CharacterModel character)
         {
             return null;
         }

--- a/Scaffolding/Characters/ModCharacterTemplate.cs
+++ b/Scaffolding/Characters/ModCharacterTemplate.cs
@@ -228,10 +228,15 @@ namespace STS2RitsuLib.Scaffolding.Characters
     /// <typeparam name="TCardPool">Concrete <see cref="CardPoolModel" /> type registered for this character.</typeparam>
     /// <typeparam name="TRelicPool">Concrete <see cref="RelicPoolModel" /> type registered for this character.</typeparam>
     /// <typeparam name="TPotionPool">Concrete <see cref="PotionPoolModel" /> type registered for this character.</typeparam>
+#pragma warning disable CS0618
+    // Template keeps the obsolete IModCharacter* visuals / animator factory interfaces wired so existing derived
+    // classes and external consumers that type-check against the old interface names continue to work.
     public abstract class ModCharacterTemplate<TCardPool, TRelicPool, TPotionPool> : CharacterModel
-        , IModCharacterAssetOverrides, IModCharacterCreatureVisualsFactory, IModCharacterCreatureAnimatorFactory,
-        IModCharacterNonSpineAnimationStateMachineFactory, IModCharacterMerchantAnimationStateMachineFactory,
+        , IModCharacterAssetOverrides, IModCreatureVisualsFactory, IModCharacterCreatureVisualsFactory,
+        IModCreatureAnimatorFactory, IModCharacterCreatureAnimatorFactory,
+        IModNonSpineAnimationStateMachineFactory, IModCharacterMerchantAnimationStateMachineFactory,
         IModCharacterEpochTimelineRequirement, IModCharacterVanillaSelectionPolicy
+#pragma warning restore CS0618
         where TCardPool : CardPoolModel
         where TRelicPool : RelicPoolModel
         where TPotionPool : PotionPoolModel
@@ -506,15 +511,19 @@ namespace STS2RitsuLib.Scaffolding.Characters
         public virtual CharacterWorldProceduralVisualSet? WorldProceduralVisuals =>
             ResolvedAssetProfile.WorldProceduralVisuals;
 
+#pragma warning disable CS0618
         CreatureAnimator? IModCharacterCreatureAnimatorFactory.TryCreateCreatureAnimator(MegaSprite controller)
         {
             return SetupCustomCreatureAnimator(controller);
         }
+#pragma warning restore CS0618
 
+#pragma warning disable CS0618
         NCreatureVisuals? IModCharacterCreatureVisualsFactory.TryCreateCreatureVisuals()
         {
             return TryCreateCreatureVisuals();
         }
+#pragma warning restore CS0618
 
         /// <inheritdoc />
         public virtual bool RequiresEpochAndTimeline => true;
@@ -525,17 +534,27 @@ namespace STS2RitsuLib.Scaffolding.Characters
             return SetupCustomMerchantAnimationStateMachine(merchantRoot, character);
         }
 
-        ModAnimStateMachine? IModCharacterNonSpineAnimationStateMachineFactory.
-            TryCreateNonSpineAnimationStateMachine(Node visualsRoot, CharacterModel character)
-        {
-            return SetupCustomNonSpineAnimationStateMachine(visualsRoot, character);
-        }
-
         /// <inheritdoc />
         public virtual bool HideFromVanillaCharacterSelect => false;
 
         /// <inheritdoc />
         public virtual bool AllowInVanillaRandomCharacterSelect => !HideFromVanillaCharacterSelect;
+
+        CreatureAnimator? IModCreatureAnimatorFactory.TryCreateCreatureAnimator(MegaSprite controller)
+        {
+            return SetupCustomCreatureAnimator(controller);
+        }
+
+        NCreatureVisuals? IModCreatureVisualsFactory.TryCreateCreatureVisuals()
+        {
+            return TryCreateCreatureVisuals();
+        }
+
+        ModAnimStateMachine? IModNonSpineAnimationStateMachineFactory.
+            TryCreateNonSpineAnimationStateMachine(Node visualsRoot)
+        {
+            return SetupCustomNonSpineAnimationStateMachine(visualsRoot, this);
+        }
 
         /// <summary>
         ///     Non-null combat visuals; otherwise <see cref="IModCharacterAssetOverrides.CustomVisualsPath" /> / vanilla

--- a/Scaffolding/Characters/Patches/ModCreatureNonSpineAnimationPlaybackPatch.cs
+++ b/Scaffolding/Characters/Patches/ModCreatureNonSpineAnimationPlaybackPatch.cs
@@ -1,6 +1,11 @@
+using System.Runtime.CompilerServices;
+using Godot;
+using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using STS2RitsuLib.Patching.Models;
 using STS2RitsuLib.Scaffolding.Characters.Visuals;
+using STS2RitsuLib.Scaffolding.Content;
+using STS2RitsuLib.Scaffolding.Visuals.StateMachine;
 
 namespace STS2RitsuLib.Scaffolding.Characters.Patches
 {
@@ -9,8 +14,18 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
     ///     <see cref="ModCreatureVisualPlayback" /> (cue textures, Godot animators). Co-loading another library that
     ///     patches the same method may run both prefixes; prefer a single stack for creature visuals when possible.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         When the character implements
+    ///         <see cref="IModCharacterNonSpineAnimationStateMachineFactory" />, the trigger is routed through the
+    ///         state machine's <see cref="ModAnimStateMachine.SetTrigger" /> so branches, any-state transitions and
+    ///         <see cref="ModAnimState.NextState" /> apply. Otherwise the original single-shot playback path is used.
+    ///     </para>
+    /// </remarks>
     public class ModCreatureNonSpineAnimationPlaybackPatch : IPatchMethod
     {
+        private static readonly ConditionalWeakTable<Node, StateMachineSlot> StateMachinesByVisuals = new();
+
         /// <inheritdoc cref="IPatchMethod.PatchId" />
         public static string PatchId => "mod_creature_non_spine_animation_playback";
 
@@ -36,7 +51,47 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
             if (__instance.HasSpineAnimation)
                 return true;
 
+            if (TryRouteToStateMachine(__instance, trigger))
+                return false;
+
             return !ModCreatureVisualPlayback.TryPlayFromCreatureAnimatorTrigger(__instance, trigger);
+        }
+
+        private static bool TryRouteToStateMachine(NCreature creature, string trigger)
+        {
+            var character = creature.Entity?.Player?.Character;
+            if (character is not IModCharacterNonSpineAnimationStateMachineFactory factory)
+                return false;
+
+            var visuals = creature.Visuals;
+            if (visuals == null || !GodotObject.IsInstanceValid(visuals))
+                return false;
+
+            var slot = StateMachinesByVisuals.GetValue(visuals,
+                _ => new());
+
+            slot.EnsureBuilt(factory, visuals, character);
+            if (slot.StateMachine == null)
+                return false;
+
+            slot.StateMachine.SetTrigger(trigger);
+            return true;
+        }
+
+        private sealed class StateMachineSlot
+        {
+            private bool _built;
+            public ModAnimStateMachine? StateMachine { get; private set; }
+
+            public void EnsureBuilt(IModCharacterNonSpineAnimationStateMachineFactory factory, Node visuals,
+                CharacterModel character)
+            {
+                if (_built)
+                    return;
+
+                _built = true;
+                StateMachine = factory.TryCreateNonSpineAnimationStateMachine(visuals, character);
+            }
         }
     }
 }

--- a/Scaffolding/Characters/Patches/ModCreatureNonSpineAnimationPlaybackPatch.cs
+++ b/Scaffolding/Characters/Patches/ModCreatureNonSpineAnimationPlaybackPatch.cs
@@ -16,10 +16,16 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         When the character implements
-    ///         <see cref="IModCharacterNonSpineAnimationStateMachineFactory" />, the trigger is routed through the
-    ///         state machine's <see cref="ModAnimStateMachine.SetTrigger" /> so branches, any-state transitions and
-    ///         <see cref="ModAnimState.NextState" /> apply. Otherwise the original single-shot playback path is used.
+    ///         Routing for non-Spine creatures: if the creature's model (either
+    ///         <c>Entity.Player?.Character</c> or <c>Entity.Monster</c>) implements
+    ///         <see cref="IModNonSpineAnimationStateMachineFactory" />, the trigger is dispatched through the
+    ///         state machine's <see cref="ModAnimStateMachine.SetTrigger" /> so branches, any-state transitions
+    ///         and <see cref="ModAnimState.NextState" /> apply. Otherwise the single-shot cue playback path
+    ///         (<see cref="ModCreatureVisualPlayback.TryPlayFromCreatureAnimatorTrigger" />) runs.
+    ///     </para>
+    ///     <para>
+    ///         State machines are cached per visuals root via a
+    ///         <see cref="ConditionalWeakTable{TKey,TValue}" /> so factories run at most once per combat lifetime.
     ///     </para>
     /// </remarks>
     public class ModCreatureNonSpineAnimationPlaybackPatch : IPatchMethod
@@ -59,18 +65,17 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
 
         private static bool TryRouteToStateMachine(NCreature creature, string trigger)
         {
-            var character = creature.Entity?.Player?.Character;
-            if (character is not IModCharacterNonSpineAnimationStateMachineFactory factory)
-                return false;
-
             var visuals = creature.Visuals;
             if (visuals == null || !GodotObject.IsInstanceValid(visuals))
                 return false;
 
-            var slot = StateMachinesByVisuals.GetValue(visuals,
-                _ => new());
+            var entity = creature.Entity;
+            if (entity == null)
+                return false;
 
-            slot.EnsureBuilt(factory, visuals, character);
+            var slot = StateMachinesByVisuals.GetValue(visuals, _ => new());
+            slot.EnsureBuilt(entity.Player?.Character, entity.Monster, visuals);
+
             if (slot.StateMachine == null)
                 return false;
 
@@ -83,14 +88,34 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
             private bool _built;
             public ModAnimStateMachine? StateMachine { get; private set; }
 
-            public void EnsureBuilt(IModCharacterNonSpineAnimationStateMachineFactory factory, Node visuals,
-                CharacterModel character)
+            /// <summary>
+            ///     Resolves the first <see cref="IModNonSpineAnimationStateMachineFactory" /> opt-in across
+            ///     <paramref name="character" /> and <paramref name="monster" /> and caches the resulting state
+            ///     machine.
+            /// </summary>
+            public void EnsureBuilt(CharacterModel? character, MonsterModel? monster, Node visuals)
             {
                 if (_built)
                     return;
 
                 _built = true;
-                StateMachine = factory.TryCreateNonSpineAnimationStateMachine(visuals, character);
+                StateMachine = BuildFrom(character, monster, visuals);
+            }
+
+            private static ModAnimStateMachine? BuildFrom(CharacterModel? character, MonsterModel? monster,
+                Node visuals)
+            {
+                if (character is IModNonSpineAnimationStateMachineFactory characterFactory)
+                {
+                    var built = characterFactory.TryCreateNonSpineAnimationStateMachine(visuals);
+                    if (built != null)
+                        return built;
+                }
+
+                if (monster is IModNonSpineAnimationStateMachineFactory monsterFactory)
+                    return monsterFactory.TryCreateNonSpineAnimationStateMachine(visuals);
+
+                return null;
             }
         }
     }

--- a/Scaffolding/Characters/Patches/ModMerchantCharacterVisualPlaybackPatch.cs
+++ b/Scaffolding/Characters/Patches/ModMerchantCharacterVisualPlaybackPatch.cs
@@ -1,10 +1,14 @@
+using System.Runtime.CompilerServices;
+using Godot;
 using MegaCrit.Sts2.Core.Bindings.MegaSpine;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Rooms;
 using MegaCrit.Sts2.Core.Nodes.Screens.Shops;
 using STS2RitsuLib.Patching.Models;
 using STS2RitsuLib.Scaffolding.Characters.Visuals;
+using STS2RitsuLib.Scaffolding.Content;
 using STS2RitsuLib.Scaffolding.Visuals.Definition;
+using STS2RitsuLib.Scaffolding.Visuals.StateMachine;
 
 namespace STS2RitsuLib.Scaffolding.Characters.Patches
 {
@@ -14,6 +18,8 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
     /// </summary>
     public class ModMerchantCharacterVisualPlaybackPatch : IPatchMethod
     {
+        private static readonly ConditionalWeakTable<Node, StateMachineSlot> StateMachinesByRoot = new();
+
         /// <inheritdoc cref="IPatchMethod.PatchId" />
         public static string PatchId => "mod_merchant_character_visual_playback";
 
@@ -46,8 +52,26 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
             ModCreatureVisualPlayback.TryResolveMerchantCharacterModel(NMerchantRoom.Instance, __instance,
                 out var character);
 
+            if (TryRouteToStateMachine(__instance, character, anim))
+                return false;
+
             var worldCues = TryGetMerchantWorldCueSet(character);
             return !ModCreatureVisualPlayback.TryPlayOnVisualRoot(__instance, character, anim, loop, worldCues);
+        }
+
+        private static bool TryRouteToStateMachine(NMerchantCharacter merchant, CharacterModel? character, string anim)
+        {
+            if (character is not IModCharacterMerchantAnimationStateMachineFactory factory)
+                return false;
+
+            var slot = StateMachinesByRoot.GetValue(merchant, _ => new());
+            slot.EnsureBuilt(factory, merchant, character);
+
+            if (slot.StateMachine == null)
+                return false;
+
+            slot.StateMachine.SetTrigger(anim);
+            return true;
         }
 
         private static VisualCueSet? TryGetMerchantWorldCueSet(CharacterModel? character)
@@ -58,6 +82,22 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
             }
                 ? null
                 : cueSet;
+        }
+
+        private sealed class StateMachineSlot
+        {
+            private bool _built;
+            public ModAnimStateMachine? StateMachine { get; private set; }
+
+            public void EnsureBuilt(IModCharacterMerchantAnimationStateMachineFactory factory, Node root,
+                CharacterModel character)
+            {
+                if (_built)
+                    return;
+
+                _built = true;
+                StateMachine = factory.TryCreateMerchantAnimationStateMachine(root, character);
+            }
         }
     }
 }

--- a/Scaffolding/Characters/Patches/NCreatureNonSpineDeathAnimationTriggerPatches.cs
+++ b/Scaffolding/Characters/Patches/NCreatureNonSpineDeathAnimationTriggerPatches.cs
@@ -161,10 +161,7 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
             if (monster is IModNonSpineAnimationStateMachineFactory)
                 return true;
 
-            if (character is IModCharacterAssetOverrides)
-                return true;
-
-            return false;
+            return character is IModCharacterAssetOverrides;
         }
     }
 }

--- a/Scaffolding/Characters/Patches/NCreatureNonSpineDeathAnimationTriggerPatches.cs
+++ b/Scaffolding/Characters/Patches/NCreatureNonSpineDeathAnimationTriggerPatches.cs
@@ -1,0 +1,170 @@
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+using STS2RitsuLib.Patching.Models;
+using STS2RitsuLib.Scaffolding.Content;
+
+namespace STS2RitsuLib.Scaffolding.Characters.Patches
+{
+    /// <summary>
+    ///     Fires the <c>Dead</c> animation trigger for RitsuLib-managed non-Spine creatures (player characters and
+    ///     monsters) after <see cref="NCreature.StartDeathAnim" /> runs. Vanilla gates the entire trigger dispatch
+    ///     (including death SFX) behind <c>_spineAnimator != null</c>, so mod creatures using
+    ///     <c>AnimatedSprite2D</c>, Godot <c>AnimationPlayer</c>, or cue-frame-sequence backends never receive the
+    ///     trigger — the most visible symptom for players is that the death animation does not play when the run
+    ///     is abandoned or the player dies in combat.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Scope:</b> the postfix only fires when all of the following hold, so foreign creatures that do
+    ///         not opt into the RitsuLib visuals pipeline are untouched:
+    ///         <list type="bullet">
+    ///             <item>
+    ///                 <description>the creature has no Spine animator;</description>
+    ///             </item>
+    ///             <item>
+    ///                 <description>
+    ///                     the creature's model (either <c>Entity.Player?.Character</c> or <c>Entity.Monster</c>)
+    ///                     opts into RitsuLib visuals by implementing
+    ///                     <see cref="IModNonSpineAnimationStateMachineFactory" />, or — for players only —
+    ///                     <see cref="IModCharacterAssetOverrides" /> (which pulls the cue-playback path).
+    ///                 </description>
+    ///             </item>
+    ///         </list>
+    ///     </para>
+    ///     <para>
+    ///         When all guards pass, the patch calls <see cref="NCreature.SetAnimationTrigger" />, which
+    ///         <see cref="ModCreatureNonSpineAnimationPlaybackPatch" /> routes through the model's
+    ///         <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.ModAnimStateMachine" /> (when registered)
+    ///         or the legacy cue playback
+    ///         (<see cref="STS2RitsuLib.Scaffolding.Characters.Visuals.ModCreatureVisualPlayback" />).
+    ///     </para>
+    ///     <para>
+    ///         This patch does not attempt to backfill the death-animation length returned from
+    ///         <see cref="NCreature.StartDeathAnim" /> — vanilla already returns <c>0f</c> for non-Spine creatures
+    ///         unless a monster sets <see cref="MonsterModel.DeathAnimLengthOverride" />.
+    ///     </para>
+    /// </remarks>
+    public class NCreatureNonSpineDeathAnimationTriggerPatch : IPatchMethod
+    {
+        /// <inheritdoc cref="IPatchMethod.PatchId" />
+        public static string PatchId => "ncreature_non_spine_death_animation_trigger";
+
+        /// <inheritdoc cref="IPatchMethod.Description" />
+        public static string Description =>
+            "Dispatch the Dead animation trigger for RitsuLib-managed non-Spine creatures so StartDeathAnim animates correctly";
+
+        /// <inheritdoc cref="IPatchMethod.IsCritical" />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc cref="IPatchMethod.GetTargets" />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NCreature), nameof(NCreature.StartDeathAnim))];
+        }
+
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        ///     Dispatches <c>Dead</c> through <see cref="NCreature.SetAnimationTrigger" /> for RitsuLib-managed
+        ///     non-Spine creatures only; returns silently otherwise.
+        /// </summary>
+        public static void Postfix(NCreature __instance)
+        {
+            if (!NonSpineAnimationTriggerScope.AppliesTo(__instance))
+                return;
+
+            __instance.SetAnimationTrigger("Dead");
+        }
+    }
+
+    /// <summary>
+    ///     Fires the <c>Revive</c> animation trigger for RitsuLib-managed non-Spine creatures after
+    ///     <see cref="NCreature.StartReviveAnim" /> runs. Vanilla only dispatches the trigger when a Spine
+    ///     animator exists and otherwise falls back to <c>AnimTempRevive</c> (a fade-out / fade-in tween on the
+    ///     visuals root), which silently swallows any <c>Revive</c> state the mod creature registered.
+    /// </summary>
+    /// <remarks>
+    ///     Scope mirrors <see cref="NCreatureNonSpineDeathAnimationTriggerPatch" /> — only RitsuLib-managed
+    ///     non-Spine creatures are affected. The vanilla fade tween still runs alongside the triggered
+    ///     animation; mods that want a clean revive animation should treat the brief fade as expected behaviour.
+    /// </remarks>
+    public class NCreatureNonSpineReviveAnimationTriggerPatch : IPatchMethod
+    {
+        /// <inheritdoc cref="IPatchMethod.PatchId" />
+        public static string PatchId => "ncreature_non_spine_revive_animation_trigger";
+
+        /// <inheritdoc cref="IPatchMethod.Description" />
+        public static string Description =>
+            "Dispatch the Revive animation trigger for RitsuLib-managed non-Spine creatures so StartReviveAnim animates correctly";
+
+        /// <inheritdoc cref="IPatchMethod.IsCritical" />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc cref="IPatchMethod.GetTargets" />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NCreature), nameof(NCreature.StartReviveAnim))];
+        }
+
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        ///     Dispatches <c>Revive</c> through <see cref="NCreature.SetAnimationTrigger" /> for RitsuLib-managed
+        ///     non-Spine creatures only; returns silently otherwise.
+        /// </summary>
+        public static void Postfix(NCreature __instance)
+        {
+            if (!NonSpineAnimationTriggerScope.AppliesTo(__instance))
+                return;
+
+            __instance.SetAnimationTrigger("Revive");
+        }
+    }
+
+    /// <summary>
+    ///     Shared gate used by the non-Spine lifecycle triggers so scope remains consistent across
+    ///     <see cref="NCreature.StartDeathAnim" /> / <see cref="NCreature.StartReviveAnim" /> postfixes.
+    /// </summary>
+    internal static class NonSpineAnimationTriggerScope
+    {
+        /// <summary>
+        ///     Returns <see langword="true" /> only for non-Spine creatures whose owning model opted into
+        ///     RitsuLib visuals:
+        ///     <list type="bullet">
+        ///         <item>
+        ///             <description>
+        ///                 Any <see cref="AbstractModel" /> implementing
+        ///                 <see cref="IModNonSpineAnimationStateMachineFactory" /> (players or monsters).
+        ///             </description>
+        ///         </item>
+        ///         <item>
+        ///             <description>
+        ///                 A <see cref="CharacterModel" /> implementing <see cref="IModCharacterAssetOverrides" />
+        ///                 (cue-playback fallback, player-only).
+        ///             </description>
+        ///         </item>
+        ///     </list>
+        /// </summary>
+        public static bool AppliesTo(NCreature creature)
+        {
+            if (creature.HasSpineAnimation)
+                return false;
+
+            var entity = creature.Entity;
+            if (entity == null)
+                return false;
+
+            var character = entity.Player?.Character;
+            var monster = entity.Monster;
+
+            if (character is IModNonSpineAnimationStateMachineFactory)
+                return true;
+
+            if (monster is IModNonSpineAnimationStateMachineFactory)
+                return true;
+
+            if (character is IModCharacterAssetOverrides)
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/Scaffolding/Characters/Visuals/ModCreatureVisualPlayback.cs
+++ b/Scaffolding/Characters/Visuals/ModCreatureVisualPlayback.cs
@@ -40,6 +40,8 @@ namespace STS2RitsuLib.Scaffolding.Characters.Visuals
 
         private static readonly string[] ReviveCueNames = ["revive", "Revive"];
 
+        private static readonly string[] StunCueNames = ["stun", "Stun"];
+
         /// <summary>
         ///     Attempts to play a logical cue (idle, die, hurt, …) on combat-style <see cref="NCreatureVisuals" />.
         /// </summary>
@@ -141,6 +143,7 @@ namespace STS2RitsuLib.Scaffolding.Characters.Visuals
                 CreatureAnimator.hitTrigger => "hurt",
                 CreatureAnimator.deathTrigger => "die",
                 CreatureAnimator.reviveTrigger => "revive",
+                "Stun" or "stun" => "stun",
                 _ => trigger.ToLowerInvariant(),
             };
         }
@@ -155,6 +158,7 @@ namespace STS2RitsuLib.Scaffolding.Characters.Visuals
                 "attack" => AttackCueNames,
                 "cast" => CastCueNames,
                 "revive" => ReviveCueNames,
+                "stun" => StunCueNames,
                 _ => TwoNameFallback(primaryCue),
             };
         }

--- a/Scaffolding/Content/ModModelRuntimeGodotFactoryInterfaces.cs
+++ b/Scaffolding/Content/ModModelRuntimeGodotFactoryInterfaces.cs
@@ -1,5 +1,9 @@
 using Godot;
+using MegaCrit.Sts2.Core.Animation;
+using MegaCrit.Sts2.Core.Bindings.MegaSpine;
+using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Combat;
+using STS2RitsuLib.Scaffolding.Visuals.StateMachine;
 
 namespace STS2RitsuLib.Scaffolding.Content
 {
@@ -95,5 +99,51 @@ namespace STS2RitsuLib.Scaffolding.Content
         ///     Orb sprite node from code, or <c>null</c> to instantiate from the visuals scene path.
         /// </summary>
         Node2D? TryCreateOrbSprite();
+    }
+
+    /// <summary>
+    ///     Runtime Spine <see cref="CreatureAnimator" /> factory for mod characters. Overrides the default vanilla
+    ///     <c>GenerateAnimator</c> so mods can wire custom <see cref="AnimState" /> graphs (idle / hit / attack / cast /
+    ///     die / relaxed) without subclassing <c>NCreature</c>. Prefer
+    ///     <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.ModAnimStateMachines.Standard" /> for the standard
+    ///     shape; return <see langword="null" /> to fall through to vanilla behaviour.
+    /// </summary>
+    public interface IModCharacterCreatureAnimatorFactory
+    {
+        /// <summary>
+        ///     Returns a fully wired <see cref="CreatureAnimator" />, or <see langword="null" /> to defer to vanilla.
+        /// </summary>
+        /// <param name="controller">Spine controller attached to the character's combat visuals.</param>
+        CreatureAnimator? TryCreateCreatureAnimator(MegaSprite controller);
+    }
+
+    /// <summary>
+    ///     Runtime non-Spine <see cref="ModAnimStateMachine" /> factory for mod characters' combat visuals
+    ///     (cue frame sequences, cue textures, Godot animation player, animated sprite). Implement when the model
+    ///     needs automatic transitions (e.g. <c>attack</c> -&gt; <c>idle</c>) without a Spine skeleton.
+    /// </summary>
+    public interface IModCharacterNonSpineAnimationStateMachineFactory
+    {
+        /// <summary>
+        ///     Builds a state machine bound to <paramref name="visualsRoot" />, or <see langword="null" /> to defer
+        ///     to the single-shot playback path.
+        /// </summary>
+        /// <param name="visualsRoot">Combat visuals root (typically an <see cref="NCreatureVisuals" />).</param>
+        /// <param name="character">Owning character model for cue lookup.</param>
+        ModAnimStateMachine? TryCreateNonSpineAnimationStateMachine(Node visualsRoot, CharacterModel character);
+    }
+
+    /// <summary>
+    ///     Runtime <see cref="ModAnimStateMachine" /> factory for mod characters in merchant / rest-site contexts.
+    ///     Implement when the merchant visuals need state transitions rather than single-shot playback.
+    /// </summary>
+    public interface IModCharacterMerchantAnimationStateMachineFactory
+    {
+        /// <summary>
+        ///     Builds a merchant-context state machine, or <see langword="null" /> to defer to the single-shot path.
+        /// </summary>
+        /// <param name="merchantRoot">Merchant character root.</param>
+        /// <param name="character">Owning character model for cue lookup.</param>
+        ModAnimStateMachine? TryCreateMerchantAnimationStateMachine(Node merchantRoot, CharacterModel character);
     }
 }

--- a/Scaffolding/Content/ModModelRuntimeGodotFactoryInterfaces.cs
+++ b/Scaffolding/Content/ModModelRuntimeGodotFactoryInterfaces.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Godot;
 using MegaCrit.Sts2.Core.Animation;
 using MegaCrit.Sts2.Core.Bindings.MegaSpine;
@@ -8,10 +9,30 @@ using STS2RitsuLib.Scaffolding.Visuals.StateMachine;
 namespace STS2RitsuLib.Scaffolding.Content
 {
     /// <summary>
-    ///     Runtime <see cref="NCreatureVisuals" /> for mod monsters. Subclass <see cref="ModMonsterTemplate" /> or implement
-    ///     on the model type; non-null <see cref="TryCreateCreatureVisuals" /> replaces path-based
-    ///     <c>CreateVisuals</c>.
+    ///     Runtime <see cref="NCreatureVisuals" /> factory for any combat creature model (player characters and
+    ///     monsters). Implement on the model type — typically by subclassing
+    ///     <see cref="STS2RitsuLib.Scaffolding.Characters.ModCharacterTemplate{TCardPool,TRelicPool,TPotionPool}" />
+    ///     or <see cref="ModMonsterTemplate" />, though the templates are convenience and not required. Non-null
+    ///     <see cref="TryCreateCreatureVisuals" /> replaces the path-based <c>CreateVisuals</c> on both
+    ///     <see cref="CharacterModel" /> and <see cref="MonsterModel" />.
     /// </summary>
+    public interface IModCreatureVisualsFactory
+    {
+        /// <summary>
+        ///     Combat visuals from code, or <c>null</c> to fall through to asset paths.
+        /// </summary>
+        NCreatureVisuals? TryCreateCreatureVisuals();
+    }
+
+    /// <summary>
+    ///     Obsolete monster-specific alias of <see cref="IModCreatureVisualsFactory" /> kept for backward
+    ///     compatibility with existing mods. New code should implement
+    ///     <see cref="IModCreatureVisualsFactory" /> — which works for both monsters and player characters —
+    ///     instead. The routing patch still honours this interface when present on a <see cref="MonsterModel" />.
+    /// </summary>
+    [Obsolete(
+        "Implement IModCreatureVisualsFactory instead; the replacement applies to both monsters and player characters.",
+        false)]
     public interface IModMonsterCreatureVisualsFactory
     {
         /// <summary>
@@ -21,9 +42,14 @@ namespace STS2RitsuLib.Scaffolding.Content
     }
 
     /// <summary>
-    ///     Runtime <see cref="NCreatureVisuals" /> for mod characters; same contract as
-    ///     <see cref="IModMonsterCreatureVisualsFactory" />.
+    ///     Obsolete character-specific alias of <see cref="IModCreatureVisualsFactory" /> kept for backward
+    ///     compatibility with existing mods. New code should implement
+    ///     <see cref="IModCreatureVisualsFactory" /> — which works for both monsters and player characters —
+    ///     instead. The routing patch still honours this interface when present on a <see cref="CharacterModel" />.
     /// </summary>
+    [Obsolete(
+        "Implement IModCreatureVisualsFactory instead; the replacement applies to both monsters and player characters.",
+        false)]
     public interface IModCharacterCreatureVisualsFactory
     {
         /// <summary>
@@ -102,12 +128,31 @@ namespace STS2RitsuLib.Scaffolding.Content
     }
 
     /// <summary>
-    ///     Runtime Spine <see cref="CreatureAnimator" /> factory for mod characters. Overrides the default vanilla
-    ///     <c>GenerateAnimator</c> so mods can wire custom <see cref="AnimState" /> graphs (idle / hit / attack / cast /
-    ///     die / relaxed) without subclassing <c>NCreature</c>. Prefer
-    ///     <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.ModAnimStateMachines.Standard" /> for the standard
-    ///     shape; return <see langword="null" /> to fall through to vanilla behaviour.
+    ///     Runtime Spine <see cref="CreatureAnimator" /> factory for any combat creature model (player characters
+    ///     and monsters). Overrides the default vanilla <c>GenerateAnimator</c> so mods can wire custom
+    ///     <see cref="AnimState" /> graphs (idle / hit / attack / cast / die / relaxed) without subclassing
+    ///     <c>NCreature</c>. Prefer
+    ///     <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.ModAnimStateMachines.Standard" /> for the
+    ///     standard shape; return <see langword="null" /> to fall through to vanilla behaviour.
     /// </summary>
+    public interface IModCreatureAnimatorFactory
+    {
+        /// <summary>
+        ///     Returns a fully wired <see cref="CreatureAnimator" />, or <see langword="null" /> to defer to vanilla.
+        /// </summary>
+        /// <param name="controller">Spine controller attached to the creature's combat visuals.</param>
+        CreatureAnimator? TryCreateCreatureAnimator(MegaSprite controller);
+    }
+
+    /// <summary>
+    ///     Obsolete character-specific alias of <see cref="IModCreatureAnimatorFactory" /> kept for backward
+    ///     compatibility with existing mods. New code should implement
+    ///     <see cref="IModCreatureAnimatorFactory" /> — which works for both monsters and player characters —
+    ///     instead. The routing patch still honours this interface when present on a <see cref="CharacterModel" />.
+    /// </summary>
+    [Obsolete(
+        "Implement IModCreatureAnimatorFactory instead; the replacement applies to both monsters and player characters.",
+        false)]
     public interface IModCharacterCreatureAnimatorFactory
     {
         /// <summary>
@@ -118,19 +163,37 @@ namespace STS2RitsuLib.Scaffolding.Content
     }
 
     /// <summary>
-    ///     Runtime non-Spine <see cref="ModAnimStateMachine" /> factory for mod characters' combat visuals
-    ///     (cue frame sequences, cue textures, Godot animation player, animated sprite). Implement when the model
-    ///     needs automatic transitions (e.g. <c>attack</c> -&gt; <c>idle</c>) without a Spine skeleton.
+    ///     Runtime non-Spine <see cref="ModAnimStateMachine" /> factory for any combat creature model (player
+    ///     characters, monsters, or any other <see cref="AbstractModel" />) whose visuals are driven without a
+    ///     Spine skeleton. Implementers bind a state machine to the supplied visuals root using any
+    ///     <see cref="IAnimationBackend" />-backed driver (cue frame sequences, cue textures, Godot
+    ///     <see cref="AnimationPlayer" />, <see cref="AnimatedSprite2D" />, or a
+    ///     <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends.CompositeAnimationBackend" />).
     /// </summary>
-    public interface IModCharacterNonSpineAnimationStateMachineFactory
+    /// <remarks>
+    ///     <para>
+    ///         Typical implementers subclass
+    ///         <see cref="STS2RitsuLib.Scaffolding.Characters.ModCharacterTemplate{TCardPool,TRelicPool,TPotionPool}" />
+    ///         or <see cref="ModMonsterTemplate" />, but the templates are convenience. The contract is opt-in via the
+    ///         interface itself: any model type implementing this interface is routed through
+    ///         <see cref="STS2RitsuLib.Scaffolding.Characters.Patches.ModCreatureNonSpineAnimationPlaybackPatch" /> —
+    ///         template subclassing is <b>not</b> required.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="ModAnimStateMachine.SetTrigger" /> receives the same trigger names that vanilla would
+    ///         dispatch to a Spine animator (<c>Idle</c>, <c>Attack</c>, <c>Cast</c>, <c>Hit</c>, <c>Dead</c>,
+    ///         <c>Revive</c>, …).
+    ///     </para>
+    /// </remarks>
+    public interface IModNonSpineAnimationStateMachineFactory
     {
         /// <summary>
         ///     Builds a state machine bound to <paramref name="visualsRoot" />, or <see langword="null" /> to defer
-        ///     to the single-shot playback path.
+        ///     to the single-shot cue playback path. Called at most once per combat visuals lifetime (cached by the
+        ///     routing patch via a <see cref="ConditionalWeakTable{TKey,TValue}" /> keyed on <paramref name="visualsRoot" />).
         /// </summary>
         /// <param name="visualsRoot">Combat visuals root (typically an <see cref="NCreatureVisuals" />).</param>
-        /// <param name="character">Owning character model for cue lookup.</param>
-        ModAnimStateMachine? TryCreateNonSpineAnimationStateMachine(Node visualsRoot, CharacterModel character);
+        ModAnimStateMachine? TryCreateNonSpineAnimationStateMachine(Node visualsRoot);
     }
 
     /// <summary>

--- a/Scaffolding/Content/ModMonsterTemplate.cs
+++ b/Scaffolding/Content/ModMonsterTemplate.cs
@@ -1,7 +1,9 @@
+using Godot;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using STS2RitsuLib.Scaffolding.Content.Patches;
 using STS2RitsuLib.Scaffolding.Godot;
+using STS2RitsuLib.Scaffolding.Visuals.StateMachine;
 
 namespace STS2RitsuLib.Scaffolding.Content
 {
@@ -12,24 +14,60 @@ namespace STS2RitsuLib.Scaffolding.Content
     ///     construction. Register with <c>ModContentRegistry.RegisterMonster&lt;T&gt;()</c> or <c>Monster&lt;T&gt;()</c> on
     ///     the pack builder.
     /// </summary>
+    /// <remarks>
+    ///     When the monster's visuals have no Spine skeleton, override
+    ///     <see cref="SetupCustomNonSpineAnimationStateMachine" /> to drive the creature with a
+    ///     <see cref="ModAnimStateMachine" /> (the same state-machine pipeline used by
+    ///     <see cref="STS2RitsuLib.Scaffolding.Characters.ModCharacterTemplate{TCardPool,TRelicPool,TPotionPool}" />).
+    /// </remarks>
+#pragma warning disable CS0618
+    // Template keeps the obsolete IModMonsterCreatureVisualsFactory wired so existing derived classes and external
+    // consumers that type-check against the old interface name continue to work.
     public abstract class ModMonsterTemplate : MonsterModel, IModMonsterAssetOverrides,
-        IModMonsterCreatureVisualsFactory
+        IModCreatureVisualsFactory, IModMonsterCreatureVisualsFactory, IModNonSpineAnimationStateMachineFactory
+#pragma warning restore CS0618
     {
+        NCreatureVisuals? IModCreatureVisualsFactory.TryCreateCreatureVisuals()
+        {
+            return TryCreateCreatureVisuals();
+        }
+
         /// <inheritdoc />
         public virtual MonsterAssetProfile AssetProfile => MonsterAssetProfile.Empty;
 
         /// <inheritdoc />
         public virtual string? CustomVisualsPath => AssetProfile.VisualsScenePath;
 
+#pragma warning disable CS0618
         NCreatureVisuals? IModMonsterCreatureVisualsFactory.TryCreateCreatureVisuals()
         {
             return TryCreateCreatureVisuals();
+        }
+#pragma warning restore CS0618
+
+        ModAnimStateMachine? IModNonSpineAnimationStateMachineFactory.
+            TryCreateNonSpineAnimationStateMachine(Node visualsRoot)
+        {
+            return SetupCustomNonSpineAnimationStateMachine(visualsRoot, this);
         }
 
         /// <summary>
         ///     Non-null value becomes combat visuals; otherwise paths (<see cref="CustomVisualsPath" /> / vanilla) apply.
         /// </summary>
         protected virtual NCreatureVisuals? TryCreateCreatureVisuals()
+        {
+            return null;
+        }
+
+        /// <summary>
+        ///     Optional override producing a non-Spine <see cref="ModAnimStateMachine" /> for the monster's combat
+        ///     visuals (cue frame sequences, Godot animation player, animated sprite). Return
+        ///     <see langword="null" /> to defer to the vanilla single-shot playback path.
+        /// </summary>
+        /// <param name="visualsRoot">Combat visuals root node.</param>
+        /// <param name="monster">Monster model (always <see langword="this" />, exposed for convenience).</param>
+        protected virtual ModAnimStateMachine? SetupCustomNonSpineAnimationStateMachine(Node visualsRoot,
+            MonsterModel monster)
         {
             return null;
         }

--- a/Scaffolding/Content/ModMonsterTemplate.cs
+++ b/Scaffolding/Content/ModMonsterTemplate.cs
@@ -1,4 +1,6 @@
 using Godot;
+using MegaCrit.Sts2.Core.Animation;
+using MegaCrit.Sts2.Core.Bindings.MegaSpine;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using STS2RitsuLib.Scaffolding.Content.Patches;
@@ -24,9 +26,15 @@ namespace STS2RitsuLib.Scaffolding.Content
     // Template keeps the obsolete IModMonsterCreatureVisualsFactory wired so existing derived classes and external
     // consumers that type-check against the old interface name continue to work.
     public abstract class ModMonsterTemplate : MonsterModel, IModMonsterAssetOverrides,
-        IModCreatureVisualsFactory, IModMonsterCreatureVisualsFactory, IModNonSpineAnimationStateMachineFactory
+        IModCreatureVisualsFactory, IModMonsterCreatureVisualsFactory, IModCreatureAnimatorFactory,
+        IModNonSpineAnimationStateMachineFactory
 #pragma warning restore CS0618
     {
+        CreatureAnimator? IModCreatureAnimatorFactory.TryCreateCreatureAnimator(MegaSprite controller)
+        {
+            return SetupCustomCreatureAnimator(controller);
+        }
+
         NCreatureVisuals? IModCreatureVisualsFactory.TryCreateCreatureVisuals()
         {
             return TryCreateCreatureVisuals();
@@ -55,6 +63,18 @@ namespace STS2RitsuLib.Scaffolding.Content
         ///     Non-null value becomes combat visuals; otherwise paths (<see cref="CustomVisualsPath" /> / vanilla) apply.
         /// </summary>
         protected virtual NCreatureVisuals? TryCreateCreatureVisuals()
+        {
+            return null;
+        }
+
+        /// <summary>
+        ///     Optional override producing a fully wired Spine <see cref="CreatureAnimator" /> (state graph for idle /
+        ///     hit / attack / cast / die / relaxed). Return <see langword="null" /> to defer to vanilla
+        ///     <see cref="MonsterModel.GenerateAnimator" />. Prefer <see cref="ModAnimStateMachines.Standard" /> to
+        ///     match baselib semantics.
+        /// </summary>
+        /// <param name="controller">Spine controller attached to the monster's combat visuals.</param>
+        protected virtual CreatureAnimator? SetupCustomCreatureAnimator(MegaSprite controller)
         {
             return null;
         }

--- a/Scaffolding/Content/Patches/ModModelRuntimeGodotFactoryPatches.cs
+++ b/Scaffolding/Content/Patches/ModModelRuntimeGodotFactoryPatches.cs
@@ -1,5 +1,6 @@
 using Godot;
 using HarmonyLib;
+using MegaCrit.Sts2.Core.Animation;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.Bindings.MegaSpine;
 using MegaCrit.Sts2.Core.Models;
@@ -89,6 +90,48 @@ namespace STS2RitsuLib.Scaffolding.Content.Patches
                     return true;
 
                 var created = factory.TryCreateCreatureVisuals();
+                if (created == null)
+                    return true;
+
+                __result = created;
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Patches <see cref="CharacterModel.GenerateAnimator" /> for
+        ///     <see cref="IModCharacterCreatureAnimatorFactory" />.
+        /// </summary>
+        public class CharacterCreatureAnimatorRuntimeFactoryPatch : IPatchMethod
+        {
+            /// <inheritdoc cref="IPatchMethod.PatchId" />
+            public static string PatchId => "runtime_godot_factory_character_creature_animator";
+
+            /// <inheritdoc cref="IPatchMethod.IsCritical" />
+            public static bool IsCritical => false;
+
+            /// <inheritdoc cref="IPatchMethod.Description" />
+            public static string Description =>
+                "Allow mod characters to supply CreatureAnimator (Spine state graph) from code";
+
+            /// <inheritdoc cref="IPatchMethod.GetTargets" />
+            public static ModPatchTarget[] GetTargets()
+            {
+                return [new(typeof(CharacterModel), nameof(CharacterModel.GenerateAnimator))];
+            }
+
+            // ReSharper disable InconsistentNaming
+            /// <summary>
+            ///     Uses <see cref="IModCharacterCreatureAnimatorFactory.TryCreateCreatureAnimator" /> when it returns non-null.
+            /// </summary>
+            [HarmonyPriority(Priority.First)]
+            public static bool Prefix(CharacterModel __instance, MegaSprite controller, ref CreatureAnimator __result)
+                // ReSharper restore InconsistentNaming
+            {
+                if (__instance is not IModCharacterCreatureAnimatorFactory factory)
+                    return true;
+
+                var created = factory.TryCreateCreatureAnimator(controller);
                 if (created == null)
                     return true;
 

--- a/Scaffolding/Content/Patches/ModModelRuntimeGodotFactoryPatches.cs
+++ b/Scaffolding/Content/Patches/ModModelRuntimeGodotFactoryPatches.cs
@@ -17,7 +17,7 @@ namespace STS2RitsuLib.Scaffolding.Content.Patches
     public static class ModModelRuntimeGodotFactoryPatches
     {
         /// <summary>
-        ///     Patches <see cref="MonsterModel.CreateVisuals" /> for <see cref="IModMonsterCreatureVisualsFactory" />.
+        ///     Patches <see cref="MonsterModel.CreateVisuals" /> for <see cref="IModCreatureVisualsFactory" />.
         /// </summary>
         public class MonsterCreatureVisualsRuntimeFactoryPatch : IPatchMethod
         {
@@ -39,16 +39,22 @@ namespace STS2RitsuLib.Scaffolding.Content.Patches
 
             // ReSharper disable InconsistentNaming
             /// <summary>
-            ///     Uses <see cref="IModMonsterCreatureVisualsFactory.TryCreateCreatureVisuals" /> when it returns non-null.
+            ///     Uses <see cref="IModCreatureVisualsFactory.TryCreateCreatureVisuals" /> when it returns non-null,
+            ///     falling back to the obsolete <see cref="IModMonsterCreatureVisualsFactory" /> for existing mods.
             /// </summary>
             [HarmonyPriority(Priority.First)]
             public static bool Prefix(MonsterModel __instance, ref NCreatureVisuals __result)
                 // ReSharper restore InconsistentNaming
             {
-                if (__instance is not IModMonsterCreatureVisualsFactory factory)
-                    return true;
+                NCreatureVisuals? created = null;
+                if (__instance is IModCreatureVisualsFactory factory)
+                    created = factory.TryCreateCreatureVisuals();
 
-                var created = factory.TryCreateCreatureVisuals();
+#pragma warning disable CS0618
+                if (created == null && __instance is IModMonsterCreatureVisualsFactory legacyFactory)
+                    created = legacyFactory.TryCreateCreatureVisuals();
+#pragma warning restore CS0618
+
                 if (created == null)
                     return true;
 
@@ -58,7 +64,7 @@ namespace STS2RitsuLib.Scaffolding.Content.Patches
         }
 
         /// <summary>
-        ///     Patches <see cref="CharacterModel.CreateVisuals" /> for <see cref="IModCharacterCreatureVisualsFactory" />.
+        ///     Patches <see cref="CharacterModel.CreateVisuals" /> for <see cref="IModCreatureVisualsFactory" />.
         /// </summary>
         public class CharacterCreatureVisualsRuntimeFactoryPatch : IPatchMethod
         {
@@ -80,16 +86,22 @@ namespace STS2RitsuLib.Scaffolding.Content.Patches
 
             // ReSharper disable InconsistentNaming
             /// <summary>
-            ///     Uses <see cref="IModCharacterCreatureVisualsFactory.TryCreateCreatureVisuals" /> when it returns non-null.
+            ///     Uses <see cref="IModCreatureVisualsFactory.TryCreateCreatureVisuals" /> when it returns non-null,
+            ///     falling back to the obsolete <see cref="IModCharacterCreatureVisualsFactory" /> for existing mods.
             /// </summary>
             [HarmonyPriority(Priority.First)]
             public static bool Prefix(CharacterModel __instance, ref NCreatureVisuals __result)
                 // ReSharper restore InconsistentNaming
             {
-                if (__instance is not IModCharacterCreatureVisualsFactory factory)
-                    return true;
+                NCreatureVisuals? created = null;
+                if (__instance is IModCreatureVisualsFactory factory)
+                    created = factory.TryCreateCreatureVisuals();
 
-                var created = factory.TryCreateCreatureVisuals();
+#pragma warning disable CS0618
+                if (created == null && __instance is IModCharacterCreatureVisualsFactory legacyFactory)
+                    created = legacyFactory.TryCreateCreatureVisuals();
+#pragma warning restore CS0618
+
                 if (created == null)
                     return true;
 
@@ -100,7 +112,7 @@ namespace STS2RitsuLib.Scaffolding.Content.Patches
 
         /// <summary>
         ///     Patches <see cref="CharacterModel.GenerateAnimator" /> for
-        ///     <see cref="IModCharacterCreatureAnimatorFactory" />.
+        ///     <see cref="IModCreatureAnimatorFactory" />.
         /// </summary>
         public class CharacterCreatureAnimatorRuntimeFactoryPatch : IPatchMethod
         {
@@ -122,13 +134,60 @@ namespace STS2RitsuLib.Scaffolding.Content.Patches
 
             // ReSharper disable InconsistentNaming
             /// <summary>
-            ///     Uses <see cref="IModCharacterCreatureAnimatorFactory.TryCreateCreatureAnimator" /> when it returns non-null.
+            ///     Uses <see cref="IModCreatureAnimatorFactory.TryCreateCreatureAnimator" /> when it returns non-null,
+            ///     falling back to the obsolete <see cref="IModCharacterCreatureAnimatorFactory" /> for existing mods.
             /// </summary>
             [HarmonyPriority(Priority.First)]
             public static bool Prefix(CharacterModel __instance, MegaSprite controller, ref CreatureAnimator __result)
                 // ReSharper restore InconsistentNaming
             {
-                if (__instance is not IModCharacterCreatureAnimatorFactory factory)
+                CreatureAnimator? created = null;
+                if (__instance is IModCreatureAnimatorFactory factory)
+                    created = factory.TryCreateCreatureAnimator(controller);
+
+#pragma warning disable CS0618
+                if (created == null && __instance is IModCharacterCreatureAnimatorFactory legacyFactory)
+                    created = legacyFactory.TryCreateCreatureAnimator(controller);
+#pragma warning restore CS0618
+
+                if (created == null)
+                    return true;
+
+                __result = created;
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Patches <see cref="MonsterModel.GenerateAnimator" /> for <see cref="IModCreatureAnimatorFactory" />.
+        /// </summary>
+        public class MonsterCreatureAnimatorRuntimeFactoryPatch : IPatchMethod
+        {
+            /// <inheritdoc cref="IPatchMethod.PatchId" />
+            public static string PatchId => "runtime_godot_factory_monster_creature_animator";
+
+            /// <inheritdoc cref="IPatchMethod.IsCritical" />
+            public static bool IsCritical => false;
+
+            /// <inheritdoc cref="IPatchMethod.Description" />
+            public static string Description =>
+                "Allow mod monsters to supply CreatureAnimator (Spine state graph) from code";
+
+            /// <inheritdoc cref="IPatchMethod.GetTargets" />
+            public static ModPatchTarget[] GetTargets()
+            {
+                return [new(typeof(MonsterModel), nameof(MonsterModel.GenerateAnimator))];
+            }
+
+            // ReSharper disable InconsistentNaming
+            /// <summary>
+            ///     Uses <see cref="IModCreatureAnimatorFactory.TryCreateCreatureAnimator" /> when it returns non-null.
+            /// </summary>
+            [HarmonyPriority(Priority.First)]
+            public static bool Prefix(MonsterModel __instance, MegaSprite controller, ref CreatureAnimator __result)
+                // ReSharper restore InconsistentNaming
+            {
+                if (__instance is not IModCreatureAnimatorFactory factory)
                     return true;
 
                 var created = factory.TryCreateCreatureAnimator(controller);

--- a/Scaffolding/Visuals/CueFrameSequencePlayer.cs
+++ b/Scaffolding/Visuals/CueFrameSequencePlayer.cs
@@ -6,8 +6,24 @@ namespace STS2RitsuLib.Scaffolding.Visuals
     /// <summary>
     ///     Internal driver that swaps a <see cref="Sprite2D.Texture" /> through a <see cref="VisualFrameSequence" />.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Emits <see cref="SignalName.Finished" /> when a non-looping sequence reaches the last frame,
+    ///         and when <see cref="TryStart" /> short-circuits into a one-frame-non-loop state (i.e. the sequence
+    ///         has already reached its terminal frame during start). The signal is consumed by
+    ///         <c>CueAnimationBackend</c> so <see cref="StateMachine.ModAnimStateMachine" /> can advance
+    ///         <see cref="StateMachine.ModAnimState.NextState" />.
+    ///     </para>
+    /// </remarks>
     internal partial class CueFrameSequencePlayer : Node
     {
+        /// <summary>
+        ///     Raised when the sequence completes (non-loop) or is an already-terminal single frame.
+        ///     Not raised for looping sequences.
+        /// </summary>
+        [Signal]
+        public delegate void FinishedEventHandler();
+
         internal const string NodeName = "RitsuCueFrameSequencePlayer";
         private bool _active;
         private Texture2D?[] _cache = [];
@@ -80,6 +96,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals
             {
                 _active = false;
                 SetProcess(false);
+                CallDeferred(GodotObject.MethodName.EmitSignal, SignalName.Finished);
                 return true;
             }
 
@@ -108,6 +125,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals
 
             _active = false;
             SetProcess(false);
+            EmitSignal(SignalName.Finished);
         }
 
         private static double ClampFrameDuration(float seconds)

--- a/Scaffolding/Visuals/StateMachine/Backends/AnimatedSprite2DBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/AnimatedSprite2DBackend.cs
@@ -14,6 +14,8 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         private readonly Callable _finishedCallable;
         private readonly AnimatedSprite2D _sprite;
         private string? _currentId;
+        private string? _queuedId;
+        private bool _queuedLoop;
 
         /// <summary>
         ///     Wraps <paramref name="sprite" /> and hooks <see cref="AnimatedSprite2D.AnimationFinished" />.
@@ -55,6 +57,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             if (_currentId != null && _sprite.IsPlaying())
                 Interrupted?.Invoke(_currentId);
 
+            _queuedId = null;
             _currentId = id;
             var frames = _sprite.SpriteFrames;
             if (frames != null && frames.GetAnimationLoop(id) != loop)
@@ -70,7 +73,14 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             if (!HasAnimation(id))
                 return;
 
-            Play(id, loop);
+            if (_currentId == null || !_sprite.IsPlaying())
+            {
+                Play(id, loop);
+                return;
+            }
+
+            _queuedId = id;
+            _queuedLoop = loop;
         }
 
         /// <summary>
@@ -85,6 +95,13 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         private void OnAnimationFinished()
         {
             Completed?.Invoke(_currentId ?? _sprite.Animation.ToString());
+
+            if (_queuedId is not { } next)
+                return;
+
+            var loop = _queuedLoop;
+            _queuedId = null;
+            Play(next, loop);
         }
     }
 }

--- a/Scaffolding/Visuals/StateMachine/Backends/AnimatedSprite2DBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/AnimatedSprite2DBackend.cs
@@ -1,0 +1,90 @@
+using Godot;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
+{
+    /// <summary>
+    ///     <see cref="IAnimationBackend" /> driver for Godot <see cref="AnimatedSprite2D" />.
+    /// </summary>
+    /// <remarks>
+    ///     Loop flag is written back to <see cref="SpriteFrames" /> when it differs from the stored value so the
+    ///     state machine's intent wins; completion is reported through <see cref="AnimatedSprite2D.AnimationFinished" />.
+    /// </remarks>
+    public sealed class AnimatedSprite2DBackend : IAnimationBackend
+    {
+        private readonly Callable _finishedCallable;
+        private readonly AnimatedSprite2D _sprite;
+        private string? _currentId;
+
+        /// <summary>
+        ///     Wraps <paramref name="sprite" /> and hooks <see cref="AnimatedSprite2D.AnimationFinished" />.
+        /// </summary>
+        public AnimatedSprite2DBackend(AnimatedSprite2D sprite)
+        {
+            ArgumentNullException.ThrowIfNull(sprite);
+            _sprite = sprite;
+            _finishedCallable = Callable.From(OnAnimationFinished);
+            _sprite.Connect(AnimatedSprite2D.SignalName.AnimationFinished, _finishedCallable);
+        }
+
+        /// <inheritdoc />
+        public Node? OwnerNode => _sprite;
+
+        /// <inheritdoc />
+        public event Action<string>? Started;
+
+        /// <inheritdoc />
+        public event Action<string>? Completed;
+
+        /// <inheritdoc />
+        public event Action<string>? Interrupted;
+
+        /// <inheritdoc />
+        public bool HasAnimation(string id)
+        {
+            return !string.IsNullOrWhiteSpace(id) &&
+                   _sprite.SpriteFrames != null &&
+                   _sprite.SpriteFrames.HasAnimation(id);
+        }
+
+        /// <inheritdoc />
+        public void Play(string id, bool loop)
+        {
+            if (!HasAnimation(id))
+                return;
+
+            if (_currentId != null && _sprite.IsPlaying())
+                Interrupted?.Invoke(_currentId);
+
+            _currentId = id;
+            var frames = _sprite.SpriteFrames;
+            if (frames != null && frames.GetAnimationLoop(id) != loop)
+                frames.SetAnimationLoop(id, loop);
+
+            _sprite.Play(id);
+            Started?.Invoke(id);
+        }
+
+        /// <inheritdoc />
+        public void Queue(string id, bool loop)
+        {
+            if (!HasAnimation(id))
+                return;
+
+            Play(id, loop);
+        }
+
+        /// <summary>
+        ///     Detaches the signal connection. Safe to call more than once.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_sprite.IsConnected(AnimatedSprite2D.SignalName.AnimationFinished, _finishedCallable))
+                _sprite.Disconnect(AnimatedSprite2D.SignalName.AnimationFinished, _finishedCallable);
+        }
+
+        private void OnAnimationFinished()
+        {
+            Completed?.Invoke(_currentId ?? _sprite.Animation.ToString());
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/Backends/AnimatedSprite2DBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/AnimatedSprite2DBackend.cs
@@ -83,6 +83,15 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             _queuedLoop = loop;
         }
 
+        /// <inheritdoc />
+        public void Stop()
+        {
+            _queuedId = null;
+            _currentId = null;
+            if (_sprite.IsPlaying())
+                _sprite.Stop();
+        }
+
         /// <summary>
         ///     Detaches the signal connection. Safe to call more than once.
         /// </summary>

--- a/Scaffolding/Visuals/StateMachine/Backends/CompositeAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/CompositeAnimationBackend.cs
@@ -1,0 +1,125 @@
+using Godot;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
+{
+    /// <summary>
+    ///     <see cref="IAnimationBackend" /> dispatcher that selects the first child backend reporting
+    ///     <see cref="IAnimationBackend.HasAnimation" /> for a given id and routes <see cref="Play" /> /
+    ///     <see cref="Queue" /> to it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Priority follows insertion order. Typical wiring (cue frame sequences and static textures first,
+    ///         then Spine, then Godot animation player, then animated sprite) is produced by
+    ///         <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.ModAnimStateMachineBuilder" />.
+    ///     </para>
+    ///     <para>
+    ///         Only one child is <c>active</c> at a time; switching to a different backend during
+    ///         <see cref="Play" /> raises <see cref="Interrupted" /> for the previously active id.
+    ///     </para>
+    /// </remarks>
+    public sealed class CompositeAnimationBackend : IAnimationBackend
+    {
+        private readonly IReadOnlyList<IAnimationBackend> _backends;
+        private IAnimationBackend? _active;
+        private string? _currentId;
+
+        /// <summary>
+        ///     Creates a composite from <paramref name="backends" /> (priority order).
+        /// </summary>
+        public CompositeAnimationBackend(IReadOnlyList<IAnimationBackend> backends, Node? ownerNode = null)
+        {
+            ArgumentNullException.ThrowIfNull(backends);
+            if (backends.Count == 0)
+                throw new ArgumentException("At least one backend is required.", nameof(backends));
+
+            _backends = backends;
+            OwnerNode = ownerNode ?? backends[0].OwnerNode;
+
+            foreach (var backend in _backends)
+            {
+                backend.Started += id => OnChildStarted(backend, id);
+                backend.Completed += id => OnChildCompleted(backend, id);
+                backend.Interrupted += id => OnChildInterrupted(backend, id);
+            }
+        }
+
+        /// <inheritdoc />
+        public Node? OwnerNode { get; }
+
+        /// <inheritdoc />
+        public event Action<string>? Started;
+
+        /// <inheritdoc />
+        public event Action<string>? Completed;
+
+        /// <inheritdoc />
+        public event Action<string>? Interrupted;
+
+        /// <inheritdoc />
+        public bool HasAnimation(string id)
+        {
+            return _backends.Any(backend => backend.HasAnimation(id));
+        }
+
+        /// <inheritdoc />
+        public void Play(string id, bool loop)
+        {
+            var chosen = Resolve(id);
+            if (chosen == null)
+                return;
+
+            if (_active != null && !ReferenceEquals(_active, chosen) && _currentId != null)
+                Interrupted?.Invoke(_currentId);
+
+            _active = chosen;
+            _currentId = id;
+            chosen.Play(id, loop);
+        }
+
+        /// <inheritdoc />
+        public void Queue(string id, bool loop)
+        {
+            var chosen = Resolve(id);
+            if (chosen == null)
+                return;
+
+            if (ReferenceEquals(_active, chosen))
+            {
+                chosen.Queue(id, loop);
+                return;
+            }
+
+            Play(id, loop);
+        }
+
+        private IAnimationBackend? Resolve(string id)
+        {
+            return _backends.FirstOrDefault(backend => backend.HasAnimation(id));
+        }
+
+        private void OnChildStarted(IAnimationBackend backend, string id)
+        {
+            if (!ReferenceEquals(backend, _active))
+                return;
+
+            Started?.Invoke(id);
+        }
+
+        private void OnChildCompleted(IAnimationBackend backend, string id)
+        {
+            if (!ReferenceEquals(backend, _active))
+                return;
+
+            Completed?.Invoke(id);
+        }
+
+        private void OnChildInterrupted(IAnimationBackend backend, string id)
+        {
+            if (!ReferenceEquals(backend, _active))
+                return;
+
+            Interrupted?.Invoke(id);
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/Backends/CompositeAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/CompositeAnimationBackend.cs
@@ -14,8 +14,12 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
     ///         <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.ModAnimStateMachineBuilder" />.
     ///     </para>
     ///     <para>
-    ///         Only one child is <c>active</c> at a time; switching to a different backend during
-    ///         <see cref="Play" /> raises <see cref="Interrupted" /> for the previously active id.
+    ///         Only one child is <c>active</c> at a time. Switching to a different backend during
+    ///         <see cref="Play" /> raises <see cref="Interrupted" /> for the previously active id and
+    ///         <see cref="IAnimationBackend.Stop" />s the outgoing backend so it does not continue playing
+    ///         alongside the newly activated one. <see cref="Queue" /> across backends is deferred until the
+    ///         current backend reports <see cref="Completed" />, at which point the stashed
+    ///         <c>(backend, id, loop)</c> triple is activated.
     ///     </para>
     /// </remarks>
     public sealed class CompositeAnimationBackend : IAnimationBackend
@@ -23,6 +27,9 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         private readonly IReadOnlyList<IAnimationBackend> _backends;
         private IAnimationBackend? _active;
         private string? _currentId;
+        private IAnimationBackend? _queuedBackend;
+        private string? _queuedId;
+        private bool _queuedLoop;
 
         /// <summary>
         ///     Creates a composite from <paramref name="backends" /> (priority order).
@@ -69,8 +76,14 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             if (chosen == null)
                 return;
 
-            if (_active != null && !ReferenceEquals(_active, chosen) && _currentId != null)
+            var switching = _active != null && !ReferenceEquals(_active, chosen);
+            if (switching && _currentId != null)
                 Interrupted?.Invoke(_currentId);
+
+            if (switching)
+                _active!.Stop();
+
+            ClearQueued();
 
             _active = chosen;
             _currentId = id;
@@ -84,18 +97,44 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             if (chosen == null)
                 return;
 
+            if (_active == null)
+            {
+                Play(id, loop);
+                return;
+            }
+
             if (ReferenceEquals(_active, chosen))
             {
+                ClearQueued();
                 chosen.Queue(id, loop);
                 return;
             }
 
-            Play(id, loop);
+            _queuedBackend = chosen;
+            _queuedId = id;
+            _queuedLoop = loop;
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+            ClearQueued();
+            var previous = _active;
+            _active = null;
+            _currentId = null;
+            previous?.Stop();
         }
 
         private IAnimationBackend? Resolve(string id)
         {
             return _backends.FirstOrDefault(backend => backend.HasAnimation(id));
+        }
+
+        private void ClearQueued()
+        {
+            _queuedBackend = null;
+            _queuedId = null;
+            _queuedLoop = false;
         }
 
         private void OnChildStarted(IAnimationBackend backend, string id)
@@ -112,6 +151,18 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
                 return;
 
             Completed?.Invoke(id);
+
+            if (!ReferenceEquals(backend, _active) || _queuedBackend is not { } nextBackend ||
+                _queuedId is not { } nextId)
+                return;
+
+            var nextLoop = _queuedLoop;
+            ClearQueued();
+
+            backend.Stop();
+            _active = nextBackend;
+            _currentId = nextId;
+            nextBackend.Play(nextId, nextLoop);
         }
 
         private void OnChildInterrupted(IAnimationBackend backend, string id)

--- a/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
@@ -1,0 +1,200 @@
+using Godot;
+using STS2RitsuLib.Scaffolding.Visuals.Definition;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
+{
+    /// <summary>
+    ///     <see cref="IAnimationBackend" /> driver for cue-based visuals backed by
+    ///     <see cref="VisualCueSet" /> (static textures and/or <see cref="VisualFrameSequence" />).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Animation ids map to cue keys in <see cref="VisualCueSet.FrameSequenceByCue" /> (preferred) or
+    ///         <see cref="VisualCueSet.TexturePathByCue" /> (fallback static texture). Frame sequences are played
+    ///         through <see cref="CueFrameSequencePlayer" />; its <c>Finished</c> signal is converted to
+    ///         <see cref="Completed" />.
+    ///     </para>
+    ///     <para>
+    ///         Non-looping static cues raise <see cref="Completed" /> on the next idle frame so the state machine
+    ///         can advance without re-entering the caller synchronously.
+    ///     </para>
+    /// </remarks>
+    public sealed class CueAnimationBackend : IAnimationBackend
+    {
+        private readonly VisualCueSet _cues;
+        private readonly Callable _finishedCallable;
+        private readonly Node _root;
+        private readonly Sprite2D _sprite;
+        private string? _currentId;
+        private CueFrameSequencePlayer? _subscribedPlayer;
+
+        /// <summary>
+        ///     Binds cues <paramref name="cues" /> to sprite <paramref name="sprite" /> rooted at <paramref name="root" />.
+        /// </summary>
+        public CueAnimationBackend(Node root, Sprite2D sprite, VisualCueSet cues)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+            ArgumentNullException.ThrowIfNull(sprite);
+            ArgumentNullException.ThrowIfNull(cues);
+            _root = root;
+            _sprite = sprite;
+            _cues = cues;
+            _finishedCallable = Callable.From(OnSequenceFinished);
+        }
+
+        /// <inheritdoc />
+        public Node? OwnerNode => _root;
+
+        /// <inheritdoc />
+        public event Action<string>? Started;
+
+        /// <inheritdoc />
+        public event Action<string>? Completed;
+
+        /// <inheritdoc />
+        public event Action<string>? Interrupted;
+
+        /// <inheritdoc />
+        public bool HasAnimation(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                return false;
+
+            if (_cues.FrameSequenceByCue is { Count: > 0 } sequences &&
+                HasKeyOrdinalIgnoreCase(sequences, id))
+                return true;
+
+            return _cues.TexturePathByCue is { Count: > 0 } textures &&
+                   HasKeyOrdinalIgnoreCase(textures, id);
+        }
+
+        /// <inheritdoc />
+        public void Play(string id, bool loop)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                return;
+
+            if (_currentId != null)
+                Interrupted?.Invoke(_currentId);
+
+            UnsubscribeActivePlayer();
+            CueFrameSequencePlayer.StopUnder(_root);
+
+            _currentId = id;
+
+            if (_cues.FrameSequenceByCue is { Count: > 0 } sequences &&
+                TryGetOrdinalIgnoreCase(sequences, id, out var sequence) &&
+                sequence is { Frames.Count: > 0 })
+            {
+                var player = CueFrameSequencePlayer.EnsureUnder(_root);
+                if (!player.TryStart(_sprite, sequence))
+                    return;
+
+                SubscribePlayer(player);
+                Started?.Invoke(id);
+                return;
+            }
+
+            if (_cues.TexturePathByCue is not { Count: > 0 } textures ||
+                !TryGetOrdinalIgnoreCase(textures, id, out var path) ||
+                string.IsNullOrWhiteSpace(path)) return;
+            var tex = ResourceLoader.Load<Texture2D>(path);
+            if (tex == null)
+                return;
+
+            _sprite.Texture = tex;
+            Started?.Invoke(id);
+
+            if (!loop)
+                DeferCompletion(id);
+        }
+
+        /// <inheritdoc />
+        public void Queue(string id, bool loop)
+        {
+            Play(id, loop);
+        }
+
+        /// <summary>
+        ///     Stops active playback and detaches the frame-sequence signal, if any.
+        /// </summary>
+        public void Dispose()
+        {
+            UnsubscribeActivePlayer();
+            CueFrameSequencePlayer.StopUnder(_root);
+        }
+
+        private void SubscribePlayer(CueFrameSequencePlayer player)
+        {
+            _subscribedPlayer = player;
+            player.Connect(CueFrameSequencePlayer.SignalName.Finished, _finishedCallable);
+        }
+
+        private void UnsubscribeActivePlayer()
+        {
+            if (_subscribedPlayer == null)
+                return;
+
+            if (GodotObject.IsInstanceValid(_subscribedPlayer) &&
+                _subscribedPlayer.IsConnected(CueFrameSequencePlayer.SignalName.Finished, _finishedCallable))
+                _subscribedPlayer.Disconnect(CueFrameSequencePlayer.SignalName.Finished, _finishedCallable);
+
+            _subscribedPlayer = null;
+        }
+
+        private void OnSequenceFinished()
+        {
+            UnsubscribeActivePlayer();
+            var id = _currentId ?? string.Empty;
+            Completed?.Invoke(id);
+        }
+
+        private void DeferCompletion(string id)
+        {
+            if (!GodotObject.IsInstanceValid(_root))
+                return;
+
+            var tree = _root.GetTree();
+            if (tree == null)
+            {
+                Completed?.Invoke(id);
+                return;
+            }
+
+            var timer = tree.CreateTimer(0.0);
+            timer.Timeout += () =>
+            {
+                if (_currentId == id)
+                    Completed?.Invoke(id);
+            };
+        }
+
+        private static bool HasKeyOrdinalIgnoreCase<TValue>(IReadOnlyDictionary<string, TValue> map, string key)
+        {
+            return map.ContainsKey(key) ||
+                   map.Any(kv => string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool TryGetOrdinalIgnoreCase<TValue>(IReadOnlyDictionary<string, TValue> map, string key,
+            out TValue? value)
+        {
+            if (map.TryGetValue(key, out var direct))
+            {
+                value = direct;
+                return true;
+            }
+
+            foreach (var kv in map)
+            {
+                if (!string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                value = kv.Value;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
@@ -63,11 +63,13 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
                 return false;
 
             if (_cues.FrameSequenceByCue is { Count: > 0 } sequences &&
-                HasKeyOrdinalIgnoreCase(sequences, id))
+                TryGetOrdinalIgnoreCase(sequences, id, out var sequence) &&
+                sequence is { Frames.Count: > 0 })
                 return true;
 
             return _cues.TexturePathByCue is { Count: > 0 } textures &&
-                   HasKeyOrdinalIgnoreCase(textures, id);
+                   TryGetOrdinalIgnoreCase(textures, id, out var path) &&
+                   !string.IsNullOrWhiteSpace(path);
         }
 
         /// <inheritdoc />
@@ -207,12 +209,6 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             var loop = _queuedLoop;
             _queuedId = null;
             Play(next, loop);
-        }
-
-        private static bool HasKeyOrdinalIgnoreCase<TValue>(IReadOnlyDictionary<string, TValue> map, string key)
-        {
-            return map.ContainsKey(key) ||
-                   map.Any(kv => string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase));
         }
 
         private static bool TryGetOrdinalIgnoreCase<TValue>(IReadOnlyDictionary<string, TValue> map, string key,

--- a/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
@@ -128,6 +128,15 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             _queuedLoop = loop;
         }
 
+        /// <inheritdoc />
+        public void Stop()
+        {
+            _queuedId = null;
+            _currentId = null;
+            UnsubscribeActivePlayer();
+            CueFrameSequencePlayer.StopUnder(_root);
+        }
+
         /// <summary>
         ///     Stops active playback and detaches the frame-sequence signal, if any.
         /// </summary>

--- a/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/CueAnimationBackend.cs
@@ -26,6 +26,8 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         private readonly Node _root;
         private readonly Sprite2D _sprite;
         private string? _currentId;
+        private string? _queuedId;
+        private bool _queuedLoop;
         private CueFrameSequencePlayer? _subscribedPlayer;
 
         /// <summary>
@@ -80,6 +82,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             UnsubscribeActivePlayer();
             CueFrameSequencePlayer.StopUnder(_root);
 
+            _queuedId = null;
             _currentId = id;
 
             if (_cues.FrameSequenceByCue is { Count: > 0 } sequences &&
@@ -112,7 +115,17 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         /// <inheritdoc />
         public void Queue(string id, bool loop)
         {
-            Play(id, loop);
+            if (!HasAnimation(id))
+                return;
+
+            if (_currentId == null)
+            {
+                Play(id, loop);
+                return;
+            }
+
+            _queuedId = id;
+            _queuedLoop = loop;
         }
 
         /// <summary>
@@ -146,7 +159,9 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         {
             UnsubscribeActivePlayer();
             var id = _currentId ?? string.Empty;
+            _currentId = null;
             Completed?.Invoke(id);
+            ConsumeQueue();
         }
 
         private void DeferCompletion(string id)
@@ -157,16 +172,32 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             var tree = _root.GetTree();
             if (tree == null)
             {
+                _currentId = null;
                 Completed?.Invoke(id);
+                ConsumeQueue();
                 return;
             }
 
             var timer = tree.CreateTimer(0.0);
             timer.Timeout += () =>
             {
-                if (_currentId == id)
-                    Completed?.Invoke(id);
+                if (_currentId != id)
+                    return;
+
+                _currentId = null;
+                Completed?.Invoke(id);
+                ConsumeQueue();
             };
+        }
+
+        private void ConsumeQueue()
+        {
+            if (_queuedId is not { } next)
+                return;
+
+            var loop = _queuedLoop;
+            _queuedId = null;
+            Play(next, loop);
         }
 
         private static bool HasKeyOrdinalIgnoreCase<TValue>(IReadOnlyDictionary<string, TValue> map, string key)

--- a/Scaffolding/Visuals/StateMachine/Backends/GodotAnimationPlayerBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/GodotAnimationPlayerBackend.cs
@@ -1,0 +1,94 @@
+using Godot;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
+{
+    /// <summary>
+    ///     <see cref="IAnimationBackend" /> driver for Godot <see cref="AnimationPlayer" />.
+    /// </summary>
+    public sealed class GodotAnimationPlayerBackend : IAnimationBackend
+    {
+        private readonly Callable _finishedCallable;
+        private readonly AnimationPlayer _player;
+        private string? _currentId;
+
+        /// <summary>
+        ///     Wraps <paramref name="player" /> and hooks <c>AnimationPlayer.AnimationFinished</c>.
+        /// </summary>
+        public GodotAnimationPlayerBackend(AnimationPlayer player)
+        {
+            ArgumentNullException.ThrowIfNull(player);
+            _player = player;
+            _finishedCallable = Callable.From<StringName>(OnAnimationFinished);
+            _player.Connect(AnimationMixer.SignalName.AnimationFinished, _finishedCallable);
+        }
+
+        /// <inheritdoc />
+        public Node? OwnerNode => _player;
+
+        /// <inheritdoc />
+        public event Action<string>? Started;
+
+        /// <inheritdoc />
+        public event Action<string>? Completed;
+
+        /// <inheritdoc />
+        public event Action<string>? Interrupted;
+
+        /// <inheritdoc />
+        public bool HasAnimation(string id)
+        {
+            return !string.IsNullOrWhiteSpace(id) && _player.HasAnimation(id);
+        }
+
+        /// <inheritdoc />
+        public void Play(string id, bool loop)
+        {
+            if (!HasAnimation(id))
+                return;
+
+            if (_currentId != null && _player.IsPlaying())
+                Interrupted?.Invoke(_currentId);
+
+            _currentId = id;
+            var animation = _player.GetAnimation(id);
+            if (animation != null)
+                animation.LoopMode = loop ? Animation.LoopModeEnum.Linear : Animation.LoopModeEnum.None;
+
+            if (_player.CurrentAnimation == id)
+                _player.Stop();
+
+            _player.Play(id);
+            Started?.Invoke(id);
+        }
+
+        /// <inheritdoc />
+        public void Queue(string id, bool loop)
+        {
+            if (!HasAnimation(id))
+                return;
+
+            var animation = _player.GetAnimation(id);
+            if (animation != null)
+                animation.LoopMode = loop ? Animation.LoopModeEnum.Linear : Animation.LoopModeEnum.None;
+
+            _player.Queue(id);
+        }
+
+        /// <summary>
+        ///     Detaches the signal connection. Safe to call more than once.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_player.IsConnected(AnimationMixer.SignalName.AnimationFinished, _finishedCallable))
+                _player.Disconnect(AnimationMixer.SignalName.AnimationFinished, _finishedCallable);
+        }
+
+        private void OnAnimationFinished(StringName animName)
+        {
+            var name = animName.ToString();
+            _currentId = name;
+
+            Completed?.Invoke(name);
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/Backends/GodotAnimationPlayerBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/GodotAnimationPlayerBackend.cs
@@ -11,6 +11,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         private readonly AnimationPlayer _player;
         private readonly Callable _startedCallable;
         private string? _currentId;
+        private bool _suppressEvents;
 
         /// <summary>
         ///     Wraps <paramref name="player" /> and hooks <c>AnimationPlayer.AnimationFinished</c> and
@@ -77,6 +78,23 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             _player.Queue(id);
         }
 
+        /// <inheritdoc />
+        public void Stop()
+        {
+            _currentId = null;
+            _suppressEvents = true;
+            try
+            {
+                _player.ClearQueue();
+                if (_player.IsPlaying())
+                    _player.Stop();
+            }
+            finally
+            {
+                _suppressEvents = false;
+            }
+        }
+
         /// <summary>
         ///     Detaches the signal connections. Safe to call more than once.
         /// </summary>
@@ -90,6 +108,8 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
 
         private void OnAnimationStarted(StringName animName)
         {
+            if (_suppressEvents)
+                return;
             var name = animName.ToString();
             _currentId = name;
             Started?.Invoke(name);
@@ -97,6 +117,8 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
 
         private void OnAnimationFinished(StringName animName)
         {
+            if (_suppressEvents)
+                return;
             var name = animName.ToString();
             Completed?.Invoke(name);
         }

--- a/Scaffolding/Visuals/StateMachine/Backends/GodotAnimationPlayerBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/GodotAnimationPlayerBackend.cs
@@ -9,17 +9,21 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
     {
         private readonly Callable _finishedCallable;
         private readonly AnimationPlayer _player;
+        private readonly Callable _startedCallable;
         private string? _currentId;
 
         /// <summary>
-        ///     Wraps <paramref name="player" /> and hooks <c>AnimationPlayer.AnimationFinished</c>.
+        ///     Wraps <paramref name="player" /> and hooks <c>AnimationPlayer.AnimationFinished</c> and
+        ///     <c>AnimationPlayer.AnimationStarted</c> so queued auto-advances surface as <see cref="Started" />.
         /// </summary>
         public GodotAnimationPlayerBackend(AnimationPlayer player)
         {
             ArgumentNullException.ThrowIfNull(player);
             _player = player;
             _finishedCallable = Callable.From<StringName>(OnAnimationFinished);
+            _startedCallable = Callable.From<StringName>(OnAnimationStarted);
             _player.Connect(AnimationMixer.SignalName.AnimationFinished, _finishedCallable);
+            _player.Connect(AnimationMixer.SignalName.AnimationStarted, _startedCallable);
         }
 
         /// <inheritdoc />
@@ -58,7 +62,6 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
                 _player.Stop();
 
             _player.Play(id);
-            Started?.Invoke(id);
         }
 
         /// <inheritdoc />
@@ -75,19 +78,26 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         }
 
         /// <summary>
-        ///     Detaches the signal connection. Safe to call more than once.
+        ///     Detaches the signal connections. Safe to call more than once.
         /// </summary>
         public void Dispose()
         {
             if (_player.IsConnected(AnimationMixer.SignalName.AnimationFinished, _finishedCallable))
                 _player.Disconnect(AnimationMixer.SignalName.AnimationFinished, _finishedCallable);
+            if (_player.IsConnected(AnimationMixer.SignalName.AnimationStarted, _startedCallable))
+                _player.Disconnect(AnimationMixer.SignalName.AnimationStarted, _startedCallable);
+        }
+
+        private void OnAnimationStarted(StringName animName)
+        {
+            var name = animName.ToString();
+            _currentId = name;
+            Started?.Invoke(name);
         }
 
         private void OnAnimationFinished(StringName animName)
         {
             var name = animName.ToString();
-            _currentId = name;
-
             Completed?.Invoke(name);
         }
     }

--- a/Scaffolding/Visuals/StateMachine/Backends/SpineAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/SpineAnimationBackend.cs
@@ -1,0 +1,119 @@
+using Godot;
+using MegaCrit.Sts2.Core.Bindings.MegaSpine;
+using MegaCrit.Sts2.Core.Random;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
+{
+    /// <summary>
+    ///     <see cref="IAnimationBackend" /> driver for Spine via <see cref="MegaSprite" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Connects to <c>animation_started</c>, <c>animation_completed</c>, and <c>animation_interrupted</c>
+    ///         signals; behaviour mirrors <see cref="MegaCrit.Sts2.Core.Animation.CreatureAnimator" /> (including
+    ///         looping-state random time-scale and start offset for natural idle variation).
+    ///     </para>
+    /// </remarks>
+    public sealed class SpineAnimationBackend : IAnimationBackend
+    {
+        private readonly Callable _completedCallable;
+        private readonly MegaSprite _controller;
+        private readonly Callable _interruptedCallable;
+        private readonly Callable _startedCallable;
+        private string? _currentId;
+
+        /// <summary>
+        ///     Wraps the given <paramref name="controller" /> and hooks its lifecycle signals.
+        /// </summary>
+        public SpineAnimationBackend(MegaSprite controller)
+        {
+            ArgumentNullException.ThrowIfNull(controller);
+            _controller = controller;
+            OwnerNode = controller.BoundObject as Node;
+            _startedCallable = Callable.From<GodotObject, GodotObject, GodotObject>(OnStarted);
+            _completedCallable = Callable.From<GodotObject, GodotObject, GodotObject>(OnCompleted);
+            _interruptedCallable = Callable.From<GodotObject, GodotObject, GodotObject>(OnInterrupted);
+            _controller.ConnectAnimationStarted(_startedCallable);
+            _controller.ConnectAnimationCompleted(_completedCallable);
+            _controller.ConnectAnimationInterrupted(_interruptedCallable);
+        }
+
+        /// <inheritdoc />
+        public Node? OwnerNode { get; }
+
+        /// <inheritdoc />
+        public event Action<string>? Started;
+
+        /// <inheritdoc />
+        public event Action<string>? Completed;
+
+        /// <inheritdoc />
+        public event Action<string>? Interrupted;
+
+        /// <inheritdoc />
+        public bool HasAnimation(string id)
+        {
+            return !string.IsNullOrWhiteSpace(id) && _controller.HasAnimation(id);
+        }
+
+        /// <inheritdoc />
+        public void Play(string id, bool loop)
+        {
+            if (!HasAnimation(id))
+                return;
+
+            _currentId = id;
+            var animationState = _controller.GetAnimationState();
+            var track = animationState.SetAnimation(id, loop);
+            if (track == null)
+                return;
+
+            if (loop)
+                OffsetLoopingAnimation(track);
+        }
+
+        /// <inheritdoc />
+        public void Queue(string id, bool loop)
+        {
+            if (!HasAnimation(id))
+                return;
+
+            var animationState = _controller.GetAnimationState();
+            var track = animationState.AddAnimation(id, 0f, loop);
+            if (loop)
+                OffsetLoopingAnimation(track);
+        }
+
+        /// <summary>
+        ///     Detaches signal connections. Safe to call more than once.
+        /// </summary>
+        public void Dispose()
+        {
+            _controller.DisconnectAnimationStarted(_startedCallable);
+            _controller.DisconnectAnimationCompleted(_completedCallable);
+            _controller.DisconnectAnimationInterrupted(_interruptedCallable);
+        }
+
+        private void OnStarted(GodotObject _, GodotObject __, GodotObject ___)
+        {
+            Started?.Invoke(_currentId ?? string.Empty);
+        }
+
+        private void OnCompleted(GodotObject _, GodotObject __, GodotObject ___)
+        {
+            Completed?.Invoke(_currentId ?? string.Empty);
+        }
+
+        private void OnInterrupted(GodotObject _, GodotObject __, GodotObject ___)
+        {
+            Interrupted?.Invoke(_currentId ?? string.Empty);
+        }
+
+        private static void OffsetLoopingAnimation(MegaTrackEntry track)
+        {
+            track.SetTimeScale(Rng.Chaotic.NextFloat(0.9f, 1.1f));
+            var end = track.GetAnimationEnd();
+            track.SetTrackTime((end + Rng.Chaotic.NextFloat(-0.1f, 0.1f)) % end);
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/Backends/SpineAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/SpineAnimationBackend.cs
@@ -21,6 +21,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
         private readonly Callable _interruptedCallable;
         private readonly Callable _startedCallable;
         private string? _currentId;
+        private bool _paused;
 
         /// <summary>
         ///     Wraps the given <paramref name="controller" /> and hooks its lifecycle signals.
@@ -64,6 +65,12 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
 
             _currentId = id;
             var animationState = _controller.GetAnimationState();
+            if (_paused)
+            {
+                animationState.SetTimeScale(1f);
+                _paused = false;
+            }
+
             var track = animationState.SetAnimation(id, loop);
             if (track == null)
                 return;
@@ -82,6 +89,24 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             var track = animationState.AddAnimation(id, 0f, loop);
             if (loop)
                 OffsetLoopingAnimation(track);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        ///     Spine exposes no clean "stop track" API through the MegaSpine bindings; this backend pauses playback
+        ///     by setting the animation state time scale to <c>0</c>. The character will freeze on its current pose
+        ///     until <see cref="Play" /> is called again (which restores the time scale). This keeps
+        ///     <see cref="Interrupted" /> / <see cref="Completed" /> silent as required by
+        ///     <see cref="IAnimationBackend.Stop" />.
+        /// </remarks>
+        public void Stop()
+        {
+            _currentId = null;
+            var animationState = _controller.GetAnimationState();
+            if (animationState == null)
+                return;
+            animationState.SetTimeScale(0f);
+            _paused = true;
         }
 
         /// <summary>

--- a/Scaffolding/Visuals/StateMachine/Backends/SpineAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/Backends/SpineAnimationBackend.cs
@@ -119,19 +119,44 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends
             _controller.DisconnectAnimationInterrupted(_interruptedCallable);
         }
 
-        private void OnStarted(GodotObject _, GodotObject __, GodotObject ___)
+        private void OnStarted(GodotObject first, GodotObject second, GodotObject third)
         {
-            Started?.Invoke(_currentId ?? string.Empty);
+            Started?.Invoke(ResolveSignalAnimationId(first, second, third));
         }
 
-        private void OnCompleted(GodotObject _, GodotObject __, GodotObject ___)
+        private void OnCompleted(GodotObject first, GodotObject second, GodotObject third)
         {
-            Completed?.Invoke(_currentId ?? string.Empty);
+            Completed?.Invoke(ResolveSignalAnimationId(first, second, third));
         }
 
-        private void OnInterrupted(GodotObject _, GodotObject __, GodotObject ___)
+        private void OnInterrupted(GodotObject first, GodotObject second, GodotObject third)
         {
-            Interrupted?.Invoke(_currentId ?? string.Empty);
+            Interrupted?.Invoke(ResolveSignalAnimationId(first, second, third));
+        }
+
+        private string ResolveSignalAnimationId(GodotObject first, GodotObject second, GodotObject third)
+        {
+            var animationId =
+                TryGetAnimationId(first) ??
+                TryGetAnimationId(second) ??
+                TryGetAnimationId(third);
+
+            if (string.IsNullOrEmpty(animationId)) return _currentId ?? string.Empty;
+            _currentId = animationId;
+            return animationId;
+        }
+
+        private static string? TryGetAnimationId(GodotObject value)
+        {
+            if (value.GetClass() != "SpineTrackEntry")
+                return null;
+
+            var animationObj = value.Call("get_animation").AsGodotObject();
+            if (animationObj == null || !animationObj.HasMethod("get_name"))
+                return null;
+
+            var name = animationObj.Call("get_name");
+            return name.VariantType == Variant.Type.String ? name.AsString() : null;
         }
 
         private static void OffsetLoopingAnimation(MegaTrackEntry track)

--- a/Scaffolding/Visuals/StateMachine/CompositeBackendFactory.cs
+++ b/Scaffolding/Visuals/StateMachine/CompositeBackendFactory.cs
@@ -1,0 +1,102 @@
+using Godot;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+using STS2RitsuLib.Scaffolding.Characters;
+using STS2RitsuLib.Scaffolding.Visuals.Definition;
+using STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
+{
+    /// <summary>
+    ///     Helper that composes a <see cref="CompositeAnimationBackend" /> from the nodes found under a visuals
+    ///     root, in priority order: cue frame sequences / static textures, Spine, Godot animation player,
+    ///     Godot animated sprite.
+    /// </summary>
+    public static class CompositeBackendFactory
+    {
+        /// <summary>
+        ///     Builds the composite backend. Returns the cue-only backend when no Godot / Spine nodes are found,
+        ///     or a truly-empty (single backend) pass-through when cues are unavailable.
+        /// </summary>
+        /// <param name="visualsRoot">Root node under which backends are discovered.</param>
+        /// <param name="character">
+        ///     Optional character model used to pull <see cref="VisualCueSet" /> when
+        ///     <paramref name="cueSet" /> is <see langword="null" />.
+        /// </param>
+        /// <param name="cueSet">Optional explicit cue set; takes priority over the character-derived one.</param>
+        public static IAnimationBackend Build(Node visualsRoot, CharacterModel? character = null,
+            VisualCueSet? cueSet = null)
+        {
+            ArgumentNullException.ThrowIfNull(visualsRoot);
+
+            var resolvedCues = cueSet ?? TryGetCharacterCueSet(character);
+            var sprite = FindPrimarySprite2D(visualsRoot);
+
+            List<IAnimationBackend> backends = [];
+            if (resolvedCues != null && sprite != null)
+                backends.Add(new CueAnimationBackend(visualsRoot, sprite, resolvedCues));
+
+            if (visualsRoot is NCreatureVisuals { HasSpineAnimation: true, SpineBody: { } spine })
+                backends.Add(new SpineAnimationBackend(spine));
+
+            var animationPlayer =
+                FindNode<AnimationPlayer>(visualsRoot) ?? SearchRecursive<AnimationPlayer>(visualsRoot);
+            if (animationPlayer != null)
+                backends.Add(new GodotAnimationPlayerBackend(animationPlayer));
+
+            var animatedSprite = FindNode<AnimatedSprite2D>(visualsRoot) ??
+                                 SearchRecursive<AnimatedSprite2D>(visualsRoot);
+            if (animatedSprite != null)
+                backends.Add(new AnimatedSprite2DBackend(animatedSprite));
+
+            if (backends.Count == 0)
+                throw new InvalidOperationException(
+                    $"No animation backend could be built for '{visualsRoot.Name}' (no cues, Spine, AnimationPlayer or AnimatedSprite2D).");
+
+            return backends.Count == 1 ? backends[0] : new CompositeAnimationBackend(backends, visualsRoot);
+        }
+
+        private static VisualCueSet? TryGetCharacterCueSet(CharacterModel? character)
+        {
+            return character is not IModCharacterAssetOverrides overrides
+                ? null
+                : overrides.WorldProceduralVisuals?.Merchant?.CueSet;
+        }
+
+        private static Sprite2D? FindPrimarySprite2D(Node root)
+        {
+            var direct = root.GetNodeOrNull("%Visuals") ?? root.GetNodeOrNull("Visuals");
+            if (direct is Sprite2D s)
+                return s;
+
+            if (root is Sprite2D rootSprite)
+                return rootSprite;
+
+            return SearchRecursive<Sprite2D>(root);
+        }
+
+        private static T? FindNode<T>(Node root) where T : class
+        {
+            var typeName = typeof(T).Name;
+            var n = root.GetNodeOrNull(typeName)
+                    ?? root.GetNodeOrNull("Visuals/" + typeName)
+                    ?? root.GetNodeOrNull("Body/" + typeName);
+            return n as T;
+        }
+
+        private static T? SearchRecursive<T>(Node parent) where T : class
+        {
+            foreach (var child in parent.GetChildren())
+            {
+                if (child is T match)
+                    return match;
+
+                var found = SearchRecursive<T>(child);
+                if (found != null)
+                    return found;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/CompositeBackendFactory.cs
+++ b/Scaffolding/Visuals/StateMachine/CompositeBackendFactory.cs
@@ -60,7 +60,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
         {
             return character is not IModCharacterAssetOverrides overrides
                 ? null
-                : overrides.WorldProceduralVisuals?.Merchant?.CueSet;
+                : overrides.VisualCues ?? overrides.WorldProceduralVisuals?.Merchant?.CueSet;
         }
 
         private static Sprite2D? FindPrimarySprite2D(Node root)

--- a/Scaffolding/Visuals/StateMachine/IAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/IAnimationBackend.cs
@@ -1,0 +1,61 @@
+using Godot;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
+{
+    /// <summary>
+    ///     Uniform driver surface required by <see cref="ModAnimStateMachine" /> so the same state graph can run on
+    ///     Spine (<c>MegaSprite</c>), Godot <c>AnimationPlayer</c>, <c>AnimatedSprite2D</c>, or cue-frame-sequence
+    ///     playback (see <see cref="STS2RitsuLib.Scaffolding.Visuals.Definition.VisualCueSet" />).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Implementations raise <see cref="Started" />, <see cref="Completed" />, and <see cref="Interrupted" />
+    ///         whenever the underlying system reports the corresponding events so the state machine can advance
+    ///         <see cref="ModAnimState.NextState" />.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="Queue" /> is only meaningful for backends with true queue semantics (Spine); other backends
+    ///         may forward it to <see cref="Play" /> or defer until <see cref="Completed" /> fires.
+    ///     </para>
+    /// </remarks>
+    public interface IAnimationBackend
+    {
+        /// <summary>
+        ///     Backend owner node (visuals root, merchant root, etc.); <see langword="null" /> when not applicable.
+        /// </summary>
+        Node? OwnerNode { get; }
+
+        /// <summary>
+        ///     Fired when the backend reports playback start for animation id <c>arg</c>.
+        /// </summary>
+        event Action<string>? Started;
+
+        /// <summary>
+        ///     Fired when the backend reports playback completion (loop cycle end or one-shot end) for id <c>arg</c>.
+        /// </summary>
+        event Action<string>? Completed;
+
+        /// <summary>
+        ///     Fired when the backend reports playback interruption for id <c>arg</c>.
+        /// </summary>
+        event Action<string>? Interrupted;
+
+        /// <summary>
+        ///     Returns <see langword="true" /> when the backend can play <paramref name="id" />.
+        /// </summary>
+        bool HasAnimation(string id);
+
+        /// <summary>
+        ///     Plays <paramref name="id" /> immediately (replaces any active animation).
+        /// </summary>
+        /// <param name="id">Animation id; must satisfy <see cref="HasAnimation" />.</param>
+        /// <param name="loop">Loop hint; backends without looping support should treat this as a best-effort flag.</param>
+        void Play(string id, bool loop);
+
+        /// <summary>
+        ///     Queues <paramref name="id" /> after the currently active animation. Non-queue backends may treat this
+        ///     as a deferred <see cref="Play" /> triggered on the next <see cref="Completed" />.
+        /// </summary>
+        void Queue(string id, bool loop);
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/IAnimationBackend.cs
+++ b/Scaffolding/Visuals/StateMachine/IAnimationBackend.cs
@@ -57,5 +57,21 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
         ///     as a deferred <see cref="Play" /> triggered on the next <see cref="Completed" />.
         /// </summary>
         void Queue(string id, bool loop);
+
+        /// <summary>
+        ///     Stops any active playback silently (does not raise <see cref="Interrupted" /> / <see cref="Completed" />)
+        ///     and clears any pending queued animation. Intended for callers that need to relinquish the backend —
+        ///     typically <see cref="STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends.CompositeAnimationBackend" />
+        ///     during cross-backend transitions, so the previously active backend does not continue visibly playing
+        ///     alongside the newly activated one.
+        /// </summary>
+        /// <remarks>
+        ///     Default implementation is a no-op; backends that drive a visible node should override to halt
+        ///     playback and suppress any lifecycle events that the underlying engine may fire as a consequence
+        ///     of the stop.
+        /// </remarks>
+        void Stop()
+        {
+        }
     }
 }

--- a/Scaffolding/Visuals/StateMachine/ModAnimState.cs
+++ b/Scaffolding/Visuals/StateMachine/ModAnimState.cs
@@ -1,0 +1,122 @@
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
+{
+    /// <summary>
+    ///     Backend-agnostic animation state, semantically equivalent to
+    ///     <see cref="MegaCrit.Sts2.Core.Animation.AnimState" /> but usable from any
+    ///     <see cref="IAnimationBackend" /> (Spine, Godot animation player, animated sprite, cue frame sequences).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Transitions follow the vanilla pattern:
+    ///     </para>
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <description>
+    ///                 <see cref="NextState" /> is consumed only when the current animation completes (non-looping) or
+    ///                 when the backend signals completion; if <see langword="null" />, the state is preserved.
+    ///             </description>
+    ///         </item>
+    ///         <item>
+    ///             <description>
+    ///                 <see cref="CallTrigger" /> resolves branches added via <see cref="AddBranch" />; branches may
+    ///                 declare an optional guard <see cref="System.Func{TResult}" />.
+    ///             </description>
+    ///         </item>
+    ///     </list>
+    /// </remarks>
+    public sealed class ModAnimState
+    {
+        private readonly Dictionary<string, List<Branch>> _branches = new(StringComparer.Ordinal);
+
+        /// <summary>
+        ///     Creates a new state bound to backend animation <paramref name="id" />.
+        /// </summary>
+        /// <param name="id">Animation id resolved by <see cref="IAnimationBackend.HasAnimation" />.</param>
+        /// <param name="isLooping">When <see langword="true" />, the backend is asked to loop playback.</param>
+        public ModAnimState(string id, bool isLooping = false)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            Id = id;
+            IsLooping = isLooping;
+        }
+
+        /// <summary>
+        ///     Backend animation id (Spine track, Godot animation name, cue key, or sprite-frames animation name).
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        ///     Whether the state loops while active.
+        /// </summary>
+        public bool IsLooping { get; }
+
+        /// <summary>
+        ///     Optional follow-up state used by <see cref="ModAnimStateMachine" /> when this state completes.
+        /// </summary>
+        /// <remarks>
+        ///     Keep <see langword="null" /> for terminal states (e.g. <c>die</c>) so completion does not advance.
+        /// </remarks>
+        public ModAnimState? NextState { get; set; }
+
+        /// <summary>
+        ///     Optional bounds-container tag forwarded through
+        ///     <see cref="ModAnimStateMachine.BoundsUpdated" /> on start and completion.
+        /// </summary>
+        public string? BoundsContainer { get; init; }
+
+        /// <summary>
+        ///     <see langword="true" /> once a looping state has completed at least one full cycle.
+        /// </summary>
+        public bool HasLooped { get; private set; }
+
+        /// <summary>
+        ///     Adds a conditional branch to <paramref name="target" /> for trigger <paramref name="trigger" />.
+        /// </summary>
+        /// <param name="trigger">Trigger name compared verbatim during <see cref="CallTrigger" />.</param>
+        /// <param name="target">State to transition to when the trigger fires and <paramref name="condition" /> passes.</param>
+        /// <param name="condition">Optional guard evaluated at trigger time; <see langword="null" /> means always.</param>
+        public void AddBranch(string trigger, ModAnimState target, Func<bool>? condition = null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(trigger);
+            ArgumentNullException.ThrowIfNull(target);
+
+            if (!_branches.TryGetValue(trigger, out var list))
+            {
+                list = [];
+                _branches[trigger] = list;
+            }
+
+            list.Add(new(target, condition));
+        }
+
+        /// <summary>
+        ///     Resolves the first matching branch for <paramref name="trigger" /> whose guard passes,
+        ///     or <see langword="null" /> when no branch is eligible.
+        /// </summary>
+        public ModAnimState? CallTrigger(string trigger)
+        {
+            return !_branches.TryGetValue(trigger, out var list)
+                ? null
+                : (from branch in list where branch.Condition == null || branch.Condition() select branch.Target)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        ///     <see langword="true" /> when at least one branch is registered for <paramref name="trigger" />.
+        /// </summary>
+        public bool HasTrigger(string trigger)
+        {
+            return _branches.ContainsKey(trigger);
+        }
+
+        /// <summary>
+        ///     Marks the state as having completed one loop iteration (for bounds / debug logic).
+        /// </summary>
+        public void MarkHasLooped()
+        {
+            HasLooped = true;
+        }
+
+        private readonly record struct Branch(ModAnimState Target, Func<bool>? Condition);
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/ModAnimStateMachine.cs
+++ b/Scaffolding/Visuals/StateMachine/ModAnimStateMachine.cs
@@ -1,0 +1,198 @@
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
+{
+    /// <summary>
+    ///     Backend-agnostic animation state machine. Semantically aligned with
+    ///     <see cref="MegaCrit.Sts2.Core.Animation.CreatureAnimator" /> (<see cref="SetTrigger" /> evaluates
+    ///     any-state branches first, then current-state branches; <see cref="ModAnimState.NextState" /> is queued
+    ///     on entry and consumed on completion) but usable against any <see cref="IAnimationBackend" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Terminal states (such as <c>die</c>) are represented by leaving <see cref="ModAnimState.NextState" />
+    ///         as <see langword="null" />; on completion the machine stays on that state without advancing.
+    ///     </para>
+    /// </remarks>
+    public sealed class ModAnimStateMachine
+    {
+        private readonly ModAnimState _anyState = new("__anyState");
+        private bool _disposed;
+
+        /// <summary>
+        ///     Wraps <paramref name="backend" />; subscribes to its event surface.
+        /// </summary>
+        public ModAnimStateMachine(IAnimationBackend backend)
+        {
+            ArgumentNullException.ThrowIfNull(backend);
+            Backend = backend;
+            Backend.Started += OnBackendStarted;
+            Backend.Completed += OnBackendCompleted;
+            Backend.Interrupted += OnBackendInterrupted;
+        }
+
+        /// <summary>
+        ///     Currently active state, or <see langword="null" /> before <see cref="Start" /> or after <see cref="Dispose" />.
+        /// </summary>
+        public ModAnimState? Current { get; private set; }
+
+        /// <summary>
+        ///     Underlying backend; exposed primarily for composite scenarios (e.g. merchant dual playback).
+        /// </summary>
+        public IAnimationBackend Backend { get; }
+
+        /// <summary>
+        ///     Raised when <see cref="ModAnimState.BoundsContainer" /> should update (enter, completion, interruption).
+        /// </summary>
+        public event Action<string>? BoundsUpdated;
+
+        /// <summary>
+        ///     Raised when the backend reports start for the current state's animation id.
+        /// </summary>
+        public event Action<ModAnimState>? AnimationStarted;
+
+        /// <summary>
+        ///     Raised when the backend reports completion for the current state's animation id.
+        /// </summary>
+        public event Action<ModAnimState>? AnimationCompleted;
+
+        /// <summary>
+        ///     Raised when the backend reports interruption for the current state's animation id.
+        /// </summary>
+        public event Action<ModAnimState>? AnimationInterrupted;
+
+        /// <summary>
+        ///     Registers a branch on the synthetic any-state, matching
+        ///     <see cref="MegaCrit.Sts2.Core.Animation.CreatureAnimator.AddAnyState" />.
+        /// </summary>
+        public void AddAnyState(string trigger, ModAnimState state, Func<bool>? condition = null)
+        {
+            _anyState.AddBranch(trigger, state, condition);
+        }
+
+        /// <summary>
+        ///     Enters <paramref name="initial" />; triggers backend playback and fires <see cref="BoundsUpdated" />.
+        /// </summary>
+        public void Start(ModAnimState initial)
+        {
+            ArgumentNullException.ThrowIfNull(initial);
+            if (_disposed)
+                return;
+
+            EnterState(initial);
+        }
+
+        /// <summary>
+        ///     <see langword="true" /> when any-state has a branch for <paramref name="trigger" />.
+        /// </summary>
+        public bool HasTrigger(string trigger)
+        {
+            return _anyState.HasTrigger(trigger);
+        }
+
+        /// <summary>
+        ///     Resolves <paramref name="trigger" /> against any-state first, then the current state; when matched,
+        ///     transitions to the resolved target.
+        /// </summary>
+        public void SetTrigger(string trigger)
+        {
+            if (_disposed || string.IsNullOrWhiteSpace(trigger))
+                return;
+
+            var target = _anyState.CallTrigger(trigger) ?? Current?.CallTrigger(trigger);
+            if (target == null)
+                return;
+
+            EnterState(target);
+        }
+
+        /// <summary>
+        ///     Detaches from backend events. Safe to call multiple times.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            Backend.Started -= OnBackendStarted;
+            Backend.Completed -= OnBackendCompleted;
+            Backend.Interrupted -= OnBackendInterrupted;
+        }
+
+        private void EnterState(ModAnimState state)
+        {
+            Current = state;
+
+            if (!Backend.HasAnimation(state.Id))
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[ModAnimStateMachine] Backend has no animation '{state.Id}' (owner={Backend.OwnerNode?.Name})");
+                return;
+            }
+
+            Backend.Play(state.Id, state.IsLooping);
+
+            if (state.BoundsContainer != null)
+                BoundsUpdated?.Invoke(state.BoundsContainer);
+
+            if (state.NextState != null)
+                QueueChain(state.NextState);
+        }
+
+        private void QueueChain(ModAnimState state)
+        {
+            while (true)
+            {
+                if (!Backend.HasAnimation(state.Id)) return;
+
+                Backend.Queue(state.Id, state.IsLooping);
+
+                if (state.NextState != null)
+                {
+                    state = state.NextState;
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        private void OnBackendStarted(string _)
+        {
+            if (Current is not { } state)
+                return;
+
+            if (state is { HasLooped: false, BoundsContainer: not null })
+                BoundsUpdated?.Invoke(state.BoundsContainer);
+
+            AnimationStarted?.Invoke(state);
+        }
+
+        private void OnBackendCompleted(string _)
+        {
+            if (Current is not { } state)
+                return;
+
+            if (state is { HasLooped: false, BoundsContainer: not null })
+                BoundsUpdated?.Invoke(state.BoundsContainer);
+
+            if (state is { IsLooping: true, HasLooped: false })
+                state.MarkHasLooped();
+
+            AnimationCompleted?.Invoke(state);
+
+            if (state.NextState != null)
+                Current = state.NextState;
+        }
+
+        private void OnBackendInterrupted(string _)
+        {
+            if (Current is not { } state)
+                return;
+
+            if (state.BoundsContainer != null)
+                BoundsUpdated?.Invoke(state.BoundsContainer);
+
+            AnimationInterrupted?.Invoke(state);
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/ModAnimStateMachine.cs
+++ b/Scaffolding/Visuals/StateMachine/ModAnimStateMachine.cs
@@ -116,12 +116,11 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
             Backend.Started -= OnBackendStarted;
             Backend.Completed -= OnBackendCompleted;
             Backend.Interrupted -= OnBackendInterrupted;
+            Current = null;
         }
 
         private void EnterState(ModAnimState state)
         {
-            Current = state;
-
             if (!Backend.HasAnimation(state.Id))
             {
                 RitsuLibFramework.Logger.Warn(
@@ -129,6 +128,7 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
                 return;
             }
 
+            Current = state;
             Backend.Play(state.Id, state.IsLooping);
 
             if (state.BoundsContainer != null)
@@ -179,6 +179,9 @@ namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
                 state.MarkHasLooped();
 
             AnimationCompleted?.Invoke(state);
+
+            if (Current != state)
+                return;
 
             if (state.NextState != null)
                 Current = state.NextState;

--- a/Scaffolding/Visuals/StateMachine/ModAnimStateMachineBuilder.cs
+++ b/Scaffolding/Visuals/StateMachine/ModAnimStateMachineBuilder.cs
@@ -1,0 +1,221 @@
+using Godot;
+using MegaCrit.Sts2.Core.Bindings.MegaSpine;
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Scaffolding.Visuals.Definition;
+using STS2RitsuLib.Scaffolding.Visuals.StateMachine.Backends;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
+{
+    /// <summary>
+    ///     Fluent builder for <see cref="ModAnimStateMachine" />. Declare named states, per-state loop / next-state
+    ///     / bounds metadata, per-state branches, and any-state transitions; finalise by calling one of the
+    ///     <c>Build</c> overloads with an <see cref="IAnimationBackend" /> or a visuals root.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The builder does not validate ids against backend animation availability: if a state id is unresolvable
+    ///         by the chosen backend, <see cref="ModAnimStateMachine" /> will skip playback for that state and log a
+    ///         warning on entry.
+    ///     </para>
+    /// </remarks>
+    public sealed class ModAnimStateMachineBuilder
+    {
+        private readonly List<AnyBranchDraft> _anyBranches = [];
+        private readonly Dictionary<string, StateDraft> _states = new(StringComparer.Ordinal);
+        private string? _initialStateId;
+
+        private ModAnimStateMachineBuilder()
+        {
+        }
+
+        /// <summary>
+        ///     Creates a fresh builder.
+        /// </summary>
+        public static ModAnimStateMachineBuilder Create()
+        {
+            return new();
+        }
+
+        /// <summary>
+        ///     Declares a state with backend animation id <paramref name="id" /> and loop hint
+        ///     <paramref name="loop" />. Returns a scope object so the caller can chain
+        ///     <see cref="StateScope.WithNext" />, <see cref="StateScope.WithBounds" />, and
+        ///     <see cref="StateScope.AsInitial" />.
+        /// </summary>
+        public StateScope AddState(string id, bool loop = false)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            if (_states.ContainsKey(id))
+                throw new InvalidOperationException($"State '{id}' already declared.");
+
+            var draft = new StateDraft(id, loop);
+            _states[id] = draft;
+            _initialStateId ??= id;
+            return new(this, draft);
+        }
+
+        /// <summary>
+        ///     Adds a branch from state <paramref name="fromId" /> for trigger <paramref name="trigger" /> to state
+        ///     <paramref name="toId" />. Optional <paramref name="condition" /> guards activation.
+        /// </summary>
+        public ModAnimStateMachineBuilder AddBranch(string fromId, string trigger, string toId,
+            Func<bool>? condition = null)
+        {
+            if (!_states.TryGetValue(fromId, out var draft))
+                throw new InvalidOperationException($"Source state '{fromId}' not declared.");
+
+            draft.Branches.Add(new(trigger, toId, condition));
+            return this;
+        }
+
+        /// <summary>
+        ///     Adds an any-state branch for trigger <paramref name="trigger" /> to <paramref name="toId" />
+        ///     (guarded by optional <paramref name="condition" />).
+        /// </summary>
+        public ModAnimStateMachineBuilder AddAnyState(string trigger, string toId, Func<bool>? condition = null)
+        {
+            _anyBranches.Add(new(trigger, toId, condition));
+            return this;
+        }
+
+        /// <summary>
+        ///     Materialises the graph against <paramref name="backend" /> and returns a started
+        ///     <see cref="ModAnimStateMachine" />.
+        /// </summary>
+        public ModAnimStateMachine Build(IAnimationBackend backend)
+        {
+            ArgumentNullException.ThrowIfNull(backend);
+            var machine = BuildCore(backend, out var initial);
+            machine.Start(initial);
+            return machine;
+        }
+
+        /// <summary>
+        ///     Convenience overload: wraps <paramref name="controller" /> in a <see cref="SpineAnimationBackend" />
+        ///     and builds the machine.
+        /// </summary>
+        public ModAnimStateMachine BuildSpine(MegaSprite controller)
+        {
+            return Build(new SpineAnimationBackend(controller));
+        }
+
+        /// <summary>
+        ///     Convenience overload: composes cue / Spine / Godot animation player / animated-sprite backends
+        ///     rooted at <paramref name="visualsRoot" /> and builds the machine.
+        /// </summary>
+        /// <param name="visualsRoot">Visuals root (typically an <see cref="MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals" />).</param>
+        /// <param name="character">
+        ///     Optional character model; used when <paramref name="cueSet" /> is <see langword="null" />
+        ///     to pull cue data from <c>IModCharacterAssetOverrides</c>.
+        /// </param>
+        /// <param name="cueSet">Optional explicit cue set; takes priority over the character-derived one.</param>
+        public ModAnimStateMachine BuildForVisualsRoot(Node visualsRoot, CharacterModel? character = null,
+            VisualCueSet? cueSet = null)
+        {
+            var backend = CompositeBackendFactory.Build(visualsRoot, character, cueSet);
+            return Build(backend);
+        }
+
+        private ModAnimStateMachine BuildCore(IAnimationBackend backend, out ModAnimState initial)
+        {
+            if (_initialStateId == null)
+                throw new InvalidOperationException("No states declared.");
+
+            var materialised = new Dictionary<string, ModAnimState>(StringComparer.Ordinal);
+
+            foreach (var (id, draft) in _states)
+                materialised[id] = new(draft.Id, draft.Loop) { BoundsContainer = draft.BoundsContainer };
+
+            foreach (var (id, draft) in _states)
+            {
+                var state = materialised[id];
+                if (draft.NextStateId != null && materialised.TryGetValue(draft.NextStateId, out var next))
+                    state.NextState = next;
+
+                foreach (var branch in draft.Branches)
+                {
+                    if (!materialised.TryGetValue(branch.ToId, out var target))
+                        continue;
+
+                    state.AddBranch(branch.Trigger, target, branch.Condition);
+                }
+            }
+
+            initial = materialised[_initialStateId];
+            var machine = new ModAnimStateMachine(backend);
+            foreach (var branch in _anyBranches)
+            {
+                if (!materialised.TryGetValue(branch.ToId, out var target))
+                    continue;
+
+                machine.AddAnyState(branch.Trigger, target, branch.Condition);
+            }
+
+            return machine;
+        }
+
+        internal sealed class StateDraft(string id, bool loop)
+        {
+            public string Id { get; } = id;
+            public bool Loop { get; } = loop;
+            public string? NextStateId { get; set; }
+            public string? BoundsContainer { get; set; }
+            public List<BranchDraft> Branches { get; } = [];
+        }
+
+        internal readonly record struct BranchDraft(string Trigger, string ToId, Func<bool>? Condition);
+
+        private readonly record struct AnyBranchDraft(string Trigger, string ToId, Func<bool>? Condition);
+
+        /// <summary>
+        ///     Fluent scope returned by <see cref="ModAnimStateMachineBuilder.AddState" /> for per-state metadata.
+        /// </summary>
+        public sealed class StateScope
+        {
+            private readonly StateDraft _draft;
+            private readonly ModAnimStateMachineBuilder _owner;
+
+            internal StateScope(ModAnimStateMachineBuilder owner, StateDraft draft)
+            {
+                _owner = owner;
+                _draft = draft;
+            }
+
+            /// <summary>
+            ///     Sets <see cref="ModAnimState.NextState" /> for the current state (by target id).
+            /// </summary>
+            public StateScope WithNext(string nextStateId)
+            {
+                _draft.NextStateId = nextStateId;
+                return this;
+            }
+
+            /// <summary>
+            ///     Sets <see cref="ModAnimState.BoundsContainer" /> tag emitted via
+            ///     <see cref="ModAnimStateMachine.BoundsUpdated" /> on enter.
+            /// </summary>
+            public StateScope WithBounds(string boundsContainer)
+            {
+                _draft.BoundsContainer = boundsContainer;
+                return this;
+            }
+
+            /// <summary>
+            ///     Marks the current state as the initial state (overrides the auto-first-state behaviour).
+            /// </summary>
+            public StateScope AsInitial()
+            {
+                _owner._initialStateId = _draft.Id;
+                return this;
+            }
+
+            /// <summary>
+            ///     Returns the owning builder so chaining can continue.
+            /// </summary>
+            public ModAnimStateMachineBuilder Done()
+            {
+                return _owner;
+            }
+        }
+    }
+}

--- a/Scaffolding/Visuals/StateMachine/ModAnimStateMachines.cs
+++ b/Scaffolding/Visuals/StateMachine/ModAnimStateMachines.cs
@@ -1,0 +1,146 @@
+using Godot;
+using MegaCrit.Sts2.Core.Animation;
+using MegaCrit.Sts2.Core.Bindings.MegaSpine;
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Scaffolding.Visuals.Definition;
+
+namespace STS2RitsuLib.Scaffolding.Visuals.StateMachine
+{
+    /// <summary>
+    ///     Top-level convenience factories for animation state machines. Mirrors the semantics of
+    ///     baselib's <c>CustomCharacterModel.SetupAnimationState</c> but usable against any
+    ///     <see cref="IAnimationBackend" /> (Spine, Godot animation player / animated sprite, cue frame sequences).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="Standard" /> produces a vanilla <see cref="CreatureAnimator" /> so callers can return it
+    ///         directly from <c>CharacterModel.GenerateAnimator</c>; this is the closest drop-in replacement for the
+    ///         baselib helper.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="StandardCue" /> produces a backend-agnostic <see cref="ModAnimStateMachine" /> for
+    ///         non-Spine visuals rooted at a <see cref="Node" /> (cue frame sequences, Godot animation player,
+    ///         animated sprite).
+    ///     </para>
+    ///     <para>
+    ///         Terminal states (<c>Dead</c>) leave <see cref="ModAnimState.NextState" /> / <c>AnimState.NextState</c>
+    ///         unset so completion does not auto-return to idle, matching the vanilla behaviour.
+    ///     </para>
+    /// </remarks>
+    public static class ModAnimStateMachines
+    {
+        /// <summary>
+        ///     Builds a vanilla Spine <see cref="CreatureAnimator" /> matching the standard idle / dead / hit /
+        ///     attack / cast / relaxed shape. Null animation names collapse to the idle state (vanilla behaviour).
+        /// </summary>
+        public static CreatureAnimator Standard(MegaSprite controller,
+            string idleName,
+            string? deadName = null, bool deadLoop = false,
+            string? hitName = null, bool hitLoop = false,
+            string? attackName = null, bool attackLoop = false,
+            string? castName = null, bool castLoop = false,
+            string? relaxedName = null, bool relaxedLoop = true)
+        {
+            ArgumentNullException.ThrowIfNull(controller);
+
+            var idle = new AnimState(idleName, true);
+            var dead = deadName == null ? idle : new(deadName, deadLoop);
+            var hit = hitName == null
+                ? idle
+                : new(hitName, hitLoop) { NextState = idle };
+            var attack = attackName == null
+                ? idle
+                : new(attackName, attackLoop) { NextState = idle };
+            var cast = castName == null
+                ? idle
+                : new(castName, castLoop) { NextState = idle };
+
+            AnimState relaxed;
+            if (relaxedName == null)
+            {
+                relaxed = idle;
+            }
+            else
+            {
+                relaxed = new(relaxedName, relaxedLoop);
+                relaxed.AddBranch("Idle", idle);
+            }
+
+            var animator = new CreatureAnimator(idle, controller);
+            animator.AddAnyState("Idle", idle);
+            animator.AddAnyState("Dead", dead);
+            animator.AddAnyState("Hit", hit);
+            animator.AddAnyState("Attack", attack);
+            animator.AddAnyState("Cast", cast);
+            animator.AddAnyState("Relaxed", relaxed);
+            return animator;
+        }
+
+        /// <summary>
+        ///     Builds a non-Spine <see cref="ModAnimStateMachine" /> over <paramref name="visualsRoot" /> matching
+        ///     the standard idle / dead / hit / attack / cast / relaxed shape; null names fall back to idle.
+        /// </summary>
+        /// <param name="visualsRoot">Visuals root used by <see cref="CompositeBackendFactory" />.</param>
+        /// <param name="character">Optional character model used to discover cue sets.</param>
+        /// <param name="idleName">Idle animation id (always required; looping).</param>
+        /// <param name="deadName">Optional die animation id; <see langword="null" /> falls back to idle.</param>
+        /// <param name="deadLoop">Loop flag for the die animation.</param>
+        /// <param name="hitName">Optional hit animation id; <see langword="null" /> falls back to idle.</param>
+        /// <param name="hitLoop">Loop flag for the hit animation.</param>
+        /// <param name="attackName">Optional attack animation id; <see langword="null" /> falls back to idle.</param>
+        /// <param name="attackLoop">Loop flag for the attack animation.</param>
+        /// <param name="castName">Optional cast animation id; <see langword="null" /> falls back to idle.</param>
+        /// <param name="castLoop">Loop flag for the cast animation.</param>
+        /// <param name="relaxedName">Optional relaxed animation id; <see langword="null" /> falls back to idle.</param>
+        /// <param name="relaxedLoop">Loop flag for the relaxed animation.</param>
+        /// <param name="cueSet">Optional explicit cue set, overriding the character-derived one.</param>
+        public static ModAnimStateMachine StandardCue(Node visualsRoot, CharacterModel? character,
+            string idleName,
+            string? deadName = null, bool deadLoop = false,
+            string? hitName = null, bool hitLoop = false,
+            string? attackName = null, bool attackLoop = false,
+            string? castName = null, bool castLoop = false,
+            string? relaxedName = null, bool relaxedLoop = true,
+            VisualCueSet? cueSet = null)
+        {
+            ArgumentNullException.ThrowIfNull(visualsRoot);
+            ArgumentException.ThrowIfNullOrWhiteSpace(idleName);
+
+            var builder = ModAnimStateMachineBuilder.Create()
+                .AddState(idleName, true).AsInitial().Done();
+
+            AddOptional(builder, deadName, deadLoop, idleName, false);
+            AddOptional(builder, hitName, hitLoop, idleName, true);
+            AddOptional(builder, attackName, attackLoop, idleName, true);
+            AddOptional(builder, castName, castLoop, idleName, true);
+
+            var relaxedTarget = idleName;
+            if (relaxedName != null && !string.Equals(relaxedName, idleName, StringComparison.Ordinal))
+            {
+                builder.AddState(relaxedName, relaxedLoop).Done();
+                builder.AddBranch(relaxedName, "Idle", idleName);
+                relaxedTarget = relaxedName;
+            }
+
+            builder.AddAnyState("Idle", idleName);
+            builder.AddAnyState("Dead", deadName ?? idleName);
+            builder.AddAnyState("Hit", hitName ?? idleName);
+            builder.AddAnyState("Attack", attackName ?? idleName);
+            builder.AddAnyState("Cast", castName ?? idleName);
+            builder.AddAnyState("Relaxed", relaxedTarget);
+
+            return builder.BuildForVisualsRoot(visualsRoot, character, cueSet);
+        }
+
+        private static void AddOptional(ModAnimStateMachineBuilder builder, string? name, bool loop, string idleName,
+            bool hasNext)
+        {
+            if (name == null || string.Equals(name, idleName, StringComparison.Ordinal))
+                return;
+
+            var scope = builder.AddState(name, loop);
+            if (hasNext)
+                scope.WithNext(idleName);
+        }
+    }
+}

--- a/Utils/SavedAttachedState.cs
+++ b/Utils/SavedAttachedState.cs
@@ -121,10 +121,8 @@ namespace STS2RitsuLib.Utils
 
             public bool Export(object model, SavedProperties props)
             {
-                if (!owner.TryGetValue((TSavedKey)model, out var value))
-                    return false;
-
-                return SavedAttachedStateRegistry.AddToProperties(props, Name, value);
+                return owner.TryGetValue((TSavedKey)model, out var value) &&
+                       SavedAttachedStateRegistry.AddToProperties(props, Name, value);
             }
 
             public void Import(object model, SavedProperties props)


### PR DESCRIPTION
This pull request adds comprehensive documentation for the creature visuals and animation pipeline, updates the documentation index in both English and Chinese, and includes minor code and resource management improvements. The main focus is on clarifying how modders can provide custom visuals and animation state machines for creatures, including non-Spine animation support. Additionally, there are small code quality improvements.

**Documentation improvements:**

* Added a new document, `CreatureVisualsAndAnimation.md`, detailing the runtime interfaces for custom creature visuals and animation state machines, including non-Spine support and migration guidance for modders.
* Updated the documentation index in both English and Chinese (`README.md`) to include the new creature visuals and animation documentation. [[1]](diffhunk://#diff-60364fd4156ab1d5407648b475dcebfa82454232dc701161659c63e4d858e5f8R29) [[2]](diffhunk://#diff-60364fd4156ab1d5407648b475dcebfa82454232dc701161659c63e4d858e5f8R73)

**Code and resource management improvements:**

* In `AudioHandleBase.cs`, added `GC.SuppressFinalize(this)` in `Dispose()` to prevent redundant finalization and improve resource management.
* In `GuidMappedNaudioStudioProxy.cs`, removed unnecessary null-forgiving operator to simplify code and improve null-safety.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core animation trigger routing and adds new Harmony patches/factories that can change combat/merchant visual behavior for modded creatures; issues would surface as missing/incorrect animations or trigger sequencing.
> 
> **Overview**
> Adds a new backend-agnostic creature animation pipeline: `ModAnimStateMachine` + builder, multiple `IAnimationBackend` implementations (cue sequences/textures, `AnimationPlayer`, `AnimatedSprite2D`, Spine) and a composite backend with explicit queue/stop semantics.
> 
> Extends the mod runtime factory surface by introducing unified `IModCreatureVisualsFactory`/`IModCreatureAnimatorFactory` (with obsolete aliases preserved) and wiring new Harmony routing patches for `CreateVisuals`, `GenerateAnimator`, and non-Spine trigger routing (including merchant/rest-site), plus opt-in lifecycle trigger postfixes to emit `Dead`/`Revive` for non-Spine creatures.
> 
> Updates cue playback to recognize `Stun`, registers the new patches, and adds new EN/ZH documentation (`CreatureVisualsAndAnimation.md`) and README index links; includes a few small correctness/cleanup tweaks (audio dispose `GC.SuppressFinalize`, minor parsing/serialization simplifications, null-safety tweak).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b0a2e0d3444c76a266506ce49017898e7a1d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->