### PR TITLE
Introduce option injection for ancient events and update documentation

### DIFF
--- a/Content/ModContentRegistry.AncientOptions.cs
+++ b/Content/ModContentRegistry.AncientOptions.cs
@@ -1,0 +1,28 @@
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Scaffolding.Ancients.Options;
+
+namespace STS2RitsuLib.Content
+{
+    public sealed partial class ModContentRegistry
+    {
+        /// <summary>
+        ///     Registers an initial-option injection rule for <typeparamref name="TAncient" />.
+        /// </summary>
+        public void RegisterAncientOption<TAncient>(ModAncientOptionRule rule)
+            where TAncient : AncientEventModel
+        {
+            EnsureMutable("register ancient option rule");
+            ModAncientOptionRegistry.Register<TAncient>(ModId, rule);
+        }
+
+        /// <summary>
+        ///     Registers an initial-option injection rule for <paramref name="ancientType" />.
+        /// </summary>
+        public void RegisterAncientOption(Type ancientType, ModAncientOptionRule rule)
+        {
+            ArgumentNullException.ThrowIfNull(ancientType);
+            EnsureMutable($"register ancient option rule for '{ancientType.Name}'");
+            ModAncientOptionRegistry.Register(ancientType, ModId, rule);
+        }
+    }
+}

--- a/Docs/en/CustomEvents.md
+++ b/Docs/en/CustomEvents.md
@@ -257,6 +257,51 @@ The same principle applies: keep option keys, page keys, and the final registere
 
 ---
 
+## Add conditional options to a target ancient
+
+If you want to append extra options to an **existing ancient** (including vanilla ancients) without modifying the ancient class itself, register `ModAncientOptionRule`.
+
+```csharp
+using MegaCrit.Sts2.Core.Models.Events;
+using STS2RitsuLib.Scaffolding.Ancients.Options;
+
+RitsuLibFramework.CreateContentPack("MyMod")
+    .AncientOption<Neow>(
+        new ModAncientOptionRule(ancient =>
+            [
+                new EventOption(
+                    ancient,
+                    () =>
+                    {
+                        ancient.SetEventFinished(ancient.L10NLookup("NEOW.pages.DONE.description"));
+                        return Task.CompletedTask;
+                    },
+                    "NEOW.pages.INITIAL.options.MYMOD_BONUS")
+            ])
+        {
+            Condition = ancient => ancient.Owner?.Character is MyCharacter,
+            Priority = 100,
+        })
+    .Apply();
+```
+
+Rule fields:
+
+- `Condition`: optional gate; option injection runs only when this returns `true`
+- `Priority`: execution order (higher runs first)
+- `SkipDuplicateTextKeys`: default `true`; skips duplicate `TextKey` options
+
+You can also register directly via framework API:
+
+```csharp
+RitsuLibFramework.RegisterAncientOption<Neow>(
+    "MyMod",
+    new ModAncientOptionRule(...)
+);
+```
+
+---
+
 ## Related docs
 
 - [Content Authoring Toolkit](ContentAuthoringToolkit.md)

--- a/Docs/en/CustomEvents.md
+++ b/Docs/en/CustomEvents.md
@@ -262,6 +262,7 @@ The same principle applies: keep option keys, page keys, and the final registere
 If you want to append extra options to an **existing ancient** (including vanilla ancients) without modifying the ancient class itself, register `ModAncientOptionRule`.
 
 ```csharp
+using MegaCrit.Sts2.Core.Events;
 using MegaCrit.Sts2.Core.Models.Events;
 using STS2RitsuLib.Scaffolding.Ancients.Options;
 

--- a/Docs/zh/CustomEvents.md
+++ b/Docs/zh/CustomEvents.md
@@ -257,6 +257,51 @@ public sealed class MyAncient : ModAncientEventTemplate
 
 ---
 
+## 给指定 Ancient 追加可条件化选项
+
+如果你要给**已有 Ancient（包括原版 Ancient）**追加额外选项，而不想改它本体，可以注册 `ModAncientOptionRule`。
+
+```csharp
+using MegaCrit.Sts2.Core.Models.Events;
+using STS2RitsuLib.Scaffolding.Ancients.Options;
+
+RitsuLibFramework.CreateContentPack("MyMod")
+    .AncientOption<Neow>(
+        new ModAncientOptionRule(ancient =>
+            [
+                new EventOption(
+                    ancient,
+                    () =>
+                    {
+                        ancient.SetEventFinished(ancient.L10NLookup("NEOW.pages.DONE.description"));
+                        return Task.CompletedTask;
+                    },
+                    "NEOW.pages.INITIAL.options.MYMOD_BONUS")
+            ])
+        {
+            Condition = ancient => ancient.Owner?.Character is MyCharacter,
+            Priority = 100,
+        })
+    .Apply();
+```
+
+规则字段说明：
+
+- `Condition`：可选条件，返回 `true` 才会注入
+- `Priority`：优先级（高优先级先执行）
+- `SkipDuplicateTextKeys`：默认 `true`，避免重复 `TextKey`
+
+也可以不用内容包，直接走框架入口：
+
+```csharp
+RitsuLibFramework.RegisterAncientOption<Neow>(
+    "MyMod",
+    new ModAncientOptionRule(...)
+);
+```
+
+---
+
 ## 相关文档
 
 - [内容注册规则](ContentAuthoringToolkit.md)

--- a/Docs/zh/CustomEvents.md
+++ b/Docs/zh/CustomEvents.md
@@ -262,6 +262,7 @@ public sealed class MyAncient : ModAncientEventTemplate
 如果你要给**已有 Ancient（包括原版 Ancient）**追加额外选项，而不想改它本体，可以注册 `ModAncientOptionRule`。
 
 ```csharp
+using MegaCrit.Sts2.Core.Events;
 using MegaCrit.Sts2.Core.Models.Events;
 using STS2RitsuLib.Scaffolding.Ancients.Options;
 

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -83,6 +83,7 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<LocTableGetLocStringCompatibilityPatch>();
             patcher.RegisterPatch<LocTableGetRawTextCompatibilityPatch>();
             patcher.RegisterPatch<AncientDialoguePopulateLocKeysPatch>();
+            patcher.RegisterPatch<AncientEventInitialOptionsRegistryPatch>();
             patcher.RegisterPatch<TheArchitectLoadDialogueMissingFallbackPatch>();
             patcher.RegisterPatch<ModelRegistryLifecyclePatch>();
             patcher.RegisterPatch<GameNodeLifecyclePatch>();

--- a/RitsuLibFramework.cs
+++ b/RitsuLibFramework.cs
@@ -5,6 +5,7 @@ using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Logging;
 using MegaCrit.Sts2.Core.Modding;
+using MegaCrit.Sts2.Core.Models;
 using STS2RitsuLib.Cards.FreePlay;
 using STS2RitsuLib.Combat.HealthBars;
 using STS2RitsuLib.Content;
@@ -14,6 +15,7 @@ using STS2RitsuLib.Interop;
 using STS2RitsuLib.Keywords;
 using STS2RitsuLib.Patching.Core;
 using STS2RitsuLib.RuntimeInput;
+using STS2RitsuLib.Scaffolding.Ancients.Options;
 using STS2RitsuLib.Scaffolding.Content;
 using STS2RitsuLib.Settings;
 using STS2RitsuLib.Timeline;
@@ -311,6 +313,15 @@ namespace STS2RitsuLib
         public static void RegisterFreePlayBinding(string bindingId, Func<CardPlay, bool> detector)
         {
             FreePlayBindingRegistry.Register(bindingId, detector);
+        }
+
+        /// <summary>
+        ///     Registers an initial-option injection rule for <typeparamref name="TAncient" />.
+        /// </summary>
+        public static void RegisterAncientOption<TAncient>(string modId, ModAncientOptionRule rule)
+            where TAncient : AncientEventModel
+        {
+            GetContentRegistry(modId).RegisterAncientOption<TAncient>(rule);
         }
 
         /// <summary>

--- a/Scaffolding/Ancients/Options/ModAncientOptionRegistry.cs
+++ b/Scaffolding/Ancients/Options/ModAncientOptionRegistry.cs
@@ -1,0 +1,162 @@
+using MegaCrit.Sts2.Core.Events;
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Content;
+
+namespace STS2RitsuLib.Scaffolding.Ancients.Options
+{
+    /// <summary>
+    ///     Global registration surface for ancient initial-option injection rules.
+    /// </summary>
+    public static class ModAncientOptionRegistry
+    {
+        private static readonly Lock SyncRoot = new();
+        private static readonly Dictionary<Type, List<RegisteredRule>> RulesByAncientType = [];
+        private static long _registrationCounter;
+
+        /// <summary>
+        ///     Registers an option rule for <typeparamref name="TAncient" />.
+        /// </summary>
+        public static void Register<TAncient>(string ownerModId, ModAncientOptionRule rule)
+            where TAncient : AncientEventModel
+        {
+            Register(typeof(TAncient), ownerModId, rule);
+        }
+
+        /// <summary>
+        ///     Registers an option rule for <paramref name="ancientType" />.
+        /// </summary>
+        public static void Register(Type ancientType, string ownerModId, ModAncientOptionRule rule)
+        {
+            ArgumentNullException.ThrowIfNull(ancientType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(ownerModId);
+            ArgumentNullException.ThrowIfNull(rule);
+
+            if (ModContentRegistry.IsFrozen)
+                throw new InvalidOperationException(
+                    "Cannot register ancient option rules after content registration has been frozen. " +
+                    "Register from your mod initializer before ModelDb initializes.");
+
+            if (ancientType.IsAbstract || !typeof(AncientEventModel).IsAssignableFrom(ancientType))
+                throw new ArgumentException(
+                    $"Type '{ancientType.FullName}' must be a concrete subtype of {typeof(AncientEventModel).FullName}.",
+                    nameof(ancientType));
+
+            var registered = new RegisteredRule(
+                ownerModId.Trim(),
+                rule,
+                Interlocked.Increment(ref _registrationCounter));
+
+            lock (SyncRoot)
+            {
+                if (!RulesByAncientType.TryGetValue(ancientType, out var list))
+                {
+                    list = [];
+                    RulesByAncientType[ancientType] = list;
+                }
+
+                list.Add(registered);
+            }
+        }
+
+        /// <summary>
+        ///     Clears all registered rules (for tests/hot reload tooling).
+        /// </summary>
+        public static void ClearForTests()
+        {
+            lock (SyncRoot)
+            {
+                RulesByAncientType.Clear();
+                _registrationCounter = 0;
+            }
+        }
+
+        internal static void AppendRegisteredOptions(AncientEventModel ancient, List<EventOption> options)
+        {
+            ArgumentNullException.ThrowIfNull(ancient);
+            ArgumentNullException.ThrowIfNull(options);
+
+            var existingTextKeys = new HashSet<string>(
+                options
+                    .Select(static option => option.TextKey)
+                    .Where(static textKey => !string.IsNullOrWhiteSpace(textKey)),
+                StringComparer.OrdinalIgnoreCase);
+
+            var snapshot = GetApplicableRulesSnapshot(ancient.GetType());
+            foreach (var registration in snapshot)
+            {
+                if (!ShouldApply(registration, ancient))
+                    continue;
+
+                IEnumerable<EventOption>? generated;
+                try
+                {
+                    generated = registration.Rule.OptionFactory(ancient);
+                }
+                catch (Exception ex)
+                {
+                    RitsuLibFramework.CreateLogger(registration.OwnerModId).Warn(
+                        $"[AncientOption] OptionFactory threw for ancient '{ancient.Id.Entry}': {ex.Message}");
+                    continue;
+                }
+
+                if (generated == null)
+                    continue;
+
+                foreach (var option in generated)
+                {
+                    if (option == null)
+                        continue;
+
+                    if (registration.Rule.SkipDuplicateTextKeys &&
+                        !string.IsNullOrWhiteSpace(option.TextKey) &&
+                        !existingTextKeys.Add(option.TextKey))
+                        continue;
+
+                    options.Add(option);
+                }
+            }
+        }
+
+        private static bool ShouldApply(RegisteredRule registration, AncientEventModel ancient)
+        {
+            var condition = registration.Rule.Condition;
+            if (condition == null)
+                return true;
+
+            try
+            {
+                return condition(ancient);
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.CreateLogger(registration.OwnerModId).Warn(
+                    $"[AncientOption] Condition threw for ancient '{ancient.Id.Entry}': {ex.Message}");
+                return false;
+            }
+        }
+
+        private static RegisteredRule[] GetApplicableRulesSnapshot(Type ancientType)
+        {
+            var collected = new List<RegisteredRule>();
+
+            lock (SyncRoot)
+            {
+                for (var type = ancientType;
+                     type != null && typeof(AncientEventModel).IsAssignableFrom(type);
+                     type = type.BaseType)
+                    if (RulesByAncientType.TryGetValue(type, out var list))
+                        collected.AddRange(list);
+            }
+
+            return collected
+                .OrderByDescending(static rule => rule.Rule.Priority)
+                .ThenBy(static rule => rule.RegistrationOrder)
+                .ToArray();
+        }
+
+        private readonly record struct RegisteredRule(
+            string OwnerModId,
+            ModAncientOptionRule Rule,
+            long RegistrationOrder);
+    }
+}

--- a/Scaffolding/Ancients/Options/ModAncientOptionRegistry.cs
+++ b/Scaffolding/Ancients/Options/ModAncientOptionRegistry.cs
@@ -87,15 +87,15 @@ namespace STS2RitsuLib.Scaffolding.Ancients.Options
                 if (!ShouldApply(registration, ancient))
                     continue;
 
-                IEnumerable<EventOption>? generated;
+                EventOption[]? generated;
                 try
                 {
-                    generated = registration.Rule.OptionFactory(ancient);
+                    generated = registration.Rule.OptionFactory(ancient)?.ToArray();
                 }
                 catch (Exception ex)
                 {
                     RitsuLibFramework.CreateLogger(registration.OwnerModId).Warn(
-                        $"[AncientOption] OptionFactory threw for ancient '{ancient.Id.Entry}': {ex.Message}");
+                        $"[AncientOption] OptionFactory threw for ancient '{ancient.Id.Entry}': {ex}");
                     continue;
                 }
 
@@ -107,10 +107,12 @@ namespace STS2RitsuLib.Scaffolding.Ancients.Options
                     if (option == null)
                         continue;
 
-                    if (registration.Rule.SkipDuplicateTextKeys &&
-                        !string.IsNullOrWhiteSpace(option.TextKey) &&
-                        !existingTextKeys.Add(option.TextKey))
-                        continue;
+                    if (!string.IsNullOrWhiteSpace(option.TextKey))
+                    {
+                        var isNewTextKey = existingTextKeys.Add(option.TextKey);
+                        if (registration.Rule.SkipDuplicateTextKeys && !isNewTextKey)
+                            continue;
+                    }
 
                     options.Add(option);
                 }
@@ -130,7 +132,7 @@ namespace STS2RitsuLib.Scaffolding.Ancients.Options
             catch (Exception ex)
             {
                 RitsuLibFramework.CreateLogger(registration.OwnerModId).Warn(
-                    $"[AncientOption] Condition threw for ancient '{ancient.Id.Entry}': {ex.Message}");
+                    $"[AncientOption] Condition threw for ancient '{ancient.Id.Entry}': {ex}");
                 return false;
             }
         }

--- a/Scaffolding/Ancients/Options/ModAncientOptionRule.cs
+++ b/Scaffolding/Ancients/Options/ModAncientOptionRule.cs
@@ -1,0 +1,66 @@
+using MegaCrit.Sts2.Core.Events;
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2RitsuLib.Scaffolding.Ancients.Options
+{
+    /// <summary>
+    ///     Declarative rule for injecting extra options into an ancient's initial option pool.
+    /// </summary>
+    public sealed class ModAncientOptionRule
+    {
+        /// <summary>
+        ///     Creates a rule with an option factory.
+        /// </summary>
+        /// <param name="optionFactory">
+        ///     Produces zero or more options for the current ancient instance.
+        /// </param>
+        public ModAncientOptionRule(Func<AncientEventModel, IEnumerable<EventOption>> optionFactory)
+        {
+            ArgumentNullException.ThrowIfNull(optionFactory);
+            OptionFactory = optionFactory;
+        }
+
+        /// <summary>
+        ///     Produces options to append for a matching ancient instance.
+        /// </summary>
+        public Func<AncientEventModel, IEnumerable<EventOption>> OptionFactory { get; }
+
+        /// <summary>
+        ///     Optional predicate gate. When null, the rule is always considered.
+        /// </summary>
+        public Func<AncientEventModel, bool>? Condition { get; init; }
+
+        /// <summary>
+        ///     Higher priority rules run first; ties preserve registration order.
+        /// </summary>
+        public int Priority { get; init; }
+
+        /// <summary>
+        ///     When true, options with duplicate <see cref="EventOption.TextKey" /> are skipped.
+        /// </summary>
+        public bool SkipDuplicateTextKeys { get; init; } = true;
+
+        /// <summary>
+        ///     Convenience helper for a single optional option.
+        /// </summary>
+        public static ModAncientOptionRule Single(
+            Func<AncientEventModel, EventOption?> optionFactory,
+            Func<AncientEventModel, bool>? condition = null,
+            int priority = 0,
+            bool skipDuplicateTextKeys = true)
+        {
+            ArgumentNullException.ThrowIfNull(optionFactory);
+
+            return new(ancient =>
+            {
+                var option = optionFactory(ancient);
+                return option == null ? [] : [option];
+            })
+            {
+                Condition = condition,
+                Priority = priority,
+                SkipDuplicateTextKeys = skipDuplicateTextKeys,
+            };
+        }
+    }
+}

--- a/Scaffolding/Content/ContentRegistrationEntries.cs
+++ b/Scaffolding/Content/ContentRegistrationEntries.cs
@@ -2,6 +2,7 @@ using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Relics;
 using STS2RitsuLib.Combat.HealthBars;
 using STS2RitsuLib.Content;
+using STS2RitsuLib.Scaffolding.Ancients.Options;
 using STS2RitsuLib.Scaffolding.Cards.HandGlow;
 using STS2RitsuLib.Scaffolding.Cards.HandOutline;
 
@@ -474,6 +475,19 @@ namespace STS2RitsuLib.Scaffolding.Content
         public void Register(ModContentRegistry registry)
         {
             registry.RegisterActAncient<TAct, TAncient>();
+        }
+    }
+
+    /// <summary>
+    ///     Registers extra initial-option injection rules for a specific ancient model type.
+    /// </summary>
+    public sealed class AncientOptionRegistrationEntry<TAncient>(ModAncientOptionRule rule) : IContentRegistrationEntry
+        where TAncient : AncientEventModel
+    {
+        /// <inheritdoc />
+        public void Register(ModContentRegistry registry)
+        {
+            registry.RegisterAncientOption<TAncient>(rule);
         }
     }
 

--- a/Scaffolding/Content/ModContentPackBuilder.cs
+++ b/Scaffolding/Content/ModContentPackBuilder.cs
@@ -4,6 +4,7 @@ using MegaCrit.Sts2.Core.Timeline;
 using STS2RitsuLib.Combat.HealthBars;
 using STS2RitsuLib.Content;
 using STS2RitsuLib.Keywords;
+using STS2RitsuLib.Scaffolding.Ancients.Options;
 using STS2RitsuLib.Scaffolding.Cards.HandGlow;
 using STS2RitsuLib.Scaffolding.Cards.HandOutline;
 using STS2RitsuLib.Timeline;
@@ -459,6 +460,15 @@ namespace STS2RitsuLib.Scaffolding.Content
             where TAncient : AncientEventModel
         {
             return AddStep(ctx => ctx.Content.RegisterActAncient<TAct, TAncient>());
+        }
+
+        /// <summary>
+        ///     Queues <see cref="ModContentRegistry.RegisterAncientOption{TAncient}" /> for injecting extra initial options.
+        /// </summary>
+        public ModContentPackBuilder AncientOption<TAncient>(ModAncientOptionRule rule)
+            where TAncient : AncientEventModel
+        {
+            return AddStep(ctx => ctx.Content.RegisterAncientOption<TAncient>(rule));
         }
 
         /// <summary>

--- a/Scaffolding/Content/Patches/AncientEventInitialOptionsRegistryPatch.cs
+++ b/Scaffolding/Content/Patches/AncientEventInitialOptionsRegistryPatch.cs
@@ -1,0 +1,63 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Events;
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Patching.Models;
+using STS2RitsuLib.Scaffolding.Ancients.Options;
+
+namespace STS2RitsuLib.Scaffolding.Content.Patches
+{
+    /// <summary>
+    ///     Appends registered mod rules into <see cref="AncientEventModel" /> initial options after vanilla generation.
+    /// </summary>
+    public class AncientEventInitialOptionsRegistryPatch : IPatchMethod
+    {
+        private static readonly AccessTools.FieldRef<AncientEventModel, List<EventOption>?> GeneratedOptionsRef =
+            AccessTools.FieldRefAccess<AncientEventModel, List<EventOption>?>("_generatedOptions");
+
+        /// <inheritdoc cref="IPatchMethod.PatchId" />
+        public static string PatchId => "ancient_event_initial_options_registry";
+
+        /// <inheritdoc cref="IPatchMethod.Description" />
+        public static string Description =>
+            "Append ModAncientOptionRegistry results into AncientEventModel initial option list";
+
+        /// <inheritdoc cref="IPatchMethod.IsCritical" />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc cref="IPatchMethod.GetTargets" />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(AncientEventModel), "GenerateInitialOptionsWrapper")];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Appends matching registered options after vanilla generated initial options are materialized.
+        /// </summary>
+        public static void Postfix(AncientEventModel __instance, ref IReadOnlyList<EventOption> __result)
+            // ReSharper restore InconsistentNaming
+        {
+            if (ShouldSkipInjection(__result))
+                return;
+
+            var mutable = __result as List<EventOption> ?? __result.ToList();
+            var countBefore = mutable.Count;
+            ModAncientOptionRegistry.AppendRegisteredOptions(__instance, mutable);
+
+            if (mutable.Count == countBefore)
+                return;
+
+            GeneratedOptionsRef(__instance) = mutable;
+            __result = mutable;
+        }
+
+        private static bool ShouldSkipInjection(IReadOnlyList<EventOption> options)
+        {
+            if (options.Count != 1)
+                return false;
+
+            var only = options[0];
+            return only.IsProceed && string.Equals(only.TextKey, "PROCEED", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new system for mods to inject custom, conditional options into the initial option pool of existing "ancient" events (including vanilla ones) in the game. It provides both a declarative API and framework integration for registering these option injection rules, ensures proper patching of the game's option generation, and documents the new feature in both English and Chinese.

**Ancient Event Option Injection System:**

- Added a global registry (`ModAncientOptionRegistry`) and rule class (`ModAncientOptionRule`) to allow mods to declaratively inject extra options into any ancient event's initial options, with support for conditions, priority, and duplicate filtering. [[1]](diffhunk://#diff-9c09b21b5566ba8940f8167805cf881afed635089c6602b018acf5a823d8534fR1-R162) [[2]](diffhunk://#diff-337d2a6f49cd90901b31ce9fc194ec7ee1b5ffba6e757b3145af50ae113a7373R1-R66)
- Integrated the registration API into the mod content registry and framework, including new methods in `ModContentRegistry`, `RitsuLibFramework`, and content pack builder, as well as a content registration entry for content packs. [[1]](diffhunk://#diff-0fc1b69f3869584a738f21b9c82075f08c75ff13c446bec6042b2577e1c945a3R1-R28) [[2]](diffhunk://#diff-8e857be736a0d755bf9820976097fe33ed0af2c49db562ede45bfc1ad290023bR318-R326) [[3]](diffhunk://#diff-a2e925851147ff684cfca87c121af74b6bccd5e66e4cf81f7f89c419bf64124fR465-R473) [[4]](diffhunk://#diff-8a0c8a0903b3efbfb1bf61ae218f6c32aa00e7fc95bc3876e1eb8b920e0365b1R481-R493)
- Implemented a Harmony patch (`AncientEventInitialOptionsRegistryPatch`) to append registered mod options to the ancient event's initial options after vanilla options are generated. [[1]](diffhunk://#diff-d9c59f738c89e9f2864f358a5cdb12b7fde6d84444cb49246b06fb90fd35dc68R1-R63) [[2]](diffhunk://#diff-f7c0678c3622ade8d1972d710bec2ab5c166e38d57fff28bcad4146cf0a31466R86)

**Documentation:**

- Added English and Chinese documentation explaining how to use the new ancient option injection system, including code examples and field descriptions. [[1]](diffhunk://#diff-e7fbbcd20dc078d03762ebed0368704fec1bc28b23af7b8ef4ce9e132c67ed6aR260-R304) [[2]](diffhunk://#diff-f41423e636d51b07545abf762a0a1c8b4b9edc51c53e8fd9955829d665fc6e3aR260-R304)

**Dependency and Import Updates:**

- Updated relevant files to import the new scaffolding and registry types where needed. [[1]](diffhunk://#diff-8a0c8a0903b3efbfb1bf61ae218f6c32aa00e7fc95bc3876e1eb8b920e0365b1R5) [[2]](diffhunk://#diff-a2e925851147ff684cfca87c121af74b6bccd5e66e4cf81f7f89c419bf64124fR7) [[3]](diffhunk://#diff-8e857be736a0d755bf9820976097fe33ed0af2c49db562ede45bfc1ad290023bR8) [[4]](diffhunk://#diff-8e857be736a0d755bf9820976097fe33ed0af2c49db562ede45bfc1ad290023bR18)

These changes provide a flexible and robust way for modders to enhance or customize ancient events without modifying their core logic, improving mod interoperability and extensibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new global registry and Harmony patch that alters `AncientEventModel` initial option generation; incorrect rules or patch edge cases could affect event UI/options across all runs.
> 
> **Overview**
> Adds a new **ancient initial-option injection** feature so mods can append options to existing (including vanilla) ancients via `ModAncientOptionRule` (condition, priority, duplicate text-key filtering) registered through `ModContentRegistry`, `RitsuLibFramework.RegisterAncientOption`, and the content pack builder (`AncientOption<TAncient>`).
> 
> Hooks the behavior into runtime by registering `AncientEventInitialOptionsRegistryPatch`, which post-processes `AncientEventModel.GenerateInitialOptionsWrapper` results to append mod-provided options (with a guard to skip the single `PROCEED` sentinel case). Documentation is updated in both `Docs/en/CustomEvents.md` and `Docs/zh/CustomEvents.md` with usage examples and rule field descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4488715bc8928696d716c3278be5ab1f2222ed73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->