### PR TITLE
Introduce mod card pile system with UI integration and management

### DIFF
--- a/CardPiles/IModCardPileHandler.cs
+++ b/CardPiles/IModCardPileHandler.cs
@@ -1,0 +1,23 @@
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Optional handler contract implemented by classes that declare themselves with
+    ///     <see cref="STS2RitsuLib.Interop.AutoRegistration.RegisterOwnedCardPileAttribute" />. When the
+    ///     attribute sees a type implementing this interface, the auto-registration pipeline instantiates
+    ///     the type once (requires a parameterless constructor) and wires its
+    ///     <see cref="OnOpen" /> method into <see cref="ModCardPileSpec.OnOpen" />.
+    /// </summary>
+    /// <remarks>
+    ///     The interface is entirely optional — annotated types may leave the button to open the default
+    ///     <c>NCardPileScreen</c>. Handler instances are cached per registered pile, so the same instance
+    ///     services every click for that pile's lifetime.
+    /// </remarks>
+    public interface IModCardPileHandler
+    {
+        /// <summary>
+        ///     Invoked when the pile's UI button is released. See <see cref="ModCardPileSpec.OnOpen" /> for
+        ///     the full contract (empty-pile short-circuit, open-default-screen toggle, etc.).
+        /// </summary>
+        void OnOpen(ModCardPileOpenContext context);
+    }
+}

--- a/CardPiles/ModCardPile.cs
+++ b/CardPiles/ModCardPile.cs
@@ -1,0 +1,26 @@
+using MegaCrit.Sts2.Core.Entities.Cards;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Runtime instance of a mod card pile. Behaves as a vanilla <see cref="CardPile" /> and simply carries
+    ///     a back-reference to its <see cref="ModCardPileDefinition" /> so UI and patch code can look up mod
+    ///     metadata (icon, localization, style).
+    /// </summary>
+    public sealed class ModCardPile : CardPile
+    {
+        /// <summary>
+        ///     Creates a pile whose <see cref="CardPile.Type" /> matches <paramref name="definition" />'s minted value.
+        /// </summary>
+        /// <param name="definition">Registry entry this pile was created from.</param>
+        public ModCardPile(ModCardPileDefinition definition) : base(definition.PileType)
+        {
+            Definition = definition;
+        }
+
+        /// <summary>
+        ///     Back-reference to the immutable definition this pile was built from.
+        /// </summary>
+        public ModCardPileDefinition Definition { get; }
+    }
+}

--- a/CardPiles/ModCardPileAnchor.cs
+++ b/CardPiles/ModCardPileAnchor.cs
@@ -1,0 +1,91 @@
+using Godot;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Location hint for a mod card pile's UI node or fly-in target. Explicit anchors take precedence over
+    ///     style defaults; when no anchor is provided, ritsulib auto-stacks same-style piles in registration
+    ///     order ("explicit anchor + auto-stack fallback").
+    /// </summary>
+    public enum ModCardPileAnchorKind
+    {
+        /// <summary>
+        ///     Let the style's default slot decide; multiple entries auto-stack along the style axis.
+        /// </summary>
+        StyleDefault = 0,
+
+        /// <summary>
+        ///     Near the bottom-left draw-pile button (auto-stacks leftwards on overflow).
+        /// </summary>
+        BottomLeftPrimary = 1,
+
+        /// <summary>
+        ///     Near the bottom-left discard button (auto-stacks rightwards on overflow).
+        /// </summary>
+        BottomLeftSecondary = 2,
+
+        /// <summary>
+        ///     Near the bottom-right exhaust button (auto-stacks leftwards on overflow).
+        /// </summary>
+        BottomRightPrimary = 3,
+
+        /// <summary>
+        ///     Reserved for a future second bottom-right slot; stacks left of the primary.
+        /// </summary>
+        BottomRightSecondary = 4,
+
+        /// <summary>
+        ///     Slot in the top bar immediately after the vanilla deck button.
+        /// </summary>
+        TopBarAfterDeck = 5,
+
+        /// <summary>
+        ///     Slot in the top bar before the right-most modifier cluster.
+        /// </summary>
+        TopBarBeforeModifiers = 6,
+
+        /// <summary>
+        ///     Centered above the vanilla hand (used by <see cref="ModCardPileUiStyle.ExtraHand" />).
+        /// </summary>
+        ExtraHandAbove = 7,
+
+        /// <summary>
+        ///     Centered below the vanilla hand (used by <see cref="ModCardPileUiStyle.ExtraHand" />).
+        /// </summary>
+        ExtraHandBelow = 8,
+
+        /// <summary>
+        ///     User-specified absolute coordinate (resolved via <see cref="ModCardPileAnchor.CustomPosition" />).
+        /// </summary>
+        Custom = 9,
+    }
+
+    /// <summary>
+    ///     UI anchoring descriptor paired with <see cref="ModCardPileUiStyle" />. Combines a discrete slot kind
+    ///     with an optional pixel offset (and an absolute position for <see cref="ModCardPileAnchorKind.Custom" />).
+    /// </summary>
+    /// <param name="Kind">Discrete slot the pile wants to attach to.</param>
+    /// <param name="Offset">Additional pixel offset applied on top of the resolved slot position.</param>
+    /// <param name="CustomPosition">
+    ///     Absolute viewport coordinate used only when <see cref="Kind" /> is
+    ///     <see cref="ModCardPileAnchorKind.Custom" />; otherwise ignored.
+    /// </param>
+    public readonly record struct ModCardPileAnchor(
+        ModCardPileAnchorKind Kind,
+        Vector2 Offset = default,
+        Vector2 CustomPosition = default)
+    {
+        /// <summary>
+        ///     Convenience anchor that falls back to the style's default slot.
+        /// </summary>
+        public static ModCardPileAnchor Default { get; } = new(ModCardPileAnchorKind.StyleDefault);
+
+        /// <summary>
+        ///     Builds a <see cref="ModCardPileAnchorKind.Custom" /> anchor at <paramref name="position" />.
+        /// </summary>
+        public static ModCardPileAnchor AtPosition(Vector2 position)
+        {
+            return new(ModCardPileAnchorKind.Custom, Vector2.Zero, position);
+        }
+    }
+}

--- a/CardPiles/ModCardPileDefinition.cs
+++ b/CardPiles/ModCardPileDefinition.cs
@@ -1,0 +1,141 @@
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Localization;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Immutable registry entry for a mod card pile. Produced by <see cref="ModCardPileRegistry" /> and keyed
+    ///     by both the normalized id and the deterministically minted <see cref="PileType" /> value.
+    /// </summary>
+    /// <remarks>
+    ///     Localization follows the vanilla pile convention: the hover-tip title / description and
+    ///     empty-pile message are always resolved against <see cref="ModCardPileSpec.HoverTipLocTable" />
+    ///     (<c>static_hover_tips</c>) using the keys <c>"{LocStem}.title"</c>,
+    ///     <c>"{LocStem}.description"</c> and <c>"{LocStem}.empty"</c>. See
+    ///     <see cref="ModCardPileSpec.LocStem" /> for the authoring contract.
+    /// </remarks>
+    public sealed record ModCardPileDefinition
+    {
+        /// <summary>
+        ///     Primary constructor used by the registry; all fields are immutable once registered.
+        /// </summary>
+        /// <param name="modId">Owning mod id (<c>com.example.my-mod</c>).</param>
+        /// <param name="id">Normalized global id (<c>NormalizeId</c> output from <see cref="ModCardPileRegistry" />).</param>
+        /// <param name="pileType">Minted <see cref="PileType" /> value that represents this pile at runtime.</param>
+        /// <param name="scope">Lifetime scope.</param>
+        /// <param name="style">UI chrome style.</param>
+        /// <param name="anchor">UI slot hint.</param>
+        /// <param name="iconPath">Optional Godot resource path for the pile icon.</param>
+        /// <param name="locStem">
+        ///     Localization stem used to build title / description / empty-pile keys in
+        ///     <see cref="ModCardPileSpec.HoverTipLocTable" />. Null means "use the normalized id as stem".
+        /// </param>
+        /// <param name="hotkeys">Optional hotkey ids for the pile button.</param>
+        /// <param name="cardShouldBeVisible">Whether cards render as <c>NCard</c> nodes inside the pile container.</param>
+        /// <param name="onOpen">
+        ///     Optional callback invoked when the pile's UI button is released (see <see cref="OnOpen" />).
+        /// </param>
+        public ModCardPileDefinition(
+            string modId,
+            string id,
+            PileType pileType,
+            ModCardPileScope scope,
+            ModCardPileUiStyle style,
+            ModCardPileAnchor anchor,
+            string? iconPath,
+            string? locStem,
+            string[]? hotkeys,
+            bool cardShouldBeVisible,
+            Action<ModCardPileOpenContext>? onOpen = null)
+        {
+            ModId = modId;
+            Id = id;
+            PileType = pileType;
+            Scope = scope;
+            Style = style;
+            Anchor = anchor;
+            IconPath = iconPath;
+            LocStem = string.IsNullOrWhiteSpace(locStem) ? id : locStem;
+            Hotkeys = hotkeys;
+            CardShouldBeVisible = cardShouldBeVisible;
+            OnOpen = onOpen;
+        }
+
+        /// <summary>
+        ///     Owning mod id.
+        /// </summary>
+        public string ModId { get; }
+
+        /// <summary>
+        ///     Normalized global id (lowercased, trimmed).
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        ///     Deterministically minted <see cref="PileType" /> value.
+        /// </summary>
+        public PileType PileType { get; }
+
+        /// <summary>
+        ///     Lifetime scope declared at registration.
+        /// </summary>
+        public ModCardPileScope Scope { get; }
+
+        /// <summary>
+        ///     UI chrome style.
+        /// </summary>
+        public ModCardPileUiStyle Style { get; }
+
+        /// <summary>
+        ///     UI slot hint.
+        /// </summary>
+        public ModCardPileAnchor Anchor { get; }
+
+        /// <summary>
+        ///     Icon resource path (<c>res://...</c>); null falls back to a placeholder icon.
+        /// </summary>
+        public string? IconPath { get; }
+
+        /// <summary>
+        ///     Localization stem (never null; defaults to <see cref="Id" /> when the spec left it unset).
+        ///     Combined with <see cref="ModCardPileSpec.HoverTipLocTable" /> to produce title / description
+        ///     / empty-pile keys.
+        /// </summary>
+        public string LocStem { get; }
+
+        /// <summary>
+        ///     Hover-tip title resolved against <see cref="ModCardPileSpec.HoverTipLocTable" /> with key
+        ///     <c>"{LocStem}.title"</c>.
+        /// </summary>
+        public LocString Title => new(ModCardPileSpec.HoverTipLocTable, $"{LocStem}.title");
+
+        /// <summary>
+        ///     Hover-tip description resolved against <see cref="ModCardPileSpec.HoverTipLocTable" /> with
+        ///     key <c>"{LocStem}.description"</c>.
+        /// </summary>
+        public LocString Description => new(ModCardPileSpec.HoverTipLocTable, $"{LocStem}.description");
+
+        /// <summary>
+        ///     Message displayed when the pile is opened while empty; resolved against
+        ///     <see cref="ModCardPileSpec.HoverTipLocTable" /> with key <c>"{LocStem}.empty"</c>.
+        /// </summary>
+        public LocString EmptyPileMessage => new(ModCardPileSpec.HoverTipLocTable, $"{LocStem}.empty");
+
+        /// <summary>
+        ///     Hotkey ids (see <c>MegaInput</c>) forwarded to <c>NCardPileScreen.ShowScreen</c>.
+        /// </summary>
+        public string[]? Hotkeys { get; }
+
+        /// <summary>
+        ///     When true, the pile renders cards as <c>NCard</c> nodes (only meaningful for
+        ///     <see cref="ModCardPileUiStyle.ExtraHand" />).
+        /// </summary>
+        public bool CardShouldBeVisible { get; }
+
+        /// <summary>
+        ///     Handler invoked when the pile's UI button is released. Null means "use the default
+        ///     <c>NCardPileScreen</c>". See <see cref="ModCardPileSpec.OnOpen" /> for the full contract.
+        /// </summary>
+        public Action<ModCardPileOpenContext>? OnOpen { get; }
+    }
+}

--- a/CardPiles/ModCardPileDefinition.cs
+++ b/CardPiles/ModCardPileDefinition.cs
@@ -67,7 +67,7 @@ namespace STS2RitsuLib.CardPiles
         public string ModId { get; }
 
         /// <summary>
-        ///     Normalized global id (lowercased, trimmed).
+        ///     Normalized global id (trimmed).
         /// </summary>
         public string Id { get; }
 

--- a/CardPiles/ModCardPileHoverTipFactory.cs
+++ b/CardPiles/ModCardPileHoverTipFactory.cs
@@ -1,0 +1,32 @@
+using Godot;
+using MegaCrit.Sts2.Core.HoverTips;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Builds a vanilla <see cref="HoverTip" /> for a <see cref="ModCardPileDefinition" /> by combining its
+    ///     localized title / description (resolved against <see cref="ModCardPileSpec.HoverTipLocTable" />)
+    ///     with the icon texture loaded from <c>IconPath</c>. Mirrors <c>ModKeywordRegistry.CreateHoverTip</c>
+    ///     so the same hover UX is available for piles.
+    /// </summary>
+    public static class ModCardPileHoverTipFactory
+    {
+        /// <summary>
+        ///     Produces a <see cref="HoverTip" /> for <paramref name="definition" />. Title and description
+        ///     come from <see cref="ModCardPileDefinition.Title" /> / <see cref="ModCardPileDefinition.Description" />
+        ///     (both derived from <see cref="ModCardPileDefinition.LocStem" />), and the icon is loaded
+        ///     from <c>ResourceLoader</c> when <see cref="ModCardPileDefinition.IconPath" /> exists.
+        /// </summary>
+        public static HoverTip Create(ModCardPileDefinition definition)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+
+            Texture2D? icon = null;
+            if (!string.IsNullOrWhiteSpace(definition.IconPath)
+                && ResourceLoader.Exists(definition.IconPath))
+                icon = ResourceLoader.Load<Texture2D>(definition.IconPath);
+
+            return new(definition.Title, definition.Description, icon);
+        }
+    }
+}

--- a/CardPiles/ModCardPileInjector.cs
+++ b/CardPiles/ModCardPileInjector.cs
@@ -32,13 +32,8 @@ namespace STS2RitsuLib.CardPiles
             if (leftDefinitions.Length == 0 && rightDefinitions.Length == 0)
                 return;
 
-            var drawPile = container.DrawPile;
-            var exhaustPile = container.ExhaustPile;
-
-            MountBottomButtons(container, leftDefinitions, drawPile,
-                new(BottomLeftStackDeltaX, 0f));
-            MountBottomButtons(container, rightDefinitions, exhaustPile,
-                new(BottomRightStackDeltaX, 0f));
+            MountBottomLeftButtons(container, leftDefinitions);
+            MountBottomRightButtons(container, rightDefinitions);
         }
 
         /// <summary>
@@ -61,6 +56,10 @@ namespace STS2RitsuLib.CardPiles
                 var anchor = definition.Anchor;
                 if (anchor.Kind == ModCardPileAnchorKind.Custom)
                     button.Position = anchor.CustomPosition + anchor.Offset;
+                else if (anchor.Kind == ModCardPileAnchorKind.TopBarAfterDeck)
+                    ModTopBarLayout.PlaceAfterDeck(topBar, button, anchor.Offset);
+                else if (anchor.Kind == ModCardPileAnchorKind.TopBarBeforeModifiers)
+                    ModTopBarLayout.PlaceBeforeModifiers(topBar, button, anchor.Offset);
                 else
                     ModTopBarLayout.Place(topBar, button, anchor.Offset);
             }
@@ -107,13 +106,12 @@ namespace STS2RitsuLib.CardPiles
                     child.Initialize(player);
         }
 
-        private static void MountBottomButtons(
+        private static void MountBottomLeftButtons(
             NCombatPilesContainer container,
-            ModCardPileDefinition[] definitions,
-            Control anchorNode,
-            Vector2 fallbackDelta)
+            ModCardPileDefinition[] definitions)
         {
-            var index = 0;
+            var primaryIndex = 0;
+            var secondaryIndex = 0;
             foreach (var definition in definitions)
             {
                 var button = NModCardPileButton.Create(definition);
@@ -121,10 +119,57 @@ namespace STS2RitsuLib.CardPiles
                 if (anchor.Kind == ModCardPileAnchorKind.Custom)
                     button.Position = anchor.CustomPosition + anchor.Offset;
                 else
-                    button.Position = anchorNode.Position + fallbackDelta * (index + 1) + anchor.Offset;
+                    switch (anchor.Kind)
+                    {
+                        case ModCardPileAnchorKind.BottomLeftSecondary:
+                            button.Position = container.DiscardPile.Position
+                                              + new Vector2(100f * (secondaryIndex + 1), 0f)
+                                              + anchor.Offset;
+                            secondaryIndex++;
+                            break;
+                        default:
+                            button.Position = container.DrawPile.Position
+                                              + new Vector2(BottomLeftStackDeltaX * (primaryIndex + 1), 0f)
+                                              + anchor.Offset;
+                            primaryIndex++;
+                            break;
+                    }
 
                 container.AddChildSafely(button);
-                index++;
+            }
+        }
+
+        private static void MountBottomRightButtons(
+            NCombatPilesContainer container,
+            ModCardPileDefinition[] definitions)
+        {
+            var primaryIndex = 0;
+            var secondaryIndex = 0;
+            foreach (var definition in definitions)
+            {
+                var button = NModCardPileButton.Create(definition);
+                var anchor = definition.Anchor;
+                if (anchor.Kind == ModCardPileAnchorKind.Custom)
+                    button.Position = anchor.CustomPosition + anchor.Offset;
+                else
+                    switch (anchor.Kind)
+                    {
+                        case ModCardPileAnchorKind.BottomRightSecondary:
+                            button.Position = container.ExhaustPile.Position
+                                              + new Vector2(BottomRightStackDeltaX * (primaryIndex + secondaryIndex + 2),
+                                                  0f)
+                                              + anchor.Offset;
+                            secondaryIndex++;
+                            break;
+                        default:
+                            button.Position = container.ExhaustPile.Position
+                                              + new Vector2(BottomRightStackDeltaX * (primaryIndex + 1), 0f)
+                                              + anchor.Offset;
+                            primaryIndex++;
+                            break;
+                    }
+
+                container.AddChildSafely(button);
             }
         }
 

--- a/CardPiles/ModCardPileInjector.cs
+++ b/CardPiles/ModCardPileInjector.cs
@@ -1,0 +1,142 @@
+using Godot;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.TopBar;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Creates and attaches UI nodes for registered mod card piles, using the explicit
+    ///     <see cref="ModCardPileAnchor" /> when provided and falling back to auto-stacking same-style piles
+    ///     along the anchor's axis. Called from lifecycle patches that fire after the corresponding vanilla
+    ///     <c>_Ready</c> runs.
+    /// </summary>
+    internal static class ModCardPileInjector
+    {
+        private const float BottomLeftStackDeltaX = -100f;
+        private const float BottomRightStackDeltaX = -100f;
+
+        /// <summary>
+        ///     Mounts all <see cref="ModCardPileUiStyle.BottomLeft" /> / <see cref="ModCardPileUiStyle.BottomRight" />
+        ///     buttons onto the combat piles container.
+        /// </summary>
+        public static void InjectCombatButtons(NCombatPilesContainer container)
+        {
+            var leftDefinitions = ModCardPileRegistry.GetDefinitionsByStyle(ModCardPileUiStyle.BottomLeft);
+            var rightDefinitions = ModCardPileRegistry.GetDefinitionsByStyle(ModCardPileUiStyle.BottomRight);
+
+            if (leftDefinitions.Length == 0 && rightDefinitions.Length == 0)
+                return;
+
+            var drawPile = container.DrawPile;
+            var exhaustPile = container.ExhaustPile;
+
+            MountBottomButtons(container, leftDefinitions, drawPile,
+                new(BottomLeftStackDeltaX, 0f));
+            MountBottomButtons(container, rightDefinitions, exhaustPile,
+                new(BottomRightStackDeltaX, 0f));
+        }
+
+        /// <summary>
+        ///     Mounts all <see cref="ModCardPileUiStyle.TopBarDeck" /> buttons onto the top bar to the
+        ///     <b>left</b> of the vanilla deck button, using the shared
+        ///     <see cref="ModTopBarLayout" /> helper so pile-mode and action-mode buttons share one
+        ///     row.
+        /// </summary>
+        public static void InjectTopBarButtons(NTopBar topBar)
+        {
+            var definitions = ModCardPileRegistry.GetDefinitionsByStyle(ModCardPileUiStyle.TopBarDeck);
+            if (definitions.Length == 0)
+                return;
+
+            foreach (var definition in definitions)
+            {
+                var button = NModTopBarPileButton.Create(definition);
+                topBar.AddChildSafely(button);
+
+                var anchor = definition.Anchor;
+                if (anchor.Kind == ModCardPileAnchorKind.Custom)
+                    button.Position = anchor.CustomPosition + anchor.Offset;
+                else
+                    ModTopBarLayout.Place(topBar, button, anchor.Offset);
+            }
+        }
+
+        /// <summary>
+        ///     Mounts all <see cref="ModCardPileUiStyle.ExtraHand" /> containers onto the combat UI.
+        /// </summary>
+        public static void InjectExtraHandContainers(NCombatUi combatUi)
+        {
+            var definitions = ModCardPileRegistry.GetDefinitionsByStyle(ModCardPileUiStyle.ExtraHand);
+            if (definitions.Length == 0)
+                return;
+
+            foreach (var definition in definitions)
+            {
+                var hand = NModExtraHand.Create(definition);
+                hand.Position = ResolveExtraHandPosition(combatUi, definition);
+                combatUi.AddChildSafely(hand);
+            }
+        }
+
+        /// <summary>
+        ///     Initializes already-mounted buttons with the local <paramref name="player" /> so they resolve
+        ///     their backing <see cref="ModCardPile" /> and start tracking card additions / removals.
+        /// </summary>
+        public static void InitializeForPlayer(NCombatUi combatUi, Player player)
+        {
+            foreach (var child in combatUi.GetChildren().OfType<NModExtraHand>())
+                child.Initialize(player);
+
+            var pilesContainer = combatUi.GetChildren().OfType<NCombatPilesContainer>().FirstOrDefault();
+            if (pilesContainer != null)
+                foreach (var child in pilesContainer.GetChildren().OfType<NModCardPileButton>())
+                    child.Initialize(player);
+
+            var topBar = NRun.Instance?.GlobalUi?.TopBar;
+            if (topBar == null) return;
+            // Pile-backed top-bar buttons are now siblings of %Deck inside `RightAlignedStuff`, not
+            // direct children of NTopBar — mirror that when iterating for player binding.
+            var rightAligned = ModTopBarLayout.GetRightAlignedContainer(topBar);
+            if (rightAligned != null)
+                foreach (var child in rightAligned.GetChildren().OfType<NModCardPileButton>())
+                    child.Initialize(player);
+        }
+
+        private static void MountBottomButtons(
+            NCombatPilesContainer container,
+            ModCardPileDefinition[] definitions,
+            Control anchorNode,
+            Vector2 fallbackDelta)
+        {
+            var index = 0;
+            foreach (var definition in definitions)
+            {
+                var button = NModCardPileButton.Create(definition);
+                var anchor = definition.Anchor;
+                if (anchor.Kind == ModCardPileAnchorKind.Custom)
+                    button.Position = anchor.CustomPosition + anchor.Offset;
+                else
+                    button.Position = anchorNode.Position + fallbackDelta * (index + 1) + anchor.Offset;
+
+                container.AddChildSafely(button);
+                index++;
+            }
+        }
+
+        private static Vector2 ResolveExtraHandPosition(NCombatUi combatUi, ModCardPileDefinition definition)
+        {
+            if (definition.Anchor.Kind == ModCardPileAnchorKind.Custom)
+                return definition.Anchor.CustomPosition + definition.Anchor.Offset;
+
+            var viewport = combatUi.GetViewportRect().Size;
+            var above = definition.Anchor.Kind == ModCardPileAnchorKind.ExtraHandAbove;
+            var yOffset = above ? -260f : -420f;
+            return new Vector2(viewport.X * 0.5f - 300f, viewport.Y + yOffset) + definition.Anchor.Offset;
+        }
+    }
+}

--- a/CardPiles/ModCardPileLayout.cs
+++ b/CardPiles/ModCardPileLayout.cs
@@ -40,7 +40,7 @@ namespace STS2RitsuLib.CardPiles
             {
                 var deck = NRun.Instance?.GlobalUi?.TopBar?.Deck;
                 if (deck != null)
-                    return deck.GlobalPosition + deck.Size * 0.5f + new Vector2(120f, 0f) + definition.Anchor.Offset;
+                    return deck.GlobalPosition + deck.Size * 0.5f + new Vector2(-120f, 0f) + definition.Anchor.Offset;
             }
 
             if (!CombatManager.Instance.IsInProgress || NCombatRoom.Instance?.Ui == null)

--- a/CardPiles/ModCardPileLayout.cs
+++ b/CardPiles/ModCardPileLayout.cs
@@ -1,0 +1,74 @@
+using Godot;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Cards;
+using MegaCrit.Sts2.Core.Nodes.Rooms;
+using STS2RitsuLib.CardPiles.Nodes;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Resolves fly-in target positions for mod card piles. Called from the
+    ///     <c>PileTypeExtensions.GetTargetPosition</c> prefix patch so vanilla's switch never sees mod-minted
+    ///     values.
+    /// </summary>
+    internal static class ModCardPileLayout
+    {
+        /// <summary>
+        ///     Computes the screen-space target position cards should animate to when moved into
+        ///     <paramref name="definition" />. Falls back to a centered screen coordinate if the expected UI
+        ///     host node is not yet available (e.g. before combat starts or between scene transitions).
+        /// </summary>
+        /// <param name="definition">Pile definition describing style / anchor.</param>
+        /// <param name="node">The flying card's node, used to offset the target by the card's half-size.</param>
+        public static Vector2 GetTargetPosition(ModCardPileDefinition definition, NCard? node)
+        {
+            var fallback = FallbackPosition();
+
+            if (definition.Anchor.Kind == ModCardPileAnchorKind.Custom)
+                return definition.Anchor.CustomPosition + definition.Anchor.Offset;
+
+            var button = ModCardPileButtonRegistry.TryGetButton(definition);
+            if (button != null && button.IsInsideTree())
+                return button.GlobalPosition + button.Size * 0.5f + definition.Anchor.Offset;
+
+            var extraHand = ModCardPileButtonRegistry.TryGetExtraHand(definition);
+            if (extraHand != null && extraHand.IsInsideTree())
+                return extraHand.GlobalPosition + extraHand.Size * 0.5f + definition.Anchor.Offset;
+
+            if (definition.Style == ModCardPileUiStyle.TopBarDeck)
+            {
+                var deck = NRun.Instance?.GlobalUi?.TopBar?.Deck;
+                if (deck != null)
+                    return deck.GlobalPosition + deck.Size * 0.5f + new Vector2(120f, 0f) + definition.Anchor.Offset;
+            }
+
+            if (!CombatManager.Instance.IsInProgress || NCombatRoom.Instance?.Ui == null)
+                return fallback + definition.Anchor.Offset;
+
+            var ui = NCombatRoom.Instance.Ui;
+            return definition.Style switch
+            {
+                ModCardPileUiStyle.BottomLeft =>
+                    ui.DrawPile.GlobalPosition + ui.DrawPile.Size * 0.5f + new Vector2(0f, -140f) +
+                    definition.Anchor.Offset,
+                ModCardPileUiStyle.BottomRight =>
+                    ui.ExhaustPile.GlobalPosition + ui.ExhaustPile.Size * 0.5f + new Vector2(-140f, 0f) +
+                    definition.Anchor.Offset,
+                ModCardPileUiStyle.ExtraHand =>
+                    new Vector2(fallback.X - (node?.Size.X ?? 0f) * 0.5f, fallback.Y - 260f) + definition.Anchor.Offset,
+                _ => fallback + definition.Anchor.Offset,
+            };
+        }
+
+        private static Vector2 FallbackPosition()
+        {
+            var game = NGame.Instance;
+            if (game == null)
+                return Vector2.Zero;
+
+            var size = game.GetViewportRect().Size;
+            return new(size.X * 0.5f, size.Y * 0.5f);
+        }
+    }
+}

--- a/CardPiles/ModCardPileOpenContext.cs
+++ b/CardPiles/ModCardPileOpenContext.cs
@@ -1,0 +1,84 @@
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Nodes.Screens;
+using MegaCrit.Sts2.Core.Nodes.Screens.Capstones;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.Screens;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Context passed to <see cref="ModCardPileSpec.OnOpen" /> when a mod pile's UI button is released.
+    ///     Exposes the backing pile plus convenience helpers so handlers can swap in a custom
+    ///     <see cref="ICapstoneScreen" /> (or invoke the default <see cref="NCardPileScreen" />) without
+    ///     hand-wiring <see cref="NCapstoneContainer" />.
+    /// </summary>
+    /// <remarks>
+    ///     Handlers may:
+    ///     <list type="bullet">
+    ///         <item>Call <see cref="ShowDefaultPileScreen" /> to reuse the vanilla <see cref="NCardPileScreen" />.</item>
+    ///         <item>
+    ///             Call <see cref="OpenCapstoneScreen(ICapstoneScreen)" /> to mount a custom
+    ///             <see cref="ICapstoneScreen" /> (for example a Godot scene script).
+    ///         </item>
+    ///         <item>Do nothing — the button returns to its idle state after the tween.</item>
+    ///     </list>
+    ///     Handlers are invoked from the button's release handler after the click tween starts and after
+    ///     ritsulib already ensured the pile is non-empty (empty piles trigger
+    ///     <see cref="ModCardPileDefinition.EmptyPileMessage" /> via a thought bubble and skip the callback).
+    /// </remarks>
+    public sealed class ModCardPileOpenContext
+    {
+        internal ModCardPileOpenContext(
+            ModCardPileDefinition definition,
+            ModCardPile pile,
+            Player player,
+            NModCardPileButton? button)
+        {
+            Definition = definition;
+            Pile = pile;
+            Player = player;
+            Button = button;
+        }
+
+        /// <summary>Definition of the pile whose button was pressed.</summary>
+        public ModCardPileDefinition Definition { get; }
+
+        /// <summary>Live <see cref="ModCardPile" /> resolved for <see cref="Player" />.</summary>
+        public ModCardPile Pile { get; }
+
+        /// <summary>The local player this button is bound to.</summary>
+        public Player Player { get; }
+
+        /// <summary>
+        ///     The clicked button, when the open was triggered from a
+        ///     <see cref="ModCardPileUiStyle.TopBarDeck" /> / <see cref="ModCardPileUiStyle.BottomLeft" /> /
+        ///     <see cref="ModCardPileUiStyle.BottomRight" /> UI node. Null for programmatic invocations.
+        /// </summary>
+        public NModCardPileButton? Button { get; }
+
+        /// <summary>
+        ///     Launches the vanilla <see cref="NCardPileScreen" /> for the current pile, re-using
+        ///     <see cref="ModCardPileDefinition.Hotkeys" /> when set. This is exactly what the default open
+        ///     handler does when <see cref="ModCardPileSpec.OnOpen" /> is null.
+        /// </summary>
+        public void ShowDefaultPileScreen()
+        {
+            NCardPileScreen.ShowScreen(Pile, Definition.Hotkeys ?? []);
+        }
+
+        /// <summary>
+        ///     Opens <paramref name="screen" /> through <see cref="ModScreenService.Open" />. If a capstone
+        ///     is already showing, it is closed first so the new screen can take the stage.
+        /// </summary>
+        /// <remarks>
+        ///     Thin convenience forwarder — the actual capstone plumbing lives in
+        ///     <see cref="ModScreenService" /> so any mod code can open custom screens without pulling in
+        ///     the card-pile subsystem.
+        /// </remarks>
+        /// <param name="screen">Custom screen implementing <see cref="ICapstoneScreen" />.</param>
+        public void OpenCapstoneScreen(ICapstoneScreen screen)
+        {
+            ModScreenService.Open(screen);
+        }
+    }
+}

--- a/CardPiles/ModCardPileRegistry.cs
+++ b/CardPiles/ModCardPileRegistry.cs
@@ -1,0 +1,281 @@
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.HoverTips;
+using STS2RitsuLib.Content;
+using STS2RitsuLib.Utils;
+using Logger = MegaCrit.Sts2.Core.Logging.Logger;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Per-mod registration surface for custom <see cref="CardPile" />s. Mirrors the conventions used by
+    ///     <c>ModKeywordRegistry</c>: ids are mod-qualified via <see cref="ModContentRegistry.GetQualifiedKeywordId" />,
+    ///     <see cref="PileType" /> values are deterministically minted with
+    ///     <see cref="DynamicEnumValueMinter{TEnum}" />, and registrations freeze at
+    ///     <c>ModelDb.Init</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A single global <see cref="DynamicEnumValueMinter{TEnum}" /> reserves the high value band
+    ///         (<c>[0x4000_0000, 0x7FFF_FFFF]</c>), strictly above any plausible vanilla growth. Ritsulib and
+    ///         baselib use different hash families (XxHash32 vs MD5) so their minted values do not collide
+    ///         numerically even when used side-by-side.
+    ///     </para>
+    ///     <para>
+    ///         Consumers reach the registry through <see cref="For" /> with their own mod id; the registry
+    ///         instance is a thin per-mod façade — definitions live in a single process-wide map keyed by the
+    ///         normalized id and minted value, so cross-mod lookups by id remain possible.
+    ///     </para>
+    /// </remarks>
+    public sealed class ModCardPileRegistry
+    {
+        private static readonly Lock SyncRoot = new();
+
+        private static readonly Dictionary<string, ModCardPileRegistry> Registries =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly Dictionary<string, ModCardPileDefinition> Definitions =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly Dictionary<PileType, ModCardPileDefinition> DefinitionsByPileType = [];
+
+        private static readonly DynamicEnumValueMinter<PileType> PileTypeMinter = new();
+
+        private readonly Logger _logger;
+        private readonly string _modId;
+        private string? _freezeReason;
+
+        private ModCardPileRegistry(string modId)
+        {
+            _modId = modId;
+            _logger = RitsuLibFramework.CreateLogger(modId);
+        }
+
+        /// <summary>
+        ///     True after the framework freezes pile registration (at <c>ModelDb.Init</c>).
+        /// </summary>
+        public static bool IsFrozen { get; private set; }
+
+        /// <summary>
+        ///     Returns the singleton registry for <paramref name="modId" />, creating it on first use.
+        /// </summary>
+        /// <param name="modId">Owning mod id.</param>
+        public static ModCardPileRegistry For(string modId)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+
+            lock (SyncRoot)
+            {
+                if (Registries.TryGetValue(modId, out var existing))
+                    return existing;
+
+                var created = new ModCardPileRegistry(modId);
+                Registries[modId] = created;
+                return created;
+            }
+        }
+
+        /// <summary>
+        ///     Freezes all registries. Called from the core lifecycle patch immediately before
+        ///     <c>ModelDb.Init</c> so every subsequent mint / register attempt throws.
+        /// </summary>
+        /// <param name="reason">Human-readable context appended to log messages.</param>
+        internal static void FreezeRegistrations(string reason)
+        {
+            ModCardPileRegistry[] snapshot;
+            lock (SyncRoot)
+            {
+                if (IsFrozen)
+                    return;
+
+                IsFrozen = true;
+                foreach (var registry in Registries.Values)
+                    registry._freezeReason = reason;
+
+                snapshot = [.. Registries.Values];
+            }
+
+            foreach (var registry in snapshot)
+                registry._logger.Info($"[CardPiles] Pile registration is now frozen ({reason}).");
+        }
+
+        /// <summary>
+        ///     Registers a card pile owned by this registry's mod. The id is mod-qualified via
+        ///     <see cref="ModContentRegistry.GetQualifiedCardPileId" /> — producing the ritsulib-standard
+        ///     <c>MODID_CARDPILE_LOCALSTEM</c> shape (uppercase, three segments) that doubles as the default
+        ///     <c>LocStem</c>. Passing the same <paramref name="localStem" /> from the same mod returns the
+        ///     existing definition.
+        /// </summary>
+        /// <param name="localStem">Local identifier, unique within this mod.</param>
+        /// <param name="spec">Pile metadata (scope, style, localization, icon).</param>
+        public ModCardPileDefinition RegisterOwned(string localStem, ModCardPileSpec spec)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(localStem);
+            ArgumentNullException.ThrowIfNull(spec);
+
+            var id = ModContentRegistry.GetQualifiedCardPileId(_modId, localStem);
+            return RegisterCore(id, spec);
+        }
+
+        /// <summary>
+        ///     Registers a card pile using a raw global id. Prefer <see cref="RegisterOwned" /> to keep ids
+        ///     mod-scoped.
+        /// </summary>
+        /// <param name="id">Global id; collisions across mods are rejected.</param>
+        /// <param name="spec">Pile metadata.</param>
+        public ModCardPileDefinition Register(string id, ModCardPileSpec spec)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            ArgumentNullException.ThrowIfNull(spec);
+
+            return RegisterCore(id, spec);
+        }
+
+        /// <summary>
+        ///     Resolves an existing definition by id (the registry does not mint on lookup).
+        /// </summary>
+        public static bool TryGet(string id, out ModCardPileDefinition definition)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+            lock (SyncRoot)
+            {
+                return Definitions.TryGetValue(NormalizeId(id), out definition!);
+            }
+        }
+
+        /// <summary>
+        ///     Resolves the definition for an already minted <see cref="PileType" /> value, returning false for
+        ///     vanilla enum members and for values never produced by this registry.
+        /// </summary>
+        public static bool TryGetByPileType(PileType value, out ModCardPileDefinition definition)
+        {
+            lock (SyncRoot)
+            {
+                return DefinitionsByPileType.TryGetValue(value, out definition!);
+            }
+        }
+
+        /// <summary>
+        ///     Whether <paramref name="value" /> was minted by this registry.
+        /// </summary>
+        public static bool IsModPileType(PileType value)
+        {
+            lock (SyncRoot)
+            {
+                return DefinitionsByPileType.ContainsKey(value);
+            }
+        }
+
+        /// <summary>
+        ///     Returns the minted <see cref="PileType" /> for <paramref name="id" /> or throws.
+        /// </summary>
+        public static PileType GetPileType(string id)
+        {
+            return TryGet(id, out var definition)
+                ? definition.PileType
+                : throw new KeyNotFoundException($"Card pile '{NormalizeId(id)}' is not registered.");
+        }
+
+        /// <summary>
+        ///     Convenience wrapper that mirrors <c>ModKeywordRegistry.CreateHoverTip</c>: builds a
+        ///     <see cref="HoverTip" /> from the registered <see cref="ModCardPileDefinition" /> with icon and
+        ///     localized title / description.
+        /// </summary>
+        /// <param name="id">Normalized pile id.</param>
+        public static HoverTip CreateHoverTip(string id)
+        {
+            return !TryGet(id, out var definition)
+                ? throw new KeyNotFoundException($"Card pile '{NormalizeId(id)}' is not registered.")
+                : ModCardPileHoverTipFactory.Create(definition);
+        }
+
+        /// <summary>
+        ///     Snapshot of all registered definitions, stable-ordered by id.
+        /// </summary>
+        internal static ModCardPileDefinition[] GetDefinitionsSnapshot()
+        {
+            lock (SyncRoot)
+            {
+                return Definitions.Values
+                    .OrderBy(def => def.Id, StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        /// <summary>
+        ///     Snapshot of every definition that should own a UI button / container of <paramref name="style" />.
+        /// </summary>
+        internal static ModCardPileDefinition[] GetDefinitionsByStyle(ModCardPileUiStyle style)
+        {
+            lock (SyncRoot)
+            {
+                return Definitions.Values
+                    .Where(def => def.Style == style)
+                    .OrderBy(def => def.Id, StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        private ModCardPileDefinition RegisterCore(string id, ModCardPileSpec spec)
+        {
+            EnsureMutable("register card piles");
+
+            var normalizedId = NormalizeId(id);
+            var pileType = PileTypeMinter.Mint(normalizedId);
+
+            var definition = new ModCardPileDefinition(
+                _modId,
+                normalizedId,
+                pileType,
+                spec.Scope,
+                spec.Style,
+                spec.Anchor,
+                spec.IconPath,
+                spec.LocStem,
+                spec.Hotkeys,
+                spec.CardShouldBeVisible,
+                spec.OnOpen);
+
+            lock (SyncRoot)
+            {
+                if (Definitions.TryGetValue(normalizedId, out var existing))
+                {
+                    if (!ReferenceEquals(existing.ModId, definition.ModId)
+                        && !StringComparer.OrdinalIgnoreCase.Equals(existing.ModId, definition.ModId))
+                        throw new InvalidOperationException(
+                            $"Card pile '{normalizedId}' is already registered by mod '{existing.ModId}'; "
+                            + $"mod '{definition.ModId}' cannot re-register it.");
+
+                    return existing;
+                }
+
+                Definitions[normalizedId] = definition;
+                DefinitionsByPileType[pileType] = definition;
+            }
+
+            _logger.Info($"[CardPiles] Registered pile: {normalizedId} (PileType=0x{(int)pileType:X8}, "
+                         + $"Style={spec.Style}, Scope={spec.Scope})");
+            return definition;
+        }
+
+        private void EnsureMutable(string operation)
+        {
+            if (!IsFrozen)
+                return;
+
+            throw new InvalidOperationException(
+                $"Cannot {operation} after pile registration has been frozen ({_freezeReason ?? "unknown"}). "
+                + "Register piles from your mod initializer before model initialization.");
+        }
+
+        // The registry dictionaries use StringComparer.OrdinalIgnoreCase so we do not force a case here —
+        // RegisterOwned emits the canonical uppercase form (MODID_CARDPILE_LOCAL) via
+        // ModContentRegistry.GetQualifiedCardPileId and Register(string, ...) preserves whatever shape
+        // the caller chose. Keeping the caller's case means LocStem defaults line up with the visible id
+        // and the vanilla `DRAW_PILE.title` convention in static_hover_tips.
+        private static string NormalizeId(string id)
+        {
+            return id.Trim();
+        }
+    }
+}

--- a/CardPiles/ModCardPileRegistry.cs
+++ b/CardPiles/ModCardPileRegistry.cs
@@ -8,7 +8,7 @@ namespace STS2RitsuLib.CardPiles
 {
     /// <summary>
     ///     Per-mod registration surface for custom <see cref="CardPile" />s. Mirrors the conventions used by
-    ///     <c>ModKeywordRegistry</c>: ids are mod-qualified via <see cref="ModContentRegistry.GetQualifiedKeywordId" />,
+    ///     <c>ModKeywordRegistry</c>: ids are mod-qualified via <see cref="ModContentRegistry.GetQualifiedCardPileId" />,
     ///     <see cref="PileType" /> values are deterministically minted with
     ///     <see cref="DynamicEnumValueMinter{TEnum}" />, and registrations freeze at
     ///     <c>ModelDb.Init</c>.

--- a/CardPiles/ModCardPileScope.cs
+++ b/CardPiles/ModCardPileScope.cs
@@ -1,0 +1,30 @@
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Lifetime scope of a custom card pile.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="CombatOnly" /> piles live on <c>PlayerCombatState</c> and are automatically disposed with
+    ///         the combat; they participate in <c>PlayerCombatState.AllPiles</c> and <c>IsCombatPile</c>.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="RunPersistent" /> piles live on <c>Player</c> and persist across combats (much like
+    ///         <c>Player.Deck</c>). The first release stores them identically to combat piles but does not yet
+    ///         participate in <c>AllPiles</c>; treat persistence as best-effort until explicit serialization
+    ///         support is added.
+    ///     </para>
+    /// </remarks>
+    public enum ModCardPileScope
+    {
+        /// <summary>
+        ///     Created lazily per <c>PlayerCombatState</c> and discarded when combat ends.
+        /// </summary>
+        CombatOnly = 0,
+
+        /// <summary>
+        ///     Attached to a <c>Player</c> for the duration of a run. Currently stored in memory only.
+        /// </summary>
+        RunPersistent = 1,
+    }
+}

--- a/CardPiles/ModCardPileSpec.cs
+++ b/CardPiles/ModCardPileSpec.cs
@@ -1,0 +1,92 @@
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Describes a mod card pile at registration time. Everything but the mod id and local stem is optional;
+    ///     sensible defaults match the vanilla Draw / Discard / Exhaust button behaviour.
+    /// </summary>
+    /// <remarks>
+    ///     Localization follows the vanilla pile convention — the hover-tip title / description and the
+    ///     "open empty pile" thought bubble are always resolved against the built-in
+    ///     <c>static_hover_tips</c> loc table, using the keys <c>"{LocStem}.title"</c>,
+    ///     <c>"{LocStem}.description"</c> and <c>"{LocStem}.empty"</c>. Mods cannot create additional loc
+    ///     tables, so all entries are expected to live in <c>static_hover_tips.json</c> merged through
+    ///     the normal mod-localization pipeline.
+    /// </remarks>
+    public sealed record ModCardPileSpec
+    {
+        /// <summary>
+        ///     Vanilla loc table used for every mod-card-pile hover tip. Mods can only *extend* this table
+        ///     (not create new tables), so the pile subsystem always resolves into it.
+        /// </summary>
+        public const string HoverTipLocTable = "static_hover_tips";
+
+        /// <summary>
+        ///     Builds a spec with defaults suitable for a combat-only, bottom-left auto-stacking pile.
+        /// </summary>
+        public ModCardPileSpec()
+        {
+        }
+
+        /// <summary>
+        ///     Lifetime scope of the pile. Defaults to <see cref="ModCardPileScope.CombatOnly" />.
+        /// </summary>
+        public ModCardPileScope Scope { get; init; } = ModCardPileScope.CombatOnly;
+
+        /// <summary>
+        ///     Visual style family; drives which UI chrome is attached in combat. Defaults to
+        ///     <see cref="ModCardPileUiStyle.Headless" /> (no UI button).
+        /// </summary>
+        public ModCardPileUiStyle Style { get; init; } = ModCardPileUiStyle.Headless;
+
+        /// <summary>
+        ///     Slot hint paired with <see cref="Style" />. When left at <see cref="ModCardPileAnchor.Default" />
+        ///     the pile auto-stacks after other same-style piles in registration order.
+        /// </summary>
+        public ModCardPileAnchor Anchor { get; init; } = ModCardPileAnchor.Default;
+
+        /// <summary>
+        ///     Godot resource path for the pile's button icon (for example <c>res://art/my_pile.png</c>). When
+        ///     null or missing the placeholder texture is used.
+        /// </summary>
+        public string? IconPath { get; init; }
+
+        /// <summary>
+        ///     Localization stem used to build the hover-tip title / description and the empty-pile message
+        ///     (all resolved against <see cref="HoverTipLocTable" />). When null, the pile's normalized id
+        ///     is used as the stem, mirroring how <c>ModKeywordRegistry</c> derives default loc keys.
+        /// </summary>
+        /// <remarks>
+        ///     Expected JSON keys are <c>"{stem}.title"</c>, <c>"{stem}.description"</c> and
+        ///     <c>"{stem}.empty"</c>. Follow the vanilla convention (see <c>DRAW_PILE.title</c> /
+        ///     <c>DRAW_PILE.description</c> in <c>static_hover_tips.json</c>) when authoring translations.
+        /// </remarks>
+        public string? LocStem { get; init; }
+
+        /// <summary>
+        ///     Optional controller / keyboard hotkey ids that open the pile's view screen.
+        /// </summary>
+        public string[]? Hotkeys { get; init; }
+
+        /// <summary>
+        ///     When true, cards added to the pile are displayed as <c>NCard</c> nodes inside the pile's UI
+        ///     container (only meaningful for <see cref="ModCardPileUiStyle.ExtraHand" />).
+        /// </summary>
+        public bool CardShouldBeVisible { get; init; }
+
+        /// <summary>
+        ///     Optional callback invoked when the pile's UI button is released. When null (the default) the
+        ///     button falls back to <c>NCardPileScreen.ShowScreen</c> — the same behaviour as vanilla Draw /
+        ///     Discard / Exhaust buttons. Supply a delegate to plug in a custom
+        ///     <see cref="MegaCrit.Sts2.Core.Nodes.Screens.Capstones.ICapstoneScreen" />, inspect the pile, or
+        ///     do nothing at all.
+        /// </summary>
+        /// <remarks>
+        ///     The context exposes helpers — <see cref="ModCardPileOpenContext.ShowDefaultPileScreen" /> runs
+        ///     the default behaviour, while <see cref="ModCardPileOpenContext.OpenCapstoneScreen" /> mounts a
+        ///     custom screen through <c>NCapstoneContainer</c>. The callback is *not* invoked when the pile is
+        ///     empty; in that case the empty-pile thought bubble is shown and re-clicking an already-open
+        ///     default pile screen continues to toggle it closed before the callback runs.
+        /// </remarks>
+        public Action<ModCardPileOpenContext>? OnOpen { get; init; }
+    }
+}

--- a/CardPiles/ModCardPileStorage.cs
+++ b/CardPiles/ModCardPileStorage.cs
@@ -1,0 +1,116 @@
+using System.Runtime.CompilerServices;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Players;
+
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Weak per-state storage for <see cref="ModCardPile" /> instances. Piles are created lazily the first
+    ///     time vanilla code asks for them via <see cref="Resolve" /> so state objects pay nothing for mods they
+    ///     do not interact with.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="ModCardPileScope.CombatOnly" /> piles are keyed by <see cref="PlayerCombatState" />
+    ///         and implicitly disposed with the combat (the <c>AllPiles</c> postfix adds them into the vanilla
+    ///         cleanup sweep).
+    ///     </para>
+    ///     <para>
+    ///         <see cref="ModCardPileScope.RunPersistent" /> piles are keyed by <see cref="Player" /> and
+    ///         persist across combats for the lifetime of the player instance. Serialization is a follow-up;
+    ///         for now the piles refill from empty at run load.
+    ///     </para>
+    /// </remarks>
+    internal static class ModCardPileStorage
+    {
+        private static readonly ConditionalWeakTable<PlayerCombatState, Dictionary<PileType, ModCardPile>>
+            CombatPiles = new();
+
+        private static readonly ConditionalWeakTable<Player, Dictionary<PileType, ModCardPile>>
+            RunPiles = new();
+
+        /// <summary>
+        ///     Looks up or lazily creates the <see cref="ModCardPile" /> bound to <paramref name="player" /> for
+        ///     <paramref name="type" />. Returns null when the minted type has no registered definition or when
+        ///     the requested state (combat / player) is not yet available.
+        /// </summary>
+        public static ModCardPile? Resolve(PileType type, Player? player)
+        {
+            if (player == null)
+                return null;
+            if (!ModCardPileRegistry.TryGetByPileType(type, out var definition))
+                return null;
+
+            return definition.Scope switch
+            {
+                ModCardPileScope.CombatOnly => ResolveCombatPile(player.PlayerCombatState, definition),
+                ModCardPileScope.RunPersistent => ResolveRunPile(player, definition),
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        ///     Returns the mod piles that currently belong to <paramref name="state" /> without creating new
+        ///     ones. The returned collection is a snapshot and safe to enumerate while vanilla mutates piles.
+        /// </summary>
+        public static IReadOnlyCollection<ModCardPile> GetCombatPiles(PlayerCombatState state)
+        {
+            ArgumentNullException.ThrowIfNull(state);
+
+            if (!CombatPiles.TryGetValue(state, out var piles) || piles.Count == 0)
+                return [];
+
+            lock (piles)
+            {
+                return [.. piles.Values];
+            }
+        }
+
+        /// <summary>
+        ///     Snapshot of persistent piles owned by <paramref name="player" />.
+        /// </summary>
+        public static IReadOnlyCollection<ModCardPile> GetRunPiles(Player player)
+        {
+            ArgumentNullException.ThrowIfNull(player);
+
+            if (!RunPiles.TryGetValue(player, out var piles) || piles.Count == 0)
+                return [];
+
+            lock (piles)
+            {
+                return [.. piles.Values];
+            }
+        }
+
+        private static ModCardPile? ResolveCombatPile(PlayerCombatState? state, ModCardPileDefinition definition)
+        {
+            if (state == null)
+                return null;
+
+            var dict = CombatPiles.GetValue(state, static _ => []);
+            lock (dict)
+            {
+                if (dict.TryGetValue(definition.PileType, out var existing))
+                    return existing;
+
+                var created = new ModCardPile(definition);
+                dict[definition.PileType] = created;
+                return created;
+            }
+        }
+
+        private static ModCardPile ResolveRunPile(Player player, ModCardPileDefinition definition)
+        {
+            var dict = RunPiles.GetValue(player, static _ => []);
+            lock (dict)
+            {
+                if (dict.TryGetValue(definition.PileType, out var existing))
+                    return existing;
+
+                var created = new ModCardPile(definition);
+                dict[definition.PileType] = created;
+                return created;
+            }
+        }
+    }
+}

--- a/CardPiles/ModCardPileUiStyle.cs
+++ b/CardPiles/ModCardPileUiStyle.cs
@@ -1,0 +1,36 @@
+namespace STS2RitsuLib.CardPiles
+{
+    /// <summary>
+    ///     Visual family of a mod card pile. Drives which UI chrome (top bar button, bottom-row combat button,
+    ///     or extra hand) is created for the pile, and how <see cref="ModCardPileAnchor" /> is interpreted.
+    /// </summary>
+    public enum ModCardPileUiStyle
+    {
+        /// <summary>
+        ///     No UI chrome. Cards fly to the coordinate declared by <c>Anchor.Custom(...)</c>; suitable for
+        ///     purely invisible holding piles.
+        /// </summary>
+        Headless = 0,
+
+        /// <summary>
+        ///     Button in the top bar, next to the vanilla deck button (<c>NTopBarDeckButton</c>).
+        /// </summary>
+        TopBarDeck = 1,
+
+        /// <summary>
+        ///     Button on the bottom-left of the combat UI (next to the draw pile).
+        /// </summary>
+        BottomLeft = 2,
+
+        /// <summary>
+        ///     Button on the bottom-right of the combat UI (next to the exhaust pile).
+        /// </summary>
+        BottomRight = 3,
+
+        /// <summary>
+        ///     Extra hand-like container; cards inside are rendered as <c>NCard</c> nodes and can be previewed,
+        ///     similar to the vanilla <c>NPlayerHand</c>.
+        /// </summary>
+        ExtraHand = 4,
+    }
+}

--- a/CardPiles/Nodes/ModCardPileButtonRegistry.cs
+++ b/CardPiles/Nodes/ModCardPileButtonRegistry.cs
@@ -1,0 +1,69 @@
+namespace STS2RitsuLib.CardPiles.Nodes
+{
+    /// <summary>
+    ///     Process-wide lookup from <see cref="ModCardPileDefinition" /> to the currently live UI instance
+    ///     (button or extra-hand container). Used by
+    ///     <see cref="ModCardPileLayout.GetTargetPosition" /> and by the <c>NCard.FindOnTable</c> patch to
+    ///     answer "where did the card fly to?" without forcing callers to look up scene nodes themselves.
+    /// </summary>
+    /// <remarks>
+    ///     The registry only holds weak UI state (Godot nodes clean themselves up on scene unload); entries
+    ///     are replaced when a new combat UI reinjects piles.
+    /// </remarks>
+    internal static class ModCardPileButtonRegistry
+    {
+        private static readonly Lock SyncRoot = new();
+        private static readonly Dictionary<string, NModCardPileButton> Buttons = [];
+        private static readonly Dictionary<string, NModExtraHand> ExtraHands = [];
+
+        internal static void RegisterButton(ModCardPileDefinition definition, NModCardPileButton button)
+        {
+            lock (SyncRoot)
+            {
+                Buttons[definition.Id] = button;
+            }
+        }
+
+        internal static void UnregisterButton(ModCardPileDefinition definition, NModCardPileButton button)
+        {
+            lock (SyncRoot)
+            {
+                if (Buttons.TryGetValue(definition.Id, out var existing) && ReferenceEquals(existing, button))
+                    Buttons.Remove(definition.Id);
+            }
+        }
+
+        internal static NModCardPileButton? TryGetButton(ModCardPileDefinition definition)
+        {
+            lock (SyncRoot)
+            {
+                return Buttons.GetValueOrDefault(definition.Id);
+            }
+        }
+
+        internal static void RegisterExtraHand(ModCardPileDefinition definition, NModExtraHand hand)
+        {
+            lock (SyncRoot)
+            {
+                ExtraHands[definition.Id] = hand;
+            }
+        }
+
+        internal static void UnregisterExtraHand(ModCardPileDefinition definition, NModExtraHand hand)
+        {
+            lock (SyncRoot)
+            {
+                if (ExtraHands.TryGetValue(definition.Id, out var existing) && ReferenceEquals(existing, hand))
+                    ExtraHands.Remove(definition.Id);
+            }
+        }
+
+        internal static NModExtraHand? TryGetExtraHand(ModCardPileDefinition definition)
+        {
+            lock (SyncRoot)
+            {
+                return ExtraHands.GetValueOrDefault(definition.Id);
+            }
+        }
+    }
+}

--- a/CardPiles/Nodes/NModCardPileButton.cs
+++ b/CardPiles/Nodes/NModCardPileButton.cs
@@ -64,6 +64,7 @@ namespace STS2RitsuLib.CardPiles.Nodes
         private MegaLabel _countLabel = null!;
         private int _currentCount;
         private bool _hovered;
+        private Control _iconHost = null!;
 
         private HoverTip? _hoverTip;
 
@@ -235,14 +236,14 @@ namespace STS2RitsuLib.CardPiles.Nodes
             //   └── Count (MegaLabel, anchored bottom-right with vanilla offsets)
             // Keeping the node names identical means tooling / scene inspection / future vanilla
             // lookups by path (`Control/Icon`) work on our buttons too.
-            var iconHost = new Control
+            _iconHost = new Control
             {
                 Name = "Control",
                 MouseFilter = MouseFilterEnum.Ignore,
                 AnchorRight = 1f,
                 AnchorBottom = 1f,
             };
-            AddChild(iconHost);
+            AddChild(_iconHost);
 
             var texture = ResolveIconTexture();
             var textureRect = new TextureRect
@@ -267,7 +268,7 @@ namespace STS2RitsuLib.CardPiles.Nodes
                 PivotOffset = new(IconSize * 0.5f, IconSize * 0.5f - 2f),
             };
             _icon = textureRect;
-            iconHost.AddChild(_icon);
+            _iconHost.AddChild(_icon);
 
             // A placeholder count label — this will be swapped in Initialize() for a deep clone of the
             // vanilla %Deck's `DeckCardCount` MegaLabel, so we inherit the exact font / outline size /
@@ -630,10 +631,11 @@ namespace STS2RitsuLib.CardPiles.Nodes
                 return;
             }
 
-            if (_pile == null || _player == null || Definition == null || !CombatManager.Instance.IsInProgress)
+            if (_pile == null || _player == null || Definition == null)
                 return;
 
-            if (_pile.IsEmpty)
+            var inCombat = CombatManager.Instance.IsInProgress;
+            if (inCombat && _pile.IsEmpty)
             {
                 var instance = NCapstoneContainer.Instance;
                 if (instance is { InUse: true })
@@ -661,6 +663,12 @@ namespace STS2RitsuLib.CardPiles.Nodes
             }
 
             NCardPileScreen.ShowScreen(_pile, Definition.Hotkeys ?? []);
+        }
+
+        internal void ApplyVisualOffset(Vector2 offset)
+        {
+            _iconHost.Position = offset;
+            _countLabel.Position = offset;
         }
 
         /// <summary>

--- a/CardPiles/Nodes/NModCardPileButton.cs
+++ b/CardPiles/Nodes/NModCardPileButton.cs
@@ -1,0 +1,676 @@
+using Godot;
+using MegaCrit.Sts2.addons.mega_text;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.HoverTips;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.HoverTips;
+using MegaCrit.Sts2.Core.Nodes.Rooms;
+using MegaCrit.Sts2.Core.Nodes.Screens;
+using MegaCrit.Sts2.Core.Nodes.Screens.Capstones;
+using MegaCrit.Sts2.Core.Nodes.Vfx;
+using STS2RitsuLib.TopBar;
+
+namespace STS2RitsuLib.CardPiles.Nodes
+{
+    /// <summary>
+    ///     Procedurally built top-bar-style button reused by BOTH systems that want the "card pile with
+    ///     icon + count" look:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <see cref="ModCardPileUiStyle.BottomLeft" /> / <see cref="ModCardPileUiStyle.BottomRight" /> /
+    ///             <see cref="ModCardPileUiStyle.TopBarDeck" /> buttons produced by
+    ///             <see cref="ModCardPileRegistry" /> — the "pile mode" — where the backing data is a real
+    ///             <see cref="ModCardPile" /> and the count tracks its card collection via events.
+    ///         </item>
+    ///         <item>
+    ///             Non-pile top-bar action buttons produced by <see cref="ModTopBarButtonRegistry" /> — the
+    ///             "action mode" — where the count comes from <see cref="ModTopBarButtonSpec.CountProvider" />
+    ///             and the click runs <see cref="ModTopBarButtonSpec.OnClick" />. Action-mode buttons fall
+    ///             back to the vanilla <c>%Deck</c>'s icon texture when
+    ///             <see cref="ModTopBarButtonSpec.IconPath" /> is left unset so users don't have to ship a
+    ///             custom PNG just to get a reasonably-styled button.
+    ///         </item>
+    ///     </list>
+    ///     Sharing one node type here is deliberate — the user-facing request was to stop "splitting the
+    ///     layout" for pile-backed vs. action-backed buttons, so both kinds look/animate/space identically.
+    /// </summary>
+    /// <remarks>
+    ///     The button reacts to pointer hover / click via Godot's control signals, shows a
+    ///     <see cref="HoverTip" /> built from the registered metadata, and on release either opens
+    ///     <see cref="NCardPileScreen" /> (pile mode, mirroring the vanilla Draw / Discard / Exhaust buttons)
+    ///     or dispatches <see cref="ModTopBarButtonDefinition.OnClick" /> (action mode).
+    /// </remarks>
+    public sealed partial class NModCardPileButton : Control
+    {
+        // Matches the vanilla `DeckContainer` MarginContainer (`scenes/ui/top_bar.tscn` line ~489) so
+        // we occupy exactly one 80x80 slot inside the right-aligned HBoxContainer — the previous
+        // 110x110 value made the button bigger than the deck and pushed the whole cluster around.
+        private const float DefaultButtonWidth = 80f;
+
+        private const float DefaultButtonHeight = 80f;
+
+        // Matches `top_bar_deck_button.tscn`: the inner Icon is a 72x72 TextureRect centred in the
+        // 80x80 slot. Recreating the same numbers keeps the rendered glyph the same size as the deck's.
+        private const float IconSize = 72f;
+        private static readonly Vector2 HoverScale = Vector2.One * 1.1f;
+
+        // Action-mode fields (null when Definition is set).
+        private int _actionLastKnownCount = -1;
+
+        // Shared state between the two modes.
+        private Tween? _bumpTween;
+        private MegaLabel _countLabel = null!;
+        private int _currentCount;
+        private bool _hovered;
+
+        private HoverTip? _hoverTip;
+
+        // Kept as the base Control type because we swap in either a TextureRect (when IconPath was
+        // supplied) or a clone of the vanilla %Deck `Control/Icon` subtree (fallback for action mode
+        // when no IconPath is given) — the latter is what makes bare action buttons render an icon
+        // that is pixel-identical to the deck button the player is used to seeing.
+        private Control _icon = null!;
+
+        // Pile-mode fields (null when ActionDefinition is set).
+        private ModCardPile? _pile;
+        private Player? _player;
+        private bool _pressed;
+
+        /// <summary>
+        ///     Pile-mode registry entry. Non-null when the button is bound to a real
+        ///     <see cref="ModCardPile" />; null while the button is running in action mode.
+        /// </summary>
+        public ModCardPileDefinition? Definition { get; private set; }
+
+        /// <summary>
+        ///     Action-mode registry entry. Non-null when the button was produced by
+        ///     <see cref="ModTopBarButtonRegistry" /> rather than <see cref="ModCardPileRegistry" />; null in
+        ///     pile mode.
+        /// </summary>
+        public ModTopBarButtonDefinition? ActionDefinition { get; private set; }
+
+        /// <summary>True when this button is an action-mode instance (has no backing pile).</summary>
+        public bool IsActionMode => ActionDefinition != null;
+
+        /// <summary>
+        ///     Builds a new pile-mode button bound to <paramref name="definition" />.
+        /// </summary>
+        public static NModCardPileButton Create(ModCardPileDefinition definition)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+
+            var button = new NModCardPileButton
+            {
+                Definition = definition,
+                Name = $"ModCardPileButton_{definition.Id}",
+                MouseFilter = MouseFilterEnum.Stop,
+                CustomMinimumSize = new(DefaultButtonWidth, DefaultButtonHeight),
+                Size = new(DefaultButtonWidth, DefaultButtonHeight),
+                PivotOffset = new(DefaultButtonWidth * 0.5f, DefaultButtonHeight * 0.5f),
+            };
+            button.BuildChildren();
+            return button;
+        }
+
+        /// <summary>
+        ///     Builds a new action-mode button bound to <paramref name="actionDefinition" />. The returned
+        ///     node is identical to a pile-mode button visually (same icon box, same count label, same
+        ///     hover / press animations) but dispatches clicks to
+        ///     <see cref="ModTopBarButtonDefinition.OnClick" /> instead of opening
+        ///     <see cref="NCardPileScreen" />, and polls
+        ///     <see cref="ModTopBarButtonDefinition.CountProvider" /> on <see cref="Node._Process" /> for the
+        ///     count display.
+        /// </summary>
+        public static NModCardPileButton CreateAction(ModTopBarButtonDefinition actionDefinition)
+        {
+            ArgumentNullException.ThrowIfNull(actionDefinition);
+
+            var button = new NModCardPileButton
+            {
+                ActionDefinition = actionDefinition,
+                Name = $"ModTopBarActionButton_{actionDefinition.Id}",
+                MouseFilter = MouseFilterEnum.Stop,
+                CustomMinimumSize = new(DefaultButtonWidth, DefaultButtonHeight),
+                Size = new(DefaultButtonWidth, DefaultButtonHeight),
+                PivotOffset = new(DefaultButtonWidth * 0.5f, DefaultButtonHeight * 0.5f),
+            };
+            button.BuildChildren();
+            return button;
+        }
+
+        /// <summary>
+        ///     Binds the button to <paramref name="player" />. In pile mode this resolves the underlying
+        ///     <see cref="ModCardPile" /> and starts tracking card add / remove events; in action mode it
+        ///     just remembers the player (used for <see cref="ModTopBarButtonContext" /> construction) and
+        ///     primes the count label from the spec's <see cref="ModTopBarButtonSpec.CountProvider" />.
+        /// </summary>
+        public void Initialize(Player player)
+        {
+            ArgumentNullException.ThrowIfNull(player);
+            _player = player;
+
+            // Regardless of mode, adopt the vanilla %Deck's `DeckCardCount` label — this gives us the
+            // exact font, outline colour / size, shadow offsets and font size that the scene designer
+            // configured on the real deck button (see `top_bar_deck_button.tscn` lines 69-93).
+            // Procedural MegaLabels render without an outline and drift whenever the game updates.
+            TryReplaceCountLabelWithVanillaDeckClone();
+
+            if (ActionDefinition != null)
+            {
+                // Action mode: when no IconPath was provided we swap our placeholder TextureRect for a
+                // deep clone of the vanilla %Deck "Control/Icon" subtree. That's the only way to be
+                // "exactly like the pile icon" — we inherit the sprite, the HSV shader material, and
+                // any children the scene designer added, so bare action buttons cannot drift visually
+                // from the vanilla deck button.
+                if (string.IsNullOrWhiteSpace(ActionDefinition.IconPath))
+                    TryReplaceIconWithVanillaDeckClone();
+                _hoverTip = ModTopBarButtonHoverTipFactory.Create(ActionDefinition);
+                PollActionCount(true);
+                return;
+            }
+
+            if (Definition != null)
+                AttachPile(ModCardPileStorage.Resolve(Definition.PileType, player));
+        }
+
+        /// <inheritdoc />
+        public override void _EnterTree()
+        {
+            base._EnterTree();
+            if (Definition != null)
+                ModCardPileButtonRegistry.RegisterButton(Definition, this);
+        }
+
+        /// <inheritdoc />
+        public override void _ExitTree()
+        {
+            base._ExitTree();
+            if (Definition != null)
+                ModCardPileButtonRegistry.UnregisterButton(Definition, this);
+            DetachPile();
+            NHoverTipSet.Remove(this);
+            _bumpTween?.Kill();
+        }
+
+        /// <inheritdoc />
+        public override void _Process(double delta)
+        {
+            base._Process(delta);
+            if (ActionDefinition == null)
+                return;
+
+            // Action-mode bookkeeping: visibility and count are polled here because there is no pile to
+            // subscribe to. Both predicates are best kept cheap per their docs.
+            RefreshActionVisibility();
+            PollActionCount(false);
+        }
+
+        /// <inheritdoc />
+        public override void _GuiInput(InputEvent @event)
+        {
+            if (@event is not InputEventMouseButton { ButtonIndex: MouseButton.Left } mouse)
+                return;
+
+            switch (mouse.Pressed)
+            {
+                case true when !_pressed:
+                    _pressed = true;
+                    OnPress();
+                    return;
+                case false when _pressed:
+                    _pressed = false;
+                    OnRelease();
+                    break;
+            }
+        }
+
+        private void BuildChildren()
+        {
+            // Mirrors the vanilla `top_bar_deck_button.tscn` hierarchy exactly:
+            //   Root (80x80 Control, mouse_filter=Stop — the click target)
+            //   └── Control (fills parent, mouse_filter=Ignore — holds the icon)
+            //       └── Icon (72x72 TextureRect, anchored centre, mouse_filter=Ignore)
+            //   └── Count (MegaLabel, anchored bottom-right with vanilla offsets)
+            // Keeping the node names identical means tooling / scene inspection / future vanilla
+            // lookups by path (`Control/Icon`) work on our buttons too.
+            var iconHost = new Control
+            {
+                Name = "Control",
+                MouseFilter = MouseFilterEnum.Ignore,
+                AnchorRight = 1f,
+                AnchorBottom = 1f,
+            };
+            AddChild(iconHost);
+
+            var texture = ResolveIconTexture();
+            var textureRect = new TextureRect
+            {
+                Name = "Icon",
+                Texture = texture,
+                StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered,
+                ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
+                MouseFilter = MouseFilterEnum.Ignore,
+                CustomMinimumSize = new(IconSize, IconSize),
+                // Anchor preset 8 (centre) with explicit ±IconSize/2 offsets — same math the vanilla
+                // scene encodes as "offset_left = -36, offset_top = -36, offset_right = 36,
+                // offset_bottom = 36" on a 72x72 icon.
+                AnchorLeft = 0.5f,
+                AnchorTop = 0.5f,
+                AnchorRight = 0.5f,
+                AnchorBottom = 0.5f,
+                OffsetLeft = -IconSize * 0.5f,
+                OffsetTop = -IconSize * 0.5f,
+                OffsetRight = IconSize * 0.5f,
+                OffsetBottom = IconSize * 0.5f,
+                PivotOffset = new(IconSize * 0.5f, IconSize * 0.5f - 2f),
+            };
+            _icon = textureRect;
+            iconHost.AddChild(_icon);
+
+            // A placeholder count label — this will be swapped in Initialize() for a deep clone of the
+            // vanilla %Deck's `DeckCardCount` MegaLabel, so we inherit the exact font / outline size /
+            // shadow offsets / font size (set by the scene designer in top_bar_deck_button.tscn). A
+            // procedural label would drift from vanilla on every visual update the game ships.
+            _countLabel = new()
+            {
+                Name = "Count",
+                MouseFilter = MouseFilterEnum.Ignore,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Bottom,
+                AnchorLeft = 1f,
+                AnchorTop = 1f,
+                AnchorRight = 1f,
+                AnchorBottom = 1f,
+                OffsetLeft = -32f,
+                OffsetTop = -36f,
+                GrowHorizontal = GrowDirection.Begin,
+                GrowVertical = GrowDirection.Begin,
+                PivotOffset = new(14f, 18f),
+            };
+            _countLabel.SetTextAutoSize("0");
+            AddChild(_countLabel);
+
+            Connect(Control.SignalName.MouseEntered, Callable.From(OnMouseEntered));
+            Connect(Control.SignalName.MouseExited, Callable.From(OnMouseExited));
+        }
+
+        private Texture2D? ResolveIconTexture()
+        {
+            // Both modes use the same single-line rule: if an IconPath was provided AND it resolves on
+            // disk we load it; otherwise we return null and rely on the action-mode Initialize() to try
+            // borrowing the vanilla %Deck icon as a last resort. Pile-mode buttons keep the legacy
+            // behaviour of "no texture" when nothing is provided — that's consistent with how old code
+            // behaved before this refactor and avoids surprising existing mods.
+            var path = Definition?.IconPath ?? ActionDefinition?.IconPath;
+            if (!string.IsNullOrWhiteSpace(path) && ResourceLoader.Exists(path))
+                return ResourceLoader.Load<Texture2D>(path);
+            return null;
+        }
+
+        /// <summary>
+        ///     Replaces our procedurally-created <see cref="TextureRect" /> icon with a deep clone of the
+        ///     vanilla <c>%Deck</c> button's <c>Control/Icon</c> subtree. This is the fidelity version of
+        ///     the old "just copy the texture" fallback — it preserves the exact node hierarchy, shader
+        ///     materials, and child sprites the scene designer set up for the deck icon, so bare
+        ///     action-mode buttons look <i>indistinguishable</i> from the deck button's icon. Safely no-ops
+        ///     (leaving our TextureRect in place) if the top bar isn't ready yet or the deck hasn't been
+        ///     constructed — e.g. when registration fires from the main menu.
+        /// </summary>
+        private void TryReplaceIconWithVanillaDeckClone()
+        {
+            try
+            {
+                var deck = NRun.Instance?.GlobalUi.TopBar.Deck;
+                var vanillaIcon = deck?.GetNodeOrNull<Control>("Control/Icon");
+                if (vanillaIcon == null)
+                    return;
+
+                // Duplicate scripts + signals + groups so the clone is fully self-contained — without
+                // this flag set Godot strips the ShaderMaterial binding that drives the deck icon's
+                // HSV shader.
+                var clone = vanillaIcon.Duplicate((int)(DuplicateFlags.Scripts
+                                                        | DuplicateFlags.Signals
+                                                        | DuplicateFlags.Groups));
+                if (clone is not Control control)
+                {
+                    clone.QueueFree();
+                    return;
+                }
+
+                // Drop our procedural Icon placeholder and plug the clone into the same "Control" host
+                // node, at the same "Icon" name — keeps the vanilla path `Control/Icon` valid on our
+                // button so any future code that looks it up by path (mirroring
+                // `NTopBarButton._Ready`) keeps working. The clone already carries the correct 72x72
+                // centered layout from the scene, so we do NOT overwrite its anchors / offsets here.
+                var host = _icon.GetParent();
+                _icon.QueueFree();
+                _icon = control;
+                host.AddChild(_icon);
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[ModCardPileButton] Could not clone vanilla %Deck icon for action button: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        ///     Replaces our procedural <see cref="MegaLabel" /> count with a deep clone of the vanilla
+        ///     <c>%Deck</c>'s <c>DeckCardCount</c> label. The scene designer configured it with a
+        ///     specific <see cref="FontVariation" />, outline colour, outline_size=12, shadow offsets,
+        ///     and font_size=28 — procedural labels have none of those by default, which is why our
+        ///     old count label looked flat next to the deck's chiselled-looking digits. Silently leaves
+        ///     the placeholder in place if the deck isn't constructed yet (e.g. we're bound before the
+        ///     top bar exists) so we degrade gracefully rather than crashing.
+        /// </summary>
+        private void TryReplaceCountLabelWithVanillaDeckClone()
+        {
+            try
+            {
+                var deck = NRun.Instance?.GlobalUi.TopBar.Deck;
+                var vanillaCount = deck?.GetNodeOrNull<MegaLabel>("DeckCardCount");
+                if (vanillaCount == null)
+                    return;
+
+                var clone = vanillaCount.Duplicate((int)(DuplicateFlags.Scripts
+                                                         | DuplicateFlags.Signals
+                                                         | DuplicateFlags.Groups));
+                if (clone is not MegaLabel cloneLabel)
+                {
+                    clone.QueueFree();
+                    return;
+                }
+
+                // Preserve the clone's theme overrides (font / outline / shadow) but re-apply the
+                // identity / positioning / mouse-filter flags our code expects. Anchors and offsets
+                // come from the scene already — matching vanilla — so we don't touch those.
+                var text = _countLabel.Text;
+                var visible = _countLabel.Visible;
+                _countLabel.QueueFree();
+                cloneLabel.Name = "Count";
+                cloneLabel.MouseFilter = MouseFilterEnum.Ignore;
+                cloneLabel.Visible = visible;
+                cloneLabel.SetTextAutoSize(string.IsNullOrEmpty(text) ? "0" : text);
+                _countLabel = cloneLabel;
+                AddChild(_countLabel);
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[ModCardPileButton] Could not clone vanilla %Deck count label: {ex.Message}");
+            }
+        }
+
+        private void AttachPile(ModCardPile? pile)
+        {
+            if (ReferenceEquals(_pile, pile))
+                return;
+
+            DetachPile();
+            _pile = pile;
+            if (_pile == null || Definition == null)
+                return;
+
+            _pile.CardAddFinished += OnCardAddFinished;
+            _pile.CardRemoveFinished += OnCardRemoveFinished;
+            _currentCount = _pile.Cards.Count;
+            _countLabel.SetTextAutoSize(_currentCount.ToString());
+            _hoverTip = ModCardPileHoverTipFactory.Create(Definition);
+        }
+
+        /// <summary>
+        ///     Refreshes the count label from <see cref="ModTopBarButtonDefinition.CountProvider" />. When
+        ///     the provider is null — or returns a negative number — the label is hidden entirely; action
+        ///     buttons that don't track a count then look like a plain icon button, matching the vanilla
+        ///     <c>%Map</c> / <c>%Pause</c> feel while keeping the card-pile click hit-box. A non-negative
+        ///     return value shows the badge and triggers the bump animation on increase.
+        /// </summary>
+        private void PollActionCount(bool force)
+        {
+            if (ActionDefinition is not { } def)
+                return;
+
+            if (def.CountProvider is null)
+            {
+                if (_countLabel.Visible)
+                    _countLabel.Visible = false;
+                return;
+            }
+
+            int count;
+            try
+            {
+                count = def.CountProvider(new(def, _player, this));
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[TopBar] CountProvider for '{def.Id}' threw: {ex.Message}; using last known count.");
+                return;
+            }
+
+            if (count < 0)
+            {
+                if (_countLabel.Visible)
+                    _countLabel.Visible = false;
+                _actionLastKnownCount = -1;
+                return;
+            }
+
+            if (!force && count == _actionLastKnownCount)
+                return;
+
+            var increased = count > _actionLastKnownCount && _actionLastKnownCount >= 0;
+            _actionLastKnownCount = count;
+            _currentCount = count;
+            _countLabel.Visible = true;
+            _countLabel.SetTextAutoSize(count.ToString());
+            _countLabel.PivotOffset = _countLabel.Size * 0.5f;
+
+            if (!increased)
+                return;
+
+            // Small "count went up" bump, mirroring the pile-mode CardAddFinished animation so action
+            // buttons feel just as responsive when the number they track jumps.
+            _bumpTween?.Kill();
+            _bumpTween = CreateTween().SetParallel();
+            _countLabel.Scale = HoverScale;
+            _bumpTween.TweenProperty(_countLabel, "scale", Vector2.One, 0.5)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Expo);
+        }
+
+        private void RefreshActionVisibility()
+        {
+            if (ActionDefinition is not { } def)
+                return;
+
+            bool visible;
+            if (def.VisibleWhen is null)
+                visible = true;
+            else
+                try
+                {
+                    visible = def.VisibleWhen(new(def, _player, this));
+                }
+                catch (Exception ex)
+                {
+                    RitsuLibFramework.Logger.Warn(
+                        $"[TopBar] VisibleWhen predicate for '{def.Id}' threw: {ex.Message}; hiding button.");
+                    visible = false;
+                }
+
+            if (Visible == visible)
+                return;
+
+            Visible = visible;
+            MouseFilter = visible ? MouseFilterEnum.Stop : MouseFilterEnum.Ignore;
+            if (!visible)
+                NHoverTipSet.Remove(this);
+        }
+
+        private void DetachPile()
+        {
+            if (_pile == null)
+                return;
+
+            _pile.CardAddFinished -= OnCardAddFinished;
+            _pile.CardRemoveFinished -= OnCardRemoveFinished;
+            _pile = null;
+        }
+
+        private void OnCardAddFinished()
+        {
+            if (_pile == null)
+                return;
+
+            _currentCount = _pile.Cards.Count;
+            _countLabel.SetTextAutoSize(_currentCount.ToString());
+            _countLabel.PivotOffset = _countLabel.Size * 0.5f;
+            _bumpTween?.Kill();
+            _bumpTween = CreateTween().SetParallel();
+            _icon.Scale = HoverScale;
+            _bumpTween.TweenProperty(_icon, "scale", Vector2.One, 0.5)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Expo);
+            _countLabel.Scale = HoverScale;
+            _bumpTween.TweenProperty(_countLabel, "scale", Vector2.One, 0.5)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Expo);
+        }
+
+        private void OnCardRemoveFinished()
+        {
+            if (_pile == null)
+                return;
+            _currentCount = _pile.Cards.Count;
+            _countLabel.SetTextAutoSize(_currentCount.ToString());
+            _countLabel.PivotOffset = _countLabel.Size * 0.5f;
+        }
+
+        private void OnMouseEntered()
+        {
+            _hovered = true;
+            _bumpTween?.Kill();
+            _bumpTween = CreateTween();
+            _bumpTween.TweenProperty(_icon, "scale", HoverScale, 0.05);
+
+            ShowHoverTipAnchored();
+        }
+
+        /// <summary>
+        ///     Shows our hover tip anchored the same way vanilla <c>NTopBarDeckButton.OnFocus</c> does it:
+        ///     right-aligned under the button with a 20 px gap. <c>NHoverTipSet.CreateAndShow</c> with
+        ///     <see cref="HoverTipAlignment.None" /> doesn't position the tip at all, so without this
+        ///     step our tip rendered at the <c>HoverTipsContainer</c>'s origin (top-left of the
+        ///     viewport) — the "weird location" the user reported.
+        /// </summary>
+        private void ShowHoverTipAnchored()
+        {
+            if (_hoverTip == null)
+                return;
+            var tipSet = NHoverTipSet.CreateAndShow(this, _hoverTip);
+            // `ResetSize()` inside Init already sized the text container; sampling Size here gives the
+            // real tip bounds so right-alignment is exact. Matches NTopBarDeckButton.OnFocus verbatim.
+            tipSet.GlobalPosition = GlobalPosition
+                                    + new Vector2(Size.X - tipSet.Size.X, Size.Y + 20f);
+        }
+
+        private void OnMouseExited()
+        {
+            _hovered = false;
+            NHoverTipSet.Remove(this);
+            _bumpTween?.Kill();
+            _bumpTween = CreateTween().SetParallel();
+            _bumpTween.TweenProperty(_icon, "scale", Vector2.One, 0.5)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Expo);
+            _bumpTween.TweenProperty(_icon, "modulate", Colors.White, 0.5)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Expo);
+        }
+
+        private void OnPress()
+        {
+            _bumpTween?.Kill();
+            _bumpTween = CreateTween().SetParallel();
+            _bumpTween.TweenProperty(_icon, "scale", Vector2.One, 0.25)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Cubic);
+            _bumpTween.TweenProperty(_icon, "modulate", Colors.DarkGray, 0.25)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Cubic);
+        }
+
+        private void OnRelease()
+        {
+            _bumpTween?.Kill();
+            _bumpTween = CreateTween();
+            _bumpTween.TweenProperty(_icon, "scale", _hovered ? HoverScale : Vector2.One, 0.05);
+            _bumpTween.TweenProperty(_icon, "modulate", Colors.White, 0.5)
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Expo);
+
+            if (ActionDefinition is { } actionDef)
+            {
+                if (actionDef.OnClick is not { } handler)
+                    return;
+                try
+                {
+                    handler(new(actionDef, _player, this));
+                }
+                catch (Exception ex)
+                {
+                    RitsuLibFramework.Logger.Error(
+                        $"[TopBar] OnClick handler for '{actionDef.Id}' threw: {ex}");
+                }
+
+                return;
+            }
+
+            if (_pile == null || _player == null || Definition == null || !CombatManager.Instance.IsInProgress)
+                return;
+
+            if (_pile.IsEmpty)
+            {
+                var instance = NCapstoneContainer.Instance;
+                if (instance is { InUse: true })
+                    NCapstoneContainer.Instance?.Close();
+
+                var message = Definition.EmptyPileMessage.GetFormattedText();
+                var thought = NThoughtBubbleVfx.Create(message, _player.Creature, 2.0);
+                NCombatRoom.Instance?.CombatVfxContainer.AddChildSafely(thought);
+                return;
+            }
+
+            var capstone = NCapstoneContainer.Instance;
+            if (capstone is { CurrentCapstoneScreen: NCardPileScreen screen }
+                && screen.Pile == _pile)
+            {
+                capstone.Close();
+                return;
+            }
+
+            if (Definition.OnOpen is { } onOpen)
+            {
+                var context = new ModCardPileOpenContext(Definition, _pile, _player, this);
+                onOpen(context);
+                return;
+            }
+
+            NCardPileScreen.ShowScreen(_pile, Definition.Hotkeys ?? []);
+        }
+
+        /// <summary>
+        ///     Programmatically triggers the same open logic the button runs on pointer release (runs
+        ///     <see cref="ModCardPileDefinition.OnOpen" /> if set, otherwise the default
+        ///     <see cref="NCardPileScreen" />). Intended for hotkey bindings or scripted flows.
+        /// </summary>
+        public void TriggerOpen()
+        {
+            OnRelease();
+        }
+    }
+}

--- a/CardPiles/Nodes/NModExtraHand.cs
+++ b/CardPiles/Nodes/NModExtraHand.cs
@@ -1,0 +1,177 @@
+using Godot;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Cards;
+
+namespace STS2RitsuLib.CardPiles.Nodes
+{
+    /// <summary>
+    ///     Extra hand-like container for <see cref="ModCardPileUiStyle.ExtraHand" /> piles. Renders the pile's
+    ///     cards as individual <see cref="NCard" /> nodes laid out horizontally, mirroring the vanilla
+    ///     <c>NPlayerHand</c> in intent but using a much simpler layout.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Rather than patching the <c>CardPileCmd.Add</c> async state machine (which would conflict with
+    ///         baselib's existing transpiler), <see cref="NModExtraHand" /> listens to the pile's
+    ///         <c>CardAdded</c> / <c>CardRemoved</c> events and keeps its own <see cref="NCard" /> roster in
+    ///         sync. The vanilla fly animation delivers the card to the pile's registered target position
+    ///         (returned by <see cref="ModCardPileLayout.GetTargetPosition" />), and this container then owns
+    ///         the long-lived visual.
+    ///     </para>
+    /// </remarks>
+    public sealed partial class NModExtraHand : Control
+    {
+        private const float CardSpacing = 120f;
+        private readonly Dictionary<CardModel, NCard> _cards = [];
+
+        private ModCardPile? _pile;
+        private Player? _player;
+
+        /// <summary>
+        ///     Back-reference to the registry entry.
+        /// </summary>
+        public ModCardPileDefinition Definition { get; private set; } = null!;
+
+        /// <summary>
+        ///     Builds a new extra-hand container for <paramref name="definition" />. Add it to the combat UI
+        ///     and call <see cref="Initialize" /> with the local player once the pile is available.
+        /// </summary>
+        public static NModExtraHand Create(ModCardPileDefinition definition)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+
+            return new()
+            {
+                Definition = definition,
+                Name = $"ModExtraHand_{definition.Id}",
+                MouseFilter = MouseFilterEnum.Pass,
+                CustomMinimumSize = new(600f, 280f),
+                Size = new(600f, 280f),
+                PivotOffset = new(300f, 140f),
+            };
+        }
+
+        /// <summary>
+        ///     Binds the container to <paramref name="player" /> and begins mirroring the underlying pile.
+        /// </summary>
+        public void Initialize(Player player)
+        {
+            ArgumentNullException.ThrowIfNull(player);
+            _player = player;
+            AttachPile(ModCardPileStorage.Resolve(Definition.PileType, player));
+        }
+
+        /// <summary>
+        ///     Returns the <see cref="NCard" /> displayed for <paramref name="card" />, or null when the card
+        ///     is not currently in this pile.
+        /// </summary>
+        public NCard? GetCard(CardModel card)
+        {
+            return _cards.GetValueOrDefault(card);
+        }
+
+        /// <inheritdoc />
+        public override void _EnterTree()
+        {
+            base._EnterTree();
+            ModCardPileButtonRegistry.RegisterExtraHand(Definition, this);
+        }
+
+        /// <inheritdoc />
+        public override void _ExitTree()
+        {
+            base._ExitTree();
+            ModCardPileButtonRegistry.UnregisterExtraHand(Definition, this);
+            DetachPile();
+        }
+
+        private void AttachPile(ModCardPile? pile)
+        {
+            if (ReferenceEquals(_pile, pile))
+                return;
+
+            DetachPile();
+            _pile = pile;
+            if (_pile == null)
+                return;
+
+            _pile.CardAdded += OnCardAdded;
+            _pile.CardRemoved += OnCardRemoved;
+            foreach (var card in _pile.Cards)
+                AddVisualFor(card);
+            ArrangeCards();
+        }
+
+        private void DetachPile()
+        {
+            if (_pile == null)
+                return;
+
+            _pile.CardAdded -= OnCardAdded;
+            _pile.CardRemoved -= OnCardRemoved;
+            _pile = null;
+
+            foreach (var ncard in _cards.Values)
+                ncard.QueueFreeSafelyIfValid();
+            _cards.Clear();
+        }
+
+        private void OnCardAdded(CardModel card)
+        {
+            AddVisualFor(card);
+            ArrangeCards();
+        }
+
+        private void OnCardRemoved(CardModel card)
+        {
+            if (!_cards.Remove(card, out var ncard))
+                return;
+
+            ncard.QueueFreeSafelyIfValid();
+            ArrangeCards();
+        }
+
+        private void AddVisualFor(CardModel card)
+        {
+            if (_cards.ContainsKey(card))
+                return;
+
+            var ncard = NCard.Create(card);
+            if (ncard == null)
+                return;
+
+            _cards[card] = ncard;
+            AddChild(ncard);
+        }
+
+        private void ArrangeCards()
+        {
+            if (_cards.Count == 0)
+                return;
+
+            var totalWidth = CardSpacing * (_cards.Count - 1);
+            var startX = Size.X * 0.5f - totalWidth * 0.5f;
+            var y = Size.Y * 0.5f;
+            var i = 0;
+            foreach (var ncard in _cards.Values.Where(ncard => ncard.IsInsideTree()))
+            {
+                ncard.Position = new(startX + CardSpacing * i - ncard.Size.X * 0.5f,
+                    y - ncard.Size.Y * 0.5f);
+                i++;
+            }
+        }
+    }
+
+    internal static class NModExtraHandNCardExtensions
+    {
+        internal static void QueueFreeSafelyIfValid(this NCard ncard)
+        {
+            if (ncard == null)
+                return;
+            if (!GodotObject.IsInstanceValid(ncard))
+                return;
+            ncard.QueueFree();
+        }
+    }
+}

--- a/CardPiles/Nodes/NModExtraHand.cs
+++ b/CardPiles/Nodes/NModExtraHand.cs
@@ -150,11 +150,20 @@ namespace STS2RitsuLib.CardPiles.Nodes
             if (_cards.Count == 0)
                 return;
 
-            var totalWidth = CardSpacing * (_cards.Count - 1);
+            var orderedCards = _pile?.Cards
+                .Select(card => _cards.GetValueOrDefault(card))
+                .OfType<NCard>()
+                .Where(ncard => ncard.IsInsideTree())
+                .ToArray()
+                ?? _cards.Values.Where(ncard => ncard.IsInsideTree()).ToArray();
+            if (orderedCards.Length == 0)
+                return;
+
+            var totalWidth = CardSpacing * (orderedCards.Length - 1);
             var startX = Size.X * 0.5f - totalWidth * 0.5f;
             var y = Size.Y * 0.5f;
             var i = 0;
-            foreach (var ncard in _cards.Values.Where(ncard => ncard.IsInsideTree()))
+            foreach (var ncard in orderedCards)
             {
                 ncard.Position = new(startX + CardSpacing * i - ncard.Size.X * 0.5f,
                     y - ncard.Size.Y * 0.5f);

--- a/CardPiles/Nodes/NModTopBarPileButton.cs
+++ b/CardPiles/Nodes/NModTopBarPileButton.cs
@@ -1,0 +1,21 @@
+namespace STS2RitsuLib.CardPiles.Nodes
+{
+    /// <summary>
+    ///     Thin specialization of <see cref="NModCardPileButton" /> for top-bar piles. Presently reuses the
+    ///     base button unchanged; placement differences (size, margins) are handled by the top-bar injection
+    ///     patch rather than by this class. The type still exists so style-specific behaviour can be added
+    ///     later without breaking callers.
+    /// </summary>
+    public sealed partial class NModTopBarPileButton
+    {
+        /// <summary>
+        ///     Builds a new top-bar button for <paramref name="definition" />. This currently produces the
+        ///     same node as <see cref="NModCardPileButton.Create" />; a dedicated class simplifies identifying
+        ///     top-bar instances in the scene tree.
+        /// </summary>
+        public static NModCardPileButton Create(ModCardPileDefinition definition)
+        {
+            return NModCardPileButton.Create(definition);
+        }
+    }
+}

--- a/CardPiles/Patches/ModCardPileAllPilesPatch.cs
+++ b/CardPiles/Patches/ModCardPileAllPilesPatch.cs
@@ -1,0 +1,76 @@
+using System.Reflection;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Players;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Appends <see cref="ModCardPileScope.CombatOnly" /> piles to
+    ///     <see cref="PlayerCombatState.AllPiles" /> so that vanilla code paths that iterate combat piles
+    ///     (enumeration, <c>AfterCombatEnd</c>, broadcast helpers) transparently include mod piles.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A Postfix is used instead of a Transpiler (unlike baselib's <c>SpecialPileInCombat</c>) so both
+    ///         libraries can coexist without IL conflicts. Whatever vanilla or baselib produced is treated as
+    ///         the base, and ritsulib's piles are concatenated on top.
+    ///     </para>
+    ///     <para>
+    ///         The underlying <c>_piles</c> field is also updated via reflection when present so subsequent
+    ///         getter calls see the combined array without reallocating per access; when the field is absent
+    ///         (future vanilla refactors), the postfix still works by replacing <c>__result</c>.
+    ///     </para>
+    /// </remarks>
+    public sealed class ModCardPileAllPilesPatch : IPatchMethod
+    {
+        private static readonly FieldInfo? PilesField =
+            typeof(PlayerCombatState).GetField("_piles", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_player_combat_state_all_piles_append";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Append ritsulib CombatOnly mod piles to PlayerCombatState.AllPiles without transpiling";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(PlayerCombatState), "get_" + nameof(PlayerCombatState.AllPiles))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Merges mod piles into <see cref="PlayerCombatState.AllPiles" />'s return value.
+        /// </summary>
+        public static void Postfix(PlayerCombatState __instance, ref IReadOnlyList<CardPile> __result)
+        {
+            var modPiles = ModCardPileStorage.GetCombatPiles(__instance);
+            if (modPiles.Count == 0)
+                return;
+
+            if (ContainsAll(__result, modPiles))
+                return;
+
+            var combined = new CardPile[__result.Count + modPiles.Count];
+            for (var i = 0; i < __result.Count; i++)
+                combined[i] = __result[i];
+            var j = __result.Count;
+            foreach (var pile in modPiles)
+                combined[j++] = pile;
+
+            PilesField?.SetValue(__instance, combined);
+            __result = combined;
+        }
+        // ReSharper restore InconsistentNaming
+
+        private static bool ContainsAll(IReadOnlyList<CardPile> haystack, IReadOnlyCollection<ModCardPile> needles)
+        {
+            return needles.Select(needle => haystack.Any(t => ReferenceEquals(t, needle))).All(found => found);
+        }
+    }
+}

--- a/CardPiles/Patches/ModCardPileCombatPilesContainerPatch.cs
+++ b/CardPiles/Patches/ModCardPileCombatPilesContainerPatch.cs
@@ -1,0 +1,73 @@
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Injects bottom-row mod pile buttons (<see cref="ModCardPileUiStyle.BottomLeft" /> /
+    ///     <see cref="ModCardPileUiStyle.BottomRight" />) into <see cref="NCombatPilesContainer" /> after its
+    ///     vanilla <c>_Ready</c> finishes wiring up draw / discard / exhaust.
+    /// </summary>
+    public sealed class ModCardPileCombatPilesContainerReadyPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_combat_piles_container_ready";
+
+        /// <inheritdoc />
+        public static string Description => "Inject mod card pile buttons into NCombatPilesContainer on ready";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NCombatPilesContainer), nameof(NCombatPilesContainer._Ready))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>Injects mod bottom-row pile buttons after vanilla wiring completes.</summary>
+        public static void Postfix(NCombatPilesContainer __instance)
+        {
+            ModCardPileInjector.InjectCombatButtons(__instance);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+
+    /// <summary>
+    ///     Forwards <see cref="NCombatPilesContainer.Initialize" /> to every injected
+    ///     <see cref="NModCardPileButton" /> so each mod pile binds to the active <see cref="Player" />
+    ///     alongside the vanilla draw / discard / exhaust buttons.
+    /// </summary>
+    public sealed class ModCardPileCombatPilesContainerInitializePatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_combat_piles_container_initialize";
+
+        /// <inheritdoc />
+        public static string Description => "Initialize injected mod pile buttons with the current player";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(NCombatPilesContainer), nameof(NCombatPilesContainer.Initialize), [typeof(Player)]),
+            ];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>Binds each mod pile button to the current player.</summary>
+        public static void Postfix(NCombatPilesContainer __instance, Player player)
+        {
+            foreach (var button in __instance.GetChildren().OfType<NModCardPileButton>())
+                button.Initialize(player);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/CardPiles/Patches/ModCardPileCombatUiExtraHandPatch.cs
+++ b/CardPiles/Patches/ModCardPileCombatUiExtraHandPatch.cs
@@ -1,0 +1,72 @@
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Context;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Injects <see cref="ModCardPileUiStyle.ExtraHand" /> containers (<see cref="Nodes.NModExtraHand" />)
+    ///     into <see cref="NCombatUi" /> on ready so they live alongside the vanilla player hand.
+    /// </summary>
+    public sealed class ModCardPileCombatUiReadyPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_combat_ui_ready_extra_hand";
+
+        /// <inheritdoc />
+        public static string Description => "Inject ExtraHand mod pile containers into NCombatUi";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NCombatUi), nameof(NCombatUi._Ready))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>Wires up ExtraHand containers after vanilla resolves its child references.</summary>
+        public static void Postfix(NCombatUi __instance)
+        {
+            ModCardPileInjector.InjectExtraHandContainers(__instance);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+
+    /// <summary>
+    ///     Activates ExtraHand containers with the current combat state so they bind to the local player
+    ///     and begin listening to <c>CardPile.CardAdded</c> / <c>CardPile.CardRemoved</c>.
+    /// </summary>
+    public sealed class ModCardPileCombatUiActivatePatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_combat_ui_activate_extra_hand";
+
+        /// <inheritdoc />
+        public static string Description => "Activate ExtraHand mod pile containers alongside NCombatUi.Activate";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NCombatUi), nameof(NCombatUi.Activate), [typeof(CombatState)])];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>Binds each injected ExtraHand container to the local player.</summary>
+        public static void Postfix(NCombatUi __instance, CombatState state)
+        {
+            var me = LocalContext.GetMe(state);
+            if (me == null)
+                return;
+            foreach (var hand in __instance.GetChildren().OfType<NModExtraHand>())
+                hand.Initialize(me);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/CardPiles/Patches/ModCardPileFindOnTablePatch.cs
+++ b/CardPiles/Patches/ModCardPileFindOnTablePatch.cs
@@ -1,0 +1,61 @@
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Cards;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Extends <see cref="NCard.FindOnTable" /> so cards resident in a visible mod pile (currently only the
+    ///     <see cref="ModCardPileUiStyle.ExtraHand" /> style) resolve to the live <c>NCard</c> instance managed
+    ///     by <c>NModExtraHand</c>. Non-visible mod piles intentionally return <c>null</c> (matching vanilla's
+    ///     Draw / Discard / Exhaust behaviour).
+    /// </summary>
+    /// <remarks>
+    ///     Implemented as a Prefix because vanilla's switch hits
+    ///     <c>
+    ///         _ =&gt; throw new
+    ///         ArgumentOutOfRangeException()
+    ///     </c>
+    ///     for any pile type it doesn't know, which would otherwise abort
+    ///     every runtime card lookup while a mod pile hosts the card.
+    /// </remarks>
+    public sealed class ModCardPileFindOnTablePatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_ncard_find_on_table_mod_route";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Resolve NCard.FindOnTable for cards held in visible mod piles (ExtraHand containers)";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NCard), nameof(NCard.FindOnTable))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Short-circuits vanilla for cards whose resolved pile is a mod pile.
+        /// </summary>
+        public static bool Prefix(CardModel card, PileType? overridePile, ref NCard? __result)
+        {
+            var pileType = card.Pile?.Type ?? overridePile;
+            if (pileType == null)
+                return true;
+            if (!ModCardPileRegistry.TryGetByPileType(pileType.Value, out var definition))
+                return true;
+
+            __result = definition.CardShouldBeVisible
+                ? ModCardPileButtonRegistry.TryGetExtraHand(definition)?.GetCard(card)
+                : null;
+            return false;
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/CardPiles/Patches/ModCardPileGetPatch.cs
+++ b/CardPiles/Patches/ModCardPileGetPatch.cs
@@ -1,0 +1,48 @@
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Players;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Short-circuits <see cref="CardPile.Get" /> for mod-minted <see cref="PileType" /> values, returning
+    ///     the per-<see cref="Player" /> / per-combat instance resolved by <see cref="ModCardPileStorage" />.
+    ///     Non-mod values defer to vanilla (and any other Prefix, such as baselib's <c>GetCombatPile</c>).
+    /// </summary>
+    /// <remarks>
+    ///     Without this patch the vanilla switch falls through to <c>ArgumentOutOfRangeException</c> whenever a
+    ///     caller uses a mod-minted pile id, which is why this must run as a Prefix rather than a Postfix.
+    /// </remarks>
+    public sealed class ModCardPileGetPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_card_pile_get_mod_route";
+
+        /// <inheritdoc />
+        public static string Description => "Route CardPile.Get to ModCardPileStorage for minted mod PileType values";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(CardPile), nameof(CardPile.Get))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Resolves mod piles before vanilla's switch throws; returns <c>true</c> to continue vanilla
+        ///     execution for unrecognized values.
+        /// </summary>
+        public static bool Prefix(PileType type, Player player, ref CardPile? __result)
+        {
+            if (!ModCardPileRegistry.IsModPileType(type))
+                return true;
+
+            __result = ModCardPileStorage.Resolve(type, player);
+            return false;
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/CardPiles/Patches/ModCardPileGetTargetPositionPatch.cs
+++ b/CardPiles/Patches/ModCardPileGetTargetPositionPatch.cs
@@ -1,0 +1,46 @@
+using Godot;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Nodes.Cards;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Intercepts <see cref="PileTypeExtensions.GetTargetPosition" /> for mod piles, returning the
+    ///     coordinate of the pile's registered UI host (button or extra-hand container). Must run as a Prefix
+    ///     because vanilla's switch would otherwise throw <see cref="ArgumentOutOfRangeException" /> for minted
+    ///     values.
+    /// </summary>
+    public sealed class ModCardPileGetTargetPositionPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_pile_get_target_position_mod_route";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Provide NCard fly-in targets for mod card piles before the vanilla switch throws";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(PileTypeExtensions), nameof(PileTypeExtensions.GetTargetPosition))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Returns false (skip vanilla) when the pile type was minted by ritsulib.
+        /// </summary>
+        public static bool Prefix(PileType pileType, NCard? node, ref Vector2 __result)
+        {
+            if (!ModCardPileRegistry.TryGetByPileType(pileType, out var definition))
+                return true;
+
+            __result = ModCardPileLayout.GetTargetPosition(definition, node);
+            return false;
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/CardPiles/Patches/ModCardPileIsCombatPatch.cs
+++ b/CardPiles/Patches/ModCardPileIsCombatPatch.cs
@@ -1,0 +1,46 @@
+using MegaCrit.Sts2.Core.Entities.Cards;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Extends <see cref="PileTypeExtensions.IsCombatPile" /> to return <c>true</c> for
+    ///     <see cref="ModCardPileScope.CombatOnly" /> mod piles. Uses a Postfix so that baselib's own Prefix (if
+    ///     present) runs first; ritsulib only upgrades the result when everyone else said "no".
+    /// </summary>
+    public sealed class ModCardPileIsCombatPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_card_pile_is_combat_mod_augment";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Treat CombatOnly mod card piles as combat piles for PileTypeExtensions.IsCombatPile";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(PileTypeExtensions), nameof(PileTypeExtensions.IsCombatPile))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Promotes mod-pile results to <c>true</c> after vanilla / baselib ran.
+        /// </summary>
+        public static void Postfix(PileType pileType, ref bool __result)
+        {
+            if (__result)
+                return;
+            if (!ModCardPileRegistry.TryGetByPileType(pileType, out var definition))
+                return;
+            if (definition.Scope != ModCardPileScope.CombatOnly)
+                return;
+
+            __result = true;
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/CardPiles/Patches/ModCardPileTopBarPatch.cs
+++ b/CardPiles/Patches/ModCardPileTopBarPatch.cs
@@ -1,0 +1,77 @@
+using MegaCrit.Sts2.Core.Context;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
+using MegaCrit.Sts2.Core.Runs;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.CardPiles.Patches
+{
+    /// <summary>
+    ///     Injects <see cref="ModCardPileUiStyle.TopBarDeck" /> style buttons into <see cref="NTopBar" />
+    ///     after its vanilla <c>_Ready</c> has resolved the built-in <c>%Deck</c> / <c>%Map</c> references.
+    /// </summary>
+    public sealed class ModCardPileTopBarReadyPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_top_bar_ready_mod_inject";
+
+        /// <inheritdoc />
+        public static string Description => "Inject mod TopBarDeck pile buttons into NTopBar";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NTopBar), nameof(NTopBar._Ready))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>Wires mod top-bar buttons after vanilla resolves its built-in children.</summary>
+        public static void Postfix(NTopBar __instance)
+        {
+            ModCardPileInjector.InjectTopBarButtons(__instance);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+
+    /// <summary>
+    ///     Forwards <see cref="NTopBar.Initialize" /> so mod TopBarDeck buttons bind to the local
+    ///     <see cref="Player" /> alongside vanilla <c>Deck.Initialize(player)</c>.
+    /// </summary>
+    public sealed class ModCardPileTopBarInitializePatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_top_bar_initialize_mod_bind";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Bind mod TopBarDeck pile buttons to the local player on NTopBar.Initialize";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(NTopBar), nameof(NTopBar.Initialize), [typeof(IRunState)]),
+            ];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>Binds each injected TopBar mod button to the local <see cref="Player" />.</summary>
+        public static void Postfix(NTopBar __instance, IRunState runState)
+        {
+            var player = LocalContext.GetMe(runState);
+            if (player == null)
+                return;
+            foreach (var button in __instance.GetChildren().OfType<NModCardPileButton>())
+                button.Initialize(player);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}

--- a/CardPiles/Patches/ModCardPileTopBarPatch.cs
+++ b/CardPiles/Patches/ModCardPileTopBarPatch.cs
@@ -69,8 +69,12 @@ namespace STS2RitsuLib.CardPiles.Patches
             var player = LocalContext.GetMe(runState);
             if (player == null)
                 return;
-            foreach (var button in __instance.GetChildren().OfType<NModCardPileButton>())
-                button.Initialize(player);
+            var container = TopBar.ModTopBarLayout.GetRightAlignedContainer(__instance);
+            if (container == null)
+                return;
+            foreach (var button in container.GetChildren().OfType<NModCardPileButton>())
+                if (!button.IsActionMode)
+                    button.Initialize(player);
         }
         // ReSharper restore InconsistentNaming
     }

--- a/Content/ModContentRegistry.cs
+++ b/Content/ModContentRegistry.cs
@@ -158,6 +158,46 @@ namespace STS2RitsuLib.Content
         }
 
         /// <summary>
+        ///     Builds a mod-scoped card-pile id using the ritsulib <c>MODID_CATEGORY_TYPENAME</c> public-entry
+        ///     convention — three uppercase segments separated by underscores, aligning with
+        ///     <see cref="GetFixedPublicEntry(string, Type)" /> and the vanilla <c>static_hover_tips</c> key
+        ///     style (<c>DRAW_PILE</c>, <c>EXHAUST_PILE</c>, ...).
+        /// </summary>
+        /// <remarks>
+        ///     The returned string doubles as the default <c>LocStem</c> used when authoring
+        ///     <c>static_hover_tips.json</c>, so a pile registered by mod <c>com.example.my-mod</c> with
+        ///     local stem <c>overflow_pile</c> shows up both as id <c>MYMOD_CARDPILE_OVERFLOW_PILE</c> and
+        ///     loc keys <c>MYMOD_CARDPILE_OVERFLOW_PILE.title</c> / <c>.description</c> / <c>.empty</c>.
+        ///     Mods can still override the stem via <c>ModCardPileSpec.LocStem</c> when they need to share
+        ///     keys with an existing translation.
+        /// </remarks>
+        public static string GetQualifiedCardPileId(string modId, string localPileStem)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+            ArgumentException.ThrowIfNullOrWhiteSpace(localPileStem);
+
+            var modStem = NormalizePublicStem(modId);
+            var keyStem = NormalizePublicStem(localPileStem);
+            return $"{modStem}_CARDPILE_{keyStem}";
+        }
+
+        /// <summary>
+        ///     Builds a mod-scoped top-bar-button id in the ritsulib <c>MODID_CATEGORY_TYPENAME</c> public
+        ///     entry style (uppercase, three segments, underscore-separated, middle segment fixed to
+        ///     <c>TOPBARBUTTON</c>). Used by <see cref="STS2RitsuLib.TopBar.ModTopBarButtonRegistry" />; the
+        ///     returned string doubles as the default <c>LocStem</c> for <c>static_hover_tips.json</c>.
+        /// </summary>
+        public static string GetQualifiedTopBarButtonId(string modId, string localButtonStem)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+            ArgumentException.ThrowIfNullOrWhiteSpace(localButtonStem);
+
+            var modStem = NormalizePublicStem(modId);
+            var keyStem = NormalizePublicStem(localButtonStem);
+            return $"{modStem}_TOPBARBUTTON_{keyStem}";
+        }
+
+        /// <summary>
         ///     Returns the singleton registry for <paramref name="modId" /> (created on first use).
         /// </summary>
         public static ModContentRegistry For(string modId)

--- a/Interop/AutoRegistration/AttributeAutoRegistrationTypeDiscoveryContributor.cs
+++ b/Interop/AutoRegistration/AttributeAutoRegistrationTypeDiscoveryContributor.cs
@@ -2,11 +2,13 @@ using System.Reflection;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Timeline;
+using STS2RitsuLib.CardPiles;
 using STS2RitsuLib.Content;
 using STS2RitsuLib.Keywords;
 using STS2RitsuLib.Scaffolding.Content;
 using STS2RitsuLib.Timeline;
 using STS2RitsuLib.Timeline.Scaffolding;
+using STS2RitsuLib.TopBar;
 
 namespace STS2RitsuLib.Interop.AutoRegistration
 {
@@ -478,6 +480,42 @@ namespace STS2RitsuLib.Interop.AutoRegistration
                                             ownedCardKeyword.IncludeInCardHoverTip);
 #pragma warning restore CS0618
                                     }));
+                            });
+                        break;
+                    case RegisterOwnedCardPileAttribute ownedCardPile:
+                        RegisterCase($"RegisterOwnedCardPile:{ownedCardPile.LocalPileStem}:{type.FullName}", () =>
+                        {
+                            operations.Add(CreateOperation(ownerModId, type, AutoRegistrationPhase.CardPiles,
+                                ownedCardPile.Order,
+                                $"RegisterOwnedCardPile:{ownedCardPile.LocalPileStem}:{type.FullName}",
+                                nameof(RegisterOwnedCardPileAttribute),
+                                () =>
+                                {
+                                    var localStem = ValidateNonEmpty(ownedCardPile.LocalPileStem,
+                                        nameof(ownedCardPile.LocalPileStem));
+                                    var spec = BuildCardPileSpec(type, ownedCardPile);
+                                    ModCardPileRegistry.For(ownerModId).RegisterOwned(localStem, spec);
+                                },
+                                [TypeDependencyKey(type)]));
+                        });
+                        break;
+                    case RegisterOwnedTopBarButtonAttribute ownedTopBarButton:
+                        RegisterCase(
+                            $"RegisterOwnedTopBarButton:{ownedTopBarButton.LocalButtonStem}:{type.FullName}", () =>
+                            {
+                                operations.Add(CreateOperation(ownerModId, type,
+                                    AutoRegistrationPhase.TopBarButtons,
+                                    ownedTopBarButton.Order,
+                                    $"RegisterOwnedTopBarButton:{ownedTopBarButton.LocalButtonStem}:{type.FullName}",
+                                    nameof(RegisterOwnedTopBarButtonAttribute),
+                                    () =>
+                                    {
+                                        var localStem = ValidateNonEmpty(ownedTopBarButton.LocalButtonStem,
+                                            nameof(ownedTopBarButton.LocalButtonStem));
+                                        var spec = BuildTopBarButtonSpec(type, ownedTopBarButton);
+                                        ModTopBarButtonRegistry.For(ownerModId).RegisterOwned(localStem, spec);
+                                    },
+                                    [TypeDependencyKey(type)]));
                             });
                         break;
                     case AutoTimelineSlotAttribute autoTimelineSlot:
@@ -954,6 +992,104 @@ namespace STS2RitsuLib.Interop.AutoRegistration
         private static string TypeDependencyKey(Type type)
         {
             return $"RegisterType:{type.AssemblyQualifiedName}";
+        }
+
+        private static ModCardPileSpec BuildCardPileSpec(Type declaringType, RegisterOwnedCardPileAttribute attr)
+        {
+            var anchor = attr.AnchorKind == ModCardPileAnchorKind.Custom
+                ? new ModCardPileAnchor(
+                    ModCardPileAnchorKind.Custom,
+                    new(attr.AnchorOffsetX, attr.AnchorOffsetY),
+                    new(attr.AnchorCustomX, attr.AnchorCustomY))
+                : new ModCardPileAnchor(attr.AnchorKind, new(attr.AnchorOffsetX, attr.AnchorOffsetY));
+
+            return new()
+            {
+                Scope = attr.Scope,
+                Style = attr.Style,
+                Anchor = anchor,
+                IconPath = attr.IconPath,
+                LocStem = attr.LocStem,
+                Hotkeys = attr.Hotkeys,
+                CardShouldBeVisible = attr.CardShouldBeVisible,
+                OnOpen = ResolveCardPileOpenHandler(declaringType),
+            };
+        }
+
+        private static Action<ModCardPileOpenContext>? ResolveCardPileOpenHandler(Type declaringType)
+        {
+            if (!typeof(IModCardPileHandler).IsAssignableFrom(declaringType))
+                return null;
+
+            if (declaringType.GetConstructor(Type.EmptyTypes) == null)
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[AutoRegister] RegisterOwnedCardPile: type '{declaringType.FullName}' implements "
+                    + $"{nameof(IModCardPileHandler)} but has no parameterless constructor — OnOpen will not be wired.");
+                return null;
+            }
+
+            try
+            {
+                var instance = (IModCardPileHandler)Activator.CreateInstance(declaringType)!;
+                return instance.OnOpen;
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.Logger.Error(
+                    $"[AutoRegister] RegisterOwnedCardPile: failed to instantiate handler '{declaringType.FullName}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private static ModTopBarButtonSpec BuildTopBarButtonSpec(Type declaringType,
+            RegisterOwnedTopBarButtonAttribute attr)
+        {
+            var handler = ResolveTopBarButtonHandler(declaringType);
+            return new()
+            {
+                IconPath = attr.IconPath,
+                LocStem = attr.LocStem,
+                Order = attr.ButtonOrder,
+                Offset = new(attr.OffsetX, attr.OffsetY),
+                OnClick = handler is null ? null : handler.OnClick,
+                VisibleWhen = handler is null ? null : handler.IsVisible,
+                IsOpenWhen = handler is null ? null : handler.IsOpen,
+                // IModTopBarButtonHandler.GetCount returns -1 by default, which NModCardPileButton
+                // interprets as "hide the badge". Handlers that want a count simply override GetCount
+                // and return a non-negative value.
+                CountProvider = handler is null ? null : handler.GetCount,
+            };
+        }
+
+        private static IModTopBarButtonHandler? ResolveTopBarButtonHandler(Type declaringType)
+        {
+            if (!typeof(IModTopBarButtonHandler).IsAssignableFrom(declaringType))
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[AutoRegister] RegisterOwnedTopBarButton: type '{declaringType.FullName}' must implement "
+                    + $"{nameof(IModTopBarButtonHandler)}; button will be registered without OnClick/VisibleWhen.");
+                return null;
+            }
+
+            if (declaringType.GetConstructor(Type.EmptyTypes) == null)
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[AutoRegister] RegisterOwnedTopBarButton: type '{declaringType.FullName}' has no parameterless "
+                    + "constructor — OnClick / VisibleWhen will not be wired.");
+                return null;
+            }
+
+            try
+            {
+                return (IModTopBarButtonHandler)Activator.CreateInstance(declaringType)!;
+            }
+            catch (Exception ex)
+            {
+                RitsuLibFramework.Logger.Error(
+                    $"[AutoRegister] RegisterOwnedTopBarButton: failed to instantiate handler '{declaringType.FullName}': {ex.Message}");
+                return null;
+            }
         }
 
         private static string? ResolveOwnerModId(Type type,

--- a/Interop/AutoRegistration/AutoRegistrationOperation.cs
+++ b/Interop/AutoRegistration/AutoRegistrationOperation.cs
@@ -8,9 +8,11 @@ namespace STS2RitsuLib.Interop.AutoRegistration
         ContentSecondary = 1,
         AncientMappings = 2,
         Keywords = 3,
-        TimelineLayout = 4,
-        Timeline = 5,
-        Unlocks = 6,
+        CardPiles = 4,
+        TopBarButtons = 5,
+        TimelineLayout = 6,
+        Timeline = 7,
+        Unlocks = 8,
     }
 
     internal sealed record AutoRegistrationOperation(

--- a/Interop/AutoRegistration/RegistrationAttributes.CardPiles.cs
+++ b/Interop/AutoRegistration/RegistrationAttributes.CardPiles.cs
@@ -1,0 +1,84 @@
+using STS2RitsuLib.CardPiles;
+
+namespace STS2RitsuLib.Interop.AutoRegistration
+{
+    /// <summary>
+    ///     Declaratively registers a mod card pile (see <see cref="ModCardPileRegistry" />). Place on any
+    ///     concrete class inside your mod assembly; the type itself acts as the registration carrier and
+    ///     can optionally implement <see cref="IModCardPileHandler" /> to customise button-click behaviour.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Field semantics mirror <see cref="ModCardPileSpec" />. Localization follows the vanilla
+    ///         pile convention — hover-tip title / description and the empty-pile thought bubble are all
+    ///         resolved against <see cref="ModCardPileSpec.HoverTipLocTable" /> using the keys
+    ///         <c>"{LocStem}.title"</c>, <c>"{LocStem}.description"</c> and <c>"{LocStem}.empty"</c>. Because
+    ///         mods can only extend existing loc tables (not create new ones) the table itself is not
+    ///         configurable; author your translations in <c>static_hover_tips.json</c>.
+    ///     </para>
+    ///     <para>
+    ///         Anchor values split across <see cref="AnchorKind" /> plus optional
+    ///         <see cref="AnchorOffsetX" /> / <see cref="AnchorOffsetY" /> /
+    ///         <see cref="AnchorCustomX" /> / <see cref="AnchorCustomY" />; when <see cref="AnchorKind" />
+    ///         is left at <see cref="ModCardPileAnchorKind.StyleDefault" /> the pile auto-stacks per the
+    ///         "explicit anchor + auto-stack fallback" rule.
+    ///     </para>
+    ///     <para>
+    ///         If the annotated type implements <see cref="IModCardPileHandler" />, ritsulib creates a
+    ///         single instance (parameterless constructor required) and wires its
+    ///         <see cref="IModCardPileHandler.OnOpen" /> method into
+    ///         <see cref="ModCardPileSpec.OnOpen" />.
+    ///     </para>
+    /// </remarks>
+    /// <param name="localPileStem">Local, mod-scoped pile stem (matches <c>RegisterOwned(localStem, ...)</c>).</param>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class RegisterOwnedCardPileAttribute(string localPileStem) : AutoRegistrationAttribute
+    {
+        /// <summary>Local, mod-scoped pile stem.</summary>
+        public string LocalPileStem { get; } = localPileStem;
+
+        /// <summary>Lifetime scope (defaults to <see cref="ModCardPileScope.CombatOnly" />).</summary>
+        public ModCardPileScope Scope { get; set; } = ModCardPileScope.CombatOnly;
+
+        /// <summary>UI chrome family (defaults to <see cref="ModCardPileUiStyle.Headless" />).</summary>
+        public ModCardPileUiStyle Style { get; set; } = ModCardPileUiStyle.Headless;
+
+        /// <summary>Anchor slot hint (defaults to <see cref="ModCardPileAnchorKind.StyleDefault" />).</summary>
+        public ModCardPileAnchorKind AnchorKind { get; set; } = ModCardPileAnchorKind.StyleDefault;
+
+        /// <summary>Extra X pixels added on top of the resolved anchor position.</summary>
+        public float AnchorOffsetX { get; set; }
+
+        /// <summary>Extra Y pixels added on top of the resolved anchor position.</summary>
+        public float AnchorOffsetY { get; set; }
+
+        /// <summary>Absolute X used only when <see cref="AnchorKind" /> is <see cref="ModCardPileAnchorKind.Custom" />.</summary>
+        public float AnchorCustomX { get; set; }
+
+        /// <summary>Absolute Y used only when <see cref="AnchorKind" /> is <see cref="ModCardPileAnchorKind.Custom" />.</summary>
+        public float AnchorCustomY { get; set; }
+
+        /// <summary>
+        ///     Godot resource path for the pile icon (e.g. <c>res://my_mod/icons/my_pile.png</c>).
+        /// </summary>
+        public string? IconPath { get; set; }
+
+        /// <summary>
+        ///     Optional localization stem (see <see cref="ModCardPileSpec.LocStem" />). When null, the
+        ///     normalized pile id is used as the stem — mirroring <c>ModKeywordRegistry</c>'s default.
+        /// </summary>
+        public string? LocStem { get; set; }
+
+        /// <summary>
+        ///     Optional hotkey ids forwarded to <c>NCardPileScreen.ShowScreen</c>. Separate ids with commas
+        ///     at the call site (<c>Hotkeys = new[] { "combat_pile_deck" }</c>).
+        /// </summary>
+        public string[]? Hotkeys { get; set; }
+
+        /// <summary>
+        ///     Only meaningful for <see cref="ModCardPileUiStyle.ExtraHand" />: when true, cards added to
+        ///     the pile are rendered as <c>NCard</c> nodes inside the pile container.
+        /// </summary>
+        public bool CardShouldBeVisible { get; set; }
+    }
+}

--- a/Interop/AutoRegistration/RegistrationAttributes.TopBarButtons.cs
+++ b/Interop/AutoRegistration/RegistrationAttributes.TopBarButtons.cs
@@ -1,0 +1,54 @@
+using STS2RitsuLib.TopBar;
+
+namespace STS2RitsuLib.Interop.AutoRegistration
+{
+    /// <summary>
+    ///     Declaratively registers a mod-owned top-bar button (see
+    ///     <see cref="ModTopBarButtonRegistry" />). Mirrors the ergonomics of
+    ///     <see cref="RegisterOwnedCardPileAttribute" /> but targets the generic, pile-independent
+    ///     top-bar button system.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Place on any concrete class inside your mod assembly. The annotated class must implement
+    ///         <see cref="IModTopBarButtonHandler" /> — ritsulib instantiates it once (parameterless
+    ///         constructor required) and wires
+    ///         <see cref="IModTopBarButtonHandler.OnClick" /> into <see cref="ModTopBarButtonSpec.OnClick" />
+    ///         and <see cref="IModTopBarButtonHandler.IsVisible" /> into
+    ///         <see cref="ModTopBarButtonSpec.VisibleWhen" />.
+    ///     </para>
+    ///     <para>
+    ///         Localization follows the vanilla loc-table convention: title / description are resolved
+    ///         against <c>static_hover_tips</c> using the keys <c>"{LocStem}.title"</c> and
+    ///         <c>"{LocStem}.description"</c>. When <see cref="LocStem" /> is null the registered id
+    ///         (<c>MYMOD_TOPBARBUTTON_STEM</c>) is used as the stem.
+    ///     </para>
+    /// </remarks>
+    /// <param name="localButtonStem">
+    ///     Local, mod-scoped stem (matches <c>RegisterOwned(localStem, ...)</c>).
+    /// </param>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class RegisterOwnedTopBarButtonAttribute(string localButtonStem) : AutoRegistrationAttribute
+    {
+        /// <summary>Local, mod-scoped button stem.</summary>
+        public string LocalButtonStem { get; } = localButtonStem;
+
+        /// <summary>Godot resource path for the icon (e.g. <c>res://my_mod/icons/recipes.png</c>).</summary>
+        public string? IconPath { get; set; }
+
+        /// <summary>
+        ///     Optional localization stem (see <see cref="ModTopBarButtonSpec.LocStem" />). Defaults to
+        ///     the registered id.
+        /// </summary>
+        public string? LocStem { get; set; }
+
+        /// <summary>Sort order within this mod's top-bar buttons.</summary>
+        public int ButtonOrder { get; set; }
+
+        /// <summary>Extra pixel offset X on top of the auto-stacked slot.</summary>
+        public float OffsetX { get; set; }
+
+        /// <summary>Extra pixel offset Y on top of the auto-stacked slot.</summary>
+        public float OffsetY { get; set; }
+    }
+}

--- a/Lifecycle/Patches/CoreLifecyclePatches.cs
+++ b/Lifecycle/Patches/CoreLifecyclePatches.cs
@@ -6,6 +6,7 @@ using MegaCrit.Sts2.Core.Multiplayer.Serialization;
 using MegaCrit.Sts2.Core.Nodes;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Saves;
+using STS2RitsuLib.CardPiles;
 using STS2RitsuLib.Content;
 using STS2RitsuLib.Diagnostics;
 using STS2RitsuLib.Keywords;
@@ -129,6 +130,7 @@ namespace STS2RitsuLib.Lifecycle.Patches
                 case ({ } declaringType, nameof(ModelDb.Init)) when declaringType == typeof(ModelDb):
                     ModContentRegistry.FreezeRegistrations(nameof(ModelDb.Init));
                     ModKeywordRegistry.FreezeRegistrations(nameof(ModelDb.Init));
+                    ModCardPileRegistry.FreezeRegistrations(nameof(ModelDb.Init));
                     ModTimelineRegistry.FreezeRegistrations(nameof(ModelDb.Init));
                     ModEpochGatedContentRegistry.FreezeRegistrations(nameof(ModelDb.Init));
                     ModUnlockRegistry.FreezeRegistrations(nameof(ModelDb.Init));

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -1,4 +1,5 @@
 using STS2RitsuLib.Audio.Patches;
+using STS2RitsuLib.CardPiles.Patches;
 using STS2RitsuLib.Cards.FreePlay.Patches;
 using STS2RitsuLib.Cards.Patches;
 using STS2RitsuLib.Combat.CardTargeting.Patches;
@@ -18,6 +19,7 @@ using STS2RitsuLib.Scaffolding.Content.Patches;
 using STS2RitsuLib.Scaffolding.Godot;
 using STS2RitsuLib.Settings.Patches;
 using STS2RitsuLib.Timeline.Patches;
+using STS2RitsuLib.TopBar.Patches;
 using STS2RitsuLib.Unlocks.Patches;
 using STS2RitsuLib.Utils.Persistence.Patches;
 
@@ -130,6 +132,19 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<CombatRoomToSerializableRewardExtPatch>();
             patcher.RegisterPatch<CombatRoomFromSerializableRewardExtPatch>();
             patcher.RegisterPatch<RewardFromSerializableExtPatch>();
+            patcher.RegisterPatch<ModCardPileGetPatch>();
+            patcher.RegisterPatch<ModCardPileIsCombatPatch>();
+            patcher.RegisterPatch<ModCardPileGetTargetPositionPatch>();
+            patcher.RegisterPatch<ModCardPileAllPilesPatch>();
+            patcher.RegisterPatch<ModCardPileFindOnTablePatch>();
+            patcher.RegisterPatch<ModCardPileCombatPilesContainerReadyPatch>();
+            patcher.RegisterPatch<ModCardPileCombatPilesContainerInitializePatch>();
+            patcher.RegisterPatch<ModCardPileTopBarReadyPatch>();
+            patcher.RegisterPatch<ModCardPileTopBarInitializePatch>();
+            patcher.RegisterPatch<ModCardPileCombatUiReadyPatch>();
+            patcher.RegisterPatch<ModCardPileCombatUiActivatePatch>();
+            patcher.RegisterPatch<ModTopBarActionButtonReadyPatch>();
+            patcher.RegisterPatch<ModTopBarActionButtonInitializePatch>();
             RegisterFrameworkPatcher(FrameworkPatcherArea.Core, patcher);
         }
 

--- a/Screens/ModScreenService.cs
+++ b/Screens/ModScreenService.cs
@@ -1,0 +1,86 @@
+using Godot;
+using MegaCrit.Sts2.Core.Nodes.Screens.Capstones;
+
+namespace STS2RitsuLib.Screens
+{
+    /// <summary>
+    ///     Lightweight mod-facing façade around <see cref="NCapstoneContainer" /> for opening and closing
+    ///     custom <see cref="ICapstoneScreen" />s without depending on any specific ritsulib subsystem
+    ///     (card piles, top-bar buttons, combat commands, …). This is the single public API any mod code
+    ///     should use when it wants to mount a screen as a full-page overlay.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The capstone container is a scene-owned singleton; during menus / between runs it may not
+    ///         yet exist. The helpers here therefore silently no-op when <see cref="NCapstoneContainer.Instance" />
+    ///         is null so callers do not need to guard every invocation.
+    ///     </para>
+    ///     <para>
+    ///         When a capstone screen is already showing, <see cref="Open" /> closes it first so the new
+    ///         screen can take the stage — matching the behaviour users expect when clicking "view"-style
+    ///         top-bar buttons that toggle or swap screens.
+    ///     </para>
+    /// </remarks>
+    public static class ModScreenService
+    {
+        /// <summary>
+        ///     The screen currently owning the capstone container, or null when the container is idle / not
+        ///     yet instantiated.
+        /// </summary>
+        public static ICapstoneScreen? CurrentCapstoneScreen => NCapstoneContainer.Instance?.CurrentCapstoneScreen;
+
+        /// <summary>
+        ///     True when a capstone is visible right now.
+        /// </summary>
+        public static bool IsCapstoneOpen => NCapstoneContainer.Instance is { InUse: true };
+
+        /// <summary>
+        ///     Mounts <paramref name="screen" /> inside <see cref="NCapstoneContainer" />. If a different
+        ///     capstone is already open, it is closed first; if the same instance is already mounted this
+        ///     is a no-op.
+        /// </summary>
+        /// <param name="screen">Screen to mount (must also be a Godot <see cref="Node" />).</param>
+        /// <returns>True when the screen was mounted; false when no container is available.</returns>
+        public static bool Open(ICapstoneScreen screen)
+        {
+            ArgumentNullException.ThrowIfNull(screen);
+
+            var container = NCapstoneContainer.Instance;
+            if (container == null)
+                return false;
+
+            if (ReferenceEquals(container.CurrentCapstoneScreen, screen))
+                return true;
+
+            if (container.InUse)
+                container.Close();
+
+            container.Open(screen);
+            return true;
+        }
+
+        /// <summary>
+        ///     Closes the current capstone, if any. Returns true when a close actually happened.
+        /// </summary>
+        public static bool Close()
+        {
+            var container = NCapstoneContainer.Instance;
+            if (container is not { InUse: true })
+                return false;
+
+            container.Close();
+            return true;
+        }
+
+        /// <summary>
+        ///     Convenience toggle: if <paramref name="screen" /> is already the current capstone, close it;
+        ///     otherwise open it.
+        /// </summary>
+        public static bool Toggle(ICapstoneScreen screen)
+        {
+            ArgumentNullException.ThrowIfNull(screen);
+
+            return ReferenceEquals(CurrentCapstoneScreen, screen) ? Close() : Open(screen);
+        }
+    }
+}

--- a/Settings/ModSettings/Mirrors/BaseLib/BaseLibVisibleIfPredicateFactory.cs
+++ b/Settings/ModSettings/Mirrors/BaseLib/BaseLibVisibleIfPredicateFactory.cs
@@ -33,7 +33,7 @@ namespace STS2RitsuLib.Settings
                     return BuildPropertyCondition(targetProperty, conditionArgs, isInverted);
 
                 var targetMethod = configType.GetMethod(target, bindingFlags);
-                if (targetMethod is { ReturnType: not null } && targetMethod.ReturnType == typeof(bool))
+                if (targetMethod is not null && targetMethod.ReturnType == typeof(bool))
                     return BuildMethodCondition(targetMethod, conditionArgs, isInverted);
 
                 return null;

--- a/TopBar/IModTopBarButtonHandler.cs
+++ b/TopBar/IModTopBarButtonHandler.cs
@@ -1,0 +1,47 @@
+namespace STS2RitsuLib.TopBar
+{
+    /// <summary>
+    ///     Optional counterpart of <see cref="ModTopBarButtonSpec.OnClick" /> /
+    ///     <see cref="ModTopBarButtonSpec.VisibleWhen" /> for classes tagged with
+    ///     <see cref="Interop.AutoRegistration.RegisterOwnedTopBarButtonAttribute" />. The
+    ///     auto-registration pipeline instantiates the annotated type (parameterless ctor) and wires
+    ///     <see cref="OnClick" /> / <see cref="IsVisible" /> into the produced spec.
+    /// </summary>
+    public interface IModTopBarButtonHandler
+    {
+        /// <summary>Invoked when the button is released (after the click tween starts).</summary>
+        void OnClick(ModTopBarButtonContext context);
+
+        /// <summary>
+        ///     Returns true when the button should be visible for the current player. Called from the
+        ///     button's <c>_Process</c>, so keep it cheap; returning true by default keeps the button
+        ///     always visible (matching the <see cref="ModTopBarButtonSpec.VisibleWhen" />
+        ///     <c>== null</c> behaviour).
+        /// </summary>
+        bool IsVisible(ModTopBarButtonContext context)
+        {
+            return true;
+        }
+
+        /// <summary>
+        ///     Returns true when the associated screen / mode is currently "open", letting the button rock
+        ///     in the vanilla top-bar-button style. Defaults to false (stateless button). Typical usage is
+        ///     <c>ctx =&gt; ModScreenService.CurrentCapstoneScreen is MyScreen</c>.
+        /// </summary>
+        bool IsOpen(ModTopBarButtonContext context)
+        {
+            return false;
+        }
+
+        /// <summary>
+        ///     Returns the current count to display in the button's count badge. Defaults to -1, which
+        ///     the auto-registration pipeline treats as "no count provider" — the badge stays hidden and
+        ///     the button looks like a plain icon. Override this when the button tracks something the
+        ///     player cares about a running total of (e.g. unlocked recipes).
+        /// </summary>
+        int GetCount(ModTopBarButtonContext context)
+        {
+            return -1;
+        }
+    }
+}

--- a/TopBar/ModTopBarButtonContext.cs
+++ b/TopBar/ModTopBarButtonContext.cs
@@ -1,0 +1,72 @@
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Nodes.Screens.Capstones;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.Screens;
+
+namespace STS2RitsuLib.TopBar
+{
+    /// <summary>
+    ///     Context passed to <see cref="ModTopBarButtonSpec.OnClick" /> and
+    ///     <see cref="ModTopBarButtonSpec.VisibleWhen" /> callbacks. Exposes the registry definition, the
+    ///     local <see cref="Player" /> this button is bound to, and convenience forwarders to
+    ///     <see cref="ModScreenService" /> so handlers don't need to pull in capstone plumbing directly.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A single context instance is constructed per click / visibility probe — it is not cached.
+    ///         <see cref="Player" /> may be null when visibility is probed before the local player has been
+    ///         resolved (for example, between runs), in which case <see cref="ModTopBarButtonSpec.VisibleWhen" />
+    ///         handlers should be prepared to return false.
+    ///     </para>
+    /// </remarks>
+    public sealed class ModTopBarButtonContext
+    {
+        internal ModTopBarButtonContext(
+            ModTopBarButtonDefinition definition,
+            Player? player,
+            NModCardPileButton? button)
+        {
+            Definition = definition;
+            Player = player;
+            Button = button;
+        }
+
+        /// <summary>Registry definition that produced the button.</summary>
+        public ModTopBarButtonDefinition Definition { get; }
+
+        /// <summary>Local player the button is currently bound to (null while the run is still booting).</summary>
+        public Player? Player { get; }
+
+        /// <summary>
+        ///     The Godot button node, when the callback is coming from a real UI click. Shared with the
+        ///     card-pile subsystem — action-mode buttons are instances of <see cref="NModCardPileButton" />
+        ///     with <see cref="NModCardPileButton.ActionDefinition" /> set rather than a pile, so the UI
+        ///     layer is identical to <see cref="STS2RitsuLib.CardPiles.ModCardPileRegistry" /> buttons.
+        /// </summary>
+        public NModCardPileButton? Button { get; }
+
+        /// <summary>
+        ///     Opens <paramref name="screen" /> via <see cref="ModScreenService.Open" />.
+        /// </summary>
+        public bool OpenCapstoneScreen(ICapstoneScreen screen)
+        {
+            return ModScreenService.Open(screen);
+        }
+
+        /// <summary>
+        ///     Toggles <paramref name="screen" /> — opens it if not currently mounted, closes it otherwise.
+        /// </summary>
+        public bool ToggleCapstoneScreen(ICapstoneScreen screen)
+        {
+            return ModScreenService.Toggle(screen);
+        }
+
+        /// <summary>
+        ///     Closes the current capstone, if any.
+        /// </summary>
+        public bool CloseCapstoneScreen()
+        {
+            return ModScreenService.Close();
+        }
+    }
+}

--- a/TopBar/ModTopBarButtonDefinition.cs
+++ b/TopBar/ModTopBarButtonDefinition.cs
@@ -1,0 +1,71 @@
+using System.Numerics;
+using MegaCrit.Sts2.Core.Localization;
+
+namespace STS2RitsuLib.TopBar
+{
+    /// <summary>
+    ///     Immutable registry entry for a mod-owned top-bar button.
+    /// </summary>
+    public sealed record ModTopBarButtonDefinition
+    {
+        internal ModTopBarButtonDefinition(
+            string modId,
+            string id,
+            string? iconPath,
+            string? locStem,
+            int order,
+            Vector2 offset,
+            Action<ModTopBarButtonContext>? onClick,
+            Func<ModTopBarButtonContext, bool>? visibleWhen,
+            Func<ModTopBarButtonContext, bool>? isOpenWhen,
+            Func<ModTopBarButtonContext, int>? countProvider)
+        {
+            ModId = modId;
+            Id = id;
+            IconPath = iconPath;
+            LocStem = string.IsNullOrWhiteSpace(locStem) ? id : locStem;
+            Order = order;
+            Offset = offset;
+            OnClick = onClick;
+            VisibleWhen = visibleWhen;
+            IsOpenWhen = isOpenWhen;
+            CountProvider = countProvider;
+        }
+
+        /// <summary>Owning mod id.</summary>
+        public string ModId { get; }
+
+        /// <summary>Normalized global id (e.g. <c>MYMOD_TOPBARBUTTON_RECIPES</c>).</summary>
+        public string Id { get; }
+
+        /// <summary>Godot resource path for the icon, or null.</summary>
+        public string? IconPath { get; }
+
+        /// <summary>Effective loc stem (defaults to <see cref="Id" />).</summary>
+        public string LocStem { get; }
+
+        /// <summary>Sort order within this mod's top-bar buttons.</summary>
+        public int Order { get; }
+
+        /// <summary>Extra pixel offset on top of the auto-stacked slot.</summary>
+        public Vector2 Offset { get; }
+
+        /// <summary>Click handler; see <see cref="ModTopBarButtonSpec.OnClick" />.</summary>
+        public Action<ModTopBarButtonContext>? OnClick { get; }
+
+        /// <summary>Optional visibility predicate; see <see cref="ModTopBarButtonSpec.VisibleWhen" />.</summary>
+        public Func<ModTopBarButtonContext, bool>? VisibleWhen { get; }
+
+        /// <summary>Optional "screen open" predicate; see <see cref="ModTopBarButtonSpec.IsOpenWhen" />.</summary>
+        public Func<ModTopBarButtonContext, bool>? IsOpenWhen { get; }
+
+        /// <summary>Optional count provider for the badge; see <see cref="ModTopBarButtonSpec.CountProvider" />.</summary>
+        public Func<ModTopBarButtonContext, int>? CountProvider { get; }
+
+        /// <summary>Hover-tip title resolved against <c>static_hover_tips</c> with key <c>{LocStem}.title</c>.</summary>
+        public LocString Title => new(ModTopBarButtonSpec.HoverTipLocTable, $"{LocStem}.title");
+
+        /// <summary>Hover-tip description resolved against <c>static_hover_tips</c> with key <c>{LocStem}.description</c>.</summary>
+        public LocString Description => new(ModTopBarButtonSpec.HoverTipLocTable, $"{LocStem}.description");
+    }
+}

--- a/TopBar/ModTopBarButtonHoverTipFactory.cs
+++ b/TopBar/ModTopBarButtonHoverTipFactory.cs
@@ -1,0 +1,30 @@
+using Godot;
+using MegaCrit.Sts2.Core.HoverTips;
+
+namespace STS2RitsuLib.TopBar
+{
+    /// <summary>
+    ///     Produces a vanilla <see cref="HoverTip" /> for a <see cref="ModTopBarButtonDefinition" /> from
+    ///     its icon path + localized title / description. Mirrors <c>ModCardPileHoverTipFactory</c>.
+    /// </summary>
+    public static class ModTopBarButtonHoverTipFactory
+    {
+        /// <summary>
+        ///     Builds a <see cref="HoverTip" /> combining the <see cref="ModTopBarButtonDefinition.Title" />
+        ///     / <see cref="ModTopBarButtonDefinition.Description" /> loc strings with the icon texture at
+        ///     <see cref="ModTopBarButtonDefinition.IconPath" />. Falls back to a text-only hover tip when
+        ///     the icon path is empty or points at a missing resource.
+        /// </summary>
+        public static HoverTip Create(ModTopBarButtonDefinition definition)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+
+            Texture2D? icon = null;
+            if (!string.IsNullOrWhiteSpace(definition.IconPath)
+                && ResourceLoader.Exists(definition.IconPath))
+                icon = ResourceLoader.Load<Texture2D>(definition.IconPath);
+
+            return new(definition.Title, definition.Description, icon);
+        }
+    }
+}

--- a/TopBar/ModTopBarButtonRegistry.cs
+++ b/TopBar/ModTopBarButtonRegistry.cs
@@ -1,0 +1,148 @@
+using STS2RitsuLib.Content;
+using Logger = MegaCrit.Sts2.Core.Logging.Logger;
+
+namespace STS2RitsuLib.TopBar
+{
+    /// <summary>
+    ///     Per-mod registration surface for extra top-bar buttons. Mirrors the ergonomics of
+    ///     <c>ModCardPileRegistry</c> (fluent <c>For(modId).RegisterOwned(localStem, spec)</c>), but is
+    ///     fully decoupled from the card-pile subsystem — the button only knows how to show an icon,
+    ///     expose a hover-tip and run a click callback.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Ids follow the ritsulib <c>MODID_CATEGORY_TYPENAME</c> public-entry convention via
+    ///         <see cref="ModContentRegistry.GetQualifiedTopBarButtonId" /> (middle segment fixed to
+    ///         <c>TOPBARBUTTON</c>). The registered id doubles as the default <c>LocStem</c> used to
+    ///         resolve <c>static_hover_tips</c> title / description keys.
+    ///     </para>
+    ///     <para>
+    ///         Registrations do not need to be frozen alongside <c>ModelDb</c>: top-bar buttons are mounted
+    ///         when the top bar node is ready, which happens after model init. The registry therefore
+    ///         simply de-duplicates by id (same mod re-registering the same stem returns the existing
+    ///         definition).
+    ///     </para>
+    /// </remarks>
+    public sealed class ModTopBarButtonRegistry
+    {
+        private static readonly Lock SyncRoot = new();
+
+        private static readonly Dictionary<string, ModTopBarButtonRegistry> Registries =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly Dictionary<string, ModTopBarButtonDefinition> Definitions =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        private readonly Logger _logger;
+        private readonly string _modId;
+
+        private ModTopBarButtonRegistry(string modId)
+        {
+            _modId = modId;
+            _logger = RitsuLibFramework.CreateLogger(modId);
+        }
+
+        /// <summary>Returns the singleton registry for <paramref name="modId" />, creating it on first use.</summary>
+        public static ModTopBarButtonRegistry For(string modId)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+
+            lock (SyncRoot)
+            {
+                if (Registries.TryGetValue(modId, out var existing))
+                    return existing;
+
+                var created = new ModTopBarButtonRegistry(modId);
+                Registries[modId] = created;
+                return created;
+            }
+        }
+
+        /// <summary>
+        ///     Registers a top-bar button owned by this registry's mod. The id is produced by
+        ///     <see cref="ModContentRegistry.GetQualifiedTopBarButtonId" /> — passing the same
+        ///     <paramref name="localStem" /> twice returns the existing definition.
+        /// </summary>
+        public ModTopBarButtonDefinition RegisterOwned(string localStem, ModTopBarButtonSpec spec)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(localStem);
+            ArgumentNullException.ThrowIfNull(spec);
+
+            var id = ModContentRegistry.GetQualifiedTopBarButtonId(_modId, localStem);
+            return RegisterCore(id, spec);
+        }
+
+        /// <summary>
+        ///     Registers a top-bar button using a raw global id. Prefer <see cref="RegisterOwned" /> to
+        ///     keep ids mod-scoped.
+        /// </summary>
+        public ModTopBarButtonDefinition Register(string id, ModTopBarButtonSpec spec)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            ArgumentNullException.ThrowIfNull(spec);
+
+            return RegisterCore(id, spec);
+        }
+
+        /// <summary>Looks up a definition by id; returns false when the id is unknown.</summary>
+        public static bool TryGet(string id, out ModTopBarButtonDefinition definition)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+            lock (SyncRoot)
+            {
+                return Definitions.TryGetValue(id.Trim(), out definition!);
+            }
+        }
+
+        /// <summary>
+        ///     Snapshot of every registered button, ordered by <see cref="ModTopBarButtonDefinition.Order" />
+        ///     then id for stability.
+        /// </summary>
+        public static ModTopBarButtonDefinition[] GetDefinitionsSnapshot()
+        {
+            lock (SyncRoot)
+            {
+                return Definitions.Values
+                    .OrderBy(def => def.Order)
+                    .ThenBy(def => def.Id, StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        private ModTopBarButtonDefinition RegisterCore(string id, ModTopBarButtonSpec spec)
+        {
+            var normalizedId = id.Trim();
+
+            var definition = new ModTopBarButtonDefinition(
+                _modId,
+                normalizedId,
+                spec.IconPath,
+                spec.LocStem,
+                spec.Order,
+                spec.Offset,
+                spec.OnClick,
+                spec.VisibleWhen,
+                spec.IsOpenWhen,
+                spec.CountProvider);
+
+            lock (SyncRoot)
+            {
+                if (Definitions.TryGetValue(normalizedId, out var existing))
+                {
+                    if (!StringComparer.OrdinalIgnoreCase.Equals(existing.ModId, definition.ModId))
+                        throw new InvalidOperationException(
+                            $"Top-bar button '{normalizedId}' is already registered by mod '{existing.ModId}'; "
+                            + $"mod '{definition.ModId}' cannot re-register it.");
+
+                    return existing;
+                }
+
+                Definitions[normalizedId] = definition;
+            }
+
+            _logger.Info($"[TopBar] Registered top-bar button: {normalizedId} (Order={spec.Order})");
+            return definition;
+        }
+    }
+}

--- a/TopBar/ModTopBarButtonRegistry.cs
+++ b/TopBar/ModTopBarButtonRegistry.cs
@@ -113,6 +113,9 @@ namespace STS2RitsuLib.TopBar
         private ModTopBarButtonDefinition RegisterCore(string id, ModTopBarButtonSpec spec)
         {
             var normalizedId = id.Trim();
+        if (spec.OnClick == null)
+            throw new InvalidOperationException(
+                $"Top-bar button '{normalizedId}' must provide a non-null OnClick handler.");
 
             var definition = new ModTopBarButtonDefinition(
                 _modId,

--- a/TopBar/ModTopBarButtonSpec.cs
+++ b/TopBar/ModTopBarButtonSpec.cs
@@ -1,0 +1,80 @@
+using System.Numerics;
+
+namespace STS2RitsuLib.TopBar
+{
+    /// <summary>
+    ///     Declarative spec for a mod-owned top-bar button. Mirrors <c>ModCardPileSpec</c>'s structure but is
+    ///     fully decoupled from card piles — the only contract is "show a button next to the vanilla deck
+    ///     button, hover-tip via <c>static_hover_tips</c>, click runs a callback".
+    /// </summary>
+    /// <remarks>
+    ///     Localization follows the same <c>static_hover_tips.{LocStem}.title</c> / <c>.description</c>
+    ///     convention used by <c>ModCardPileSpec</c>; <see cref="LocStem" /> defaults to the registered id
+    ///     (<c>MODID_TOPBARBUTTON_STEM</c>) when left null.
+    /// </remarks>
+    public sealed record ModTopBarButtonSpec
+    {
+        /// <summary>Vanilla loc table that the button's hover-tip resolves against.</summary>
+        public const string HoverTipLocTable = ModTopBarButtonLocConstants.HoverTipLocTable;
+
+        /// <summary>Godot resource path for the button icon (for example <c>res://my_mod/icon.png</c>).</summary>
+        public string? IconPath { get; init; }
+
+        /// <summary>
+        ///     Stem used to build <c>{LocStem}.title</c> / <c>{LocStem}.description</c> under
+        ///     <c>static_hover_tips</c>. Defaults to the registered id (<c>MODID_TOPBARBUTTON_STEM</c>)
+        ///     when left null.
+        /// </summary>
+        public string? LocStem { get; init; }
+
+        /// <summary>
+        ///     Sort order within a single mod's top-bar buttons; lower values render closer to the vanilla
+        ///     deck button.
+        /// </summary>
+        public int Order { get; init; }
+
+        /// <summary>
+        ///     Extra pixel offset applied on top of the auto-stacked slot position. Use this for
+        ///     fine-tuning when the default horizontal stacking layout doesn't match your icon.
+        /// </summary>
+        public Vector2 Offset { get; init; }
+
+        /// <summary>
+        ///     Required click handler. Receives a <see cref="ModTopBarButtonContext" /> that exposes
+        ///     <see cref="ModTopBarButtonContext.OpenCapstoneScreen" /> / related helpers.
+        /// </summary>
+        public Action<ModTopBarButtonContext>? OnClick { get; init; }
+
+        /// <summary>
+        ///     Optional predicate that decides whether the button is visible for the current player. When
+        ///     null the button is always visible (once the top bar exists). Evaluated on
+        ///     <see cref="Godot.Node._Process" /> to keep the visibility state in sync with combat/run state
+        ///     changes.
+        /// </summary>
+        public Func<ModTopBarButtonContext, bool>? VisibleWhen { get; init; }
+
+        /// <summary>
+        ///     Optional predicate used by the button to decide when it should render in its "screen open"
+        ///     rocking state (mirroring vanilla <c>NTopBarDeckButton</c> / <c>NTopBarMapButton</c>). Typical
+        ///     usage is
+        ///     <c>ctx =&gt; ModScreenService.CurrentCapstoneScreen is MyScreen</c>. When null the button never
+        ///     enters the open state — pick this for one-shot "fire and forget" click handlers.
+        /// </summary>
+        public Func<ModTopBarButtonContext, bool>? IsOpenWhen { get; init; }
+
+        /// <summary>
+        ///     Optional provider used to populate the count badge under the button's icon. Called on
+        ///     <see cref="Godot.Node._Process" /> — keep it cheap. When null, the count label is hidden
+        ///     entirely, which is the right choice for fire-and-forget action buttons (menus, toggles).
+        ///     When set, the button reuses the vanilla card-pile "number jumped up" bump animation so the
+        ///     feedback feels identical to the player's deck / draw / discard counts.
+        /// </summary>
+        public Func<ModTopBarButtonContext, int>? CountProvider { get; init; }
+    }
+
+    /// <summary>Shared constants for the top-bar-button localization convention.</summary>
+    internal static class ModTopBarButtonLocConstants
+    {
+        public const string HoverTipLocTable = "static_hover_tips";
+    }
+}

--- a/TopBar/ModTopBarLayout.cs
+++ b/TopBar/ModTopBarLayout.cs
@@ -93,47 +93,102 @@ namespace STS2RitsuLib.TopBar
         ///     — the enclosing <see cref="HBoxContainer" /> drives the actual screen position.
         ///     Returns true on success, false when the top bar isn't ready yet (caller should retry).
         /// </summary>
-        /// <remarks>
-        ///     The <paramref name="offset" /> parameter is intentionally ignored here: in an
-        ///     HBoxContainer-driven layout, "offset" doesn't map cleanly to a property without
-        ///     fighting the container. It's kept on the public API because existing definitions may
-        ///     supply it, but mods that relied on nudging their button by a few pixels should
-        ///     instead adjust their registration order or wait for a dedicated spacing knob.
-        /// </remarks>
         public static bool Place(NTopBar topBar, NModCardPileButton button, Vector2 offset = default)
         {
             ArgumentNullException.ThrowIfNull(topBar);
             ArgumentNullException.ThrowIfNull(button);
-            _ = offset;
 
             var container = GetRightAlignedContainer(topBar);
             var anchor = GetDeckSlotAnchor(topBar);
             if (container == null || anchor == null)
                 return false;
 
-            // Re-parent into the HBoxContainer if the injector dropped the button somewhere else
-            // (e.g. directly on NTopBar). Don't carry over Position / Size — the container will
-            // assign them based on CustomMinimumSize and the HBoxContainer's alignment rules.
-            if (button.GetParent() != container)
-            {
-                button.GetParent()?.RemoveChild(button);
-                container.AddChildSafely(button);
-            }
+        return PlaceBeforeAnchor(container, anchor, button, offset);
+    }
 
-            // Reset any stray transform state so HBoxContainer layout isn't fighting leftover values
-            // from an earlier "manual Position" implementation.
-            button.Position = Vector2.Zero;
-            button.Scale = Vector2.One;
+    /// <summary>
+    ///     Attaches <paramref name="button" /> to the right-aligned container and places it immediately
+    ///     <b>after</b> the deck slot anchor (typically between deck and pause).
+    /// </summary>
+    /// <returns>False when the top bar anchor nodes are not ready yet.</returns>
+    public static bool PlaceAfterDeck(NTopBar topBar, NModCardPileButton button, Vector2 offset = default)
+    {
+        ArgumentNullException.ThrowIfNull(topBar);
+        ArgumentNullException.ThrowIfNull(button);
 
-            // Slide the button into the slot immediately before the deck anchor. The anchor index
-            // must be re-read AFTER the reparent above because move_child shifts indices.
-            var anchorIndex = anchor.GetIndex();
-            var currentIndex = button.GetIndex();
-            var targetIndex = currentIndex < anchorIndex ? anchorIndex - 1 : anchorIndex;
-            if (currentIndex != targetIndex)
-                container.MoveChild(button, targetIndex);
+        var container = GetRightAlignedContainer(topBar);
+        var anchor = GetDeckSlotAnchor(topBar);
+        if (container == null || anchor == null)
+            return false;
 
-            return true;
+        return PlaceAfterAnchor(container, anchor, button, offset);
+    }
+
+    /// <summary>
+    ///     Attaches <paramref name="button" /> to the right-aligned container and places it immediately
+    ///     <b>before</b> the modifiers slot when available; falls back to the default deck-left placement.
+    /// </summary>
+    /// <returns>False only when all candidate anchors are unavailable.</returns>
+    public static bool PlaceBeforeModifiers(NTopBar topBar, NModCardPileButton button, Vector2 offset = default)
+    {
+        ArgumentNullException.ThrowIfNull(topBar);
+        ArgumentNullException.ThrowIfNull(button);
+
+        var container = GetRightAlignedContainer(topBar);
+        if (container == null)
+            return false;
+
+        var modifiers = topBar.GetNodeOrNull<Control>("%Modifiers");
+        if (modifiers == null)
+            return Place(topBar, button, offset);
+
+        Node anchor = modifiers;
+        while (anchor.GetParent() is { } parent && parent != container)
+            anchor = parent;
+        if (anchor.GetParent() != container)
+            return Place(topBar, button, offset);
+
+        return PlaceBeforeAnchor(container, anchor, button, offset);
+    }
+
+    private static bool PlaceBeforeAnchor(Control container, Node anchor, NModCardPileButton button, Vector2 offset)
+    {
+        AttachToContainer(container, button);
+
+        var anchorIndex = anchor.GetIndex();
+        var currentIndex = button.GetIndex();
+        var targetIndex = currentIndex < anchorIndex ? anchorIndex - 1 : anchorIndex;
+        if (currentIndex != targetIndex)
+            container.MoveChild(button, targetIndex);
+
+        button.ApplyVisualOffset(offset);
+        return true;
+    }
+
+    private static bool PlaceAfterAnchor(Control container, Node anchor, NModCardPileButton button, Vector2 offset)
+    {
+        AttachToContainer(container, button);
+
+        var anchorIndex = anchor.GetIndex();
+        var currentIndex = button.GetIndex();
+        var targetIndex = currentIndex < anchorIndex ? anchorIndex : anchorIndex + 1;
+        if (currentIndex != targetIndex)
+            container.MoveChild(button, targetIndex);
+
+        button.ApplyVisualOffset(offset);
+        return true;
+    }
+
+    private static void AttachToContainer(Control container, NModCardPileButton button)
+    {
+        if (button.GetParent() != container)
+        {
+            button.GetParent()?.RemoveChild(button);
+            container.AddChildSafely(button);
+        }
+
+        button.Position = Vector2.Zero;
+        button.Scale = Vector2.One;
         }
 
         /// <summary>

--- a/TopBar/ModTopBarLayout.cs
+++ b/TopBar/ModTopBarLayout.cs
@@ -1,0 +1,148 @@
+using Godot;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
+using STS2RitsuLib.CardPiles.Nodes;
+using NVec2 = System.Numerics.Vector2;
+
+namespace STS2RitsuLib.TopBar
+{
+    /// <summary>
+    ///     Single source of truth for where mod top-bar buttons land relative to the vanilla
+    ///     <c>%Deck</c> button. Both pile-backed
+    ///     <see cref="STS2RitsuLib.CardPiles.ModCardPileUiStyle.TopBarDeck" /> buttons and
+    ///     action-backed <see cref="ModTopBarButtonRegistry" /> buttons funnel through this helper so
+    ///     the two systems cannot disagree about slot ordering / direction — addressing the user
+    ///     feedback that having <i>two</i> independent layout algorithms was a "meaningless split".
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The actual layout container for the right-side cluster is
+    ///         <c>RootSceneContainer/Run/GlobalUi/TopBar/RightAlignedStuff</c> — and crucially it is
+    ///         an <see cref="HBoxContainer" /> (<c>separation=0</c>, <c>alignment=end</c>) that
+    ///         auto-lays out its children left-to-right in registration order. The canonical vanilla
+    ///         child sequence is <c>[SaveIndicator][Padding][TimerContainer][Map][DeckContainer][PauseButton]</c>
+    ///         — so to drop a mod button "just to the left of the deck" we need two things:
+    ///         <list type="number">
+    ///             <item>the button must be parented under this HBoxContainer, and</item>
+    ///             <item>its child index must be immediately before <c>DeckContainer</c>'s index.</item>
+    ///         </list>
+    ///         Because the container is auto-laid-out, we <b>do not</b> set
+    ///         <see cref="Control.Position" /> ourselves — doing so would fight the HBoxContainer and
+    ///         produce the "button appears nowhere visible" bug from the previous iteration.
+    ///     </para>
+    ///     <para>
+    ///         Slot ordering: mod buttons are inserted in registration order, each one claiming the
+    ///         slot <i>immediately before</i> the deck container / deck button. The newest
+    ///         registration ends up closest to the deck; the earliest registration ends up furthest
+    ///         left. This keeps every mod button contiguous with the vanilla deck icon and avoids
+    ///         splitting them into "pile row" / "action row".
+    ///     </para>
+    /// </remarks>
+    public static class ModTopBarLayout
+    {
+        /// <summary>
+        ///     Returns the real right-side layout container (<c>RightAlignedStuff</c>, an
+        ///     <see cref="HBoxContainer" />) — the parent of either <c>%Deck</c> directly or the
+        ///     <c>DeckContainer</c> that wraps it. Returns null when the top bar hasn't resolved
+        ///     <see cref="NTopBar.Deck" /> yet.
+        /// </summary>
+        public static Control? GetRightAlignedContainer(NTopBar topBar)
+        {
+            ArgumentNullException.ThrowIfNull(topBar);
+            var deck = topBar.Deck;
+            if (deck == null)
+                return null;
+            // Deck in 0.103.x lives inside a `DeckContainer` MarginContainer; walk up until we hit
+            // the HBoxContainer so the lookup is stable across scene refactors that add / remove the
+            // wrapper.
+            var cursor = deck.GetParent();
+            while (cursor is { } node)
+            {
+                if (node is HBoxContainer hbox)
+                    return hbox;
+                cursor = node.GetParent();
+            }
+
+            return deck.GetParent() as Control;
+        }
+
+        /// <summary>
+        ///     Returns the direct child of the right-aligned container that ultimately contains
+        ///     <c>%Deck</c> — in 0.103.x this is the <c>DeckContainer</c> <see cref="MarginContainer" />
+        ///     that wraps the deck button. We insert mod buttons immediately <i>before</i> this node
+        ///     so they land "just to the left of the deck", matching the existing vanilla placement
+        ///     of Map / DeckContainer / PauseButton.
+        /// </summary>
+        public static Node? GetDeckSlotAnchor(NTopBar topBar)
+        {
+            var container = GetRightAlignedContainer(topBar);
+            var deck = topBar.Deck;
+            if (container == null || deck == null)
+                return null;
+            Node cursor = deck;
+            while (cursor.GetParent() is { } parent && parent != container)
+                cursor = parent;
+            return cursor.GetParent() == container ? cursor : null;
+        }
+
+        /// <summary>
+        ///     Attaches <paramref name="button" /> to the right-aligned container (re-parenting when
+        ///     necessary) and orders it so it sits immediately to the <b>left</b> of the deck-slot
+        ///     anchor. The button is sized to match one vanilla top-bar slot
+        ///     (<c>80×80</c> minimum) and left at <see cref="Vector2.Zero" /> <see cref="Control.Position" />
+        ///     — the enclosing <see cref="HBoxContainer" /> drives the actual screen position.
+        ///     Returns true on success, false when the top bar isn't ready yet (caller should retry).
+        /// </summary>
+        /// <remarks>
+        ///     The <paramref name="offset" /> parameter is intentionally ignored here: in an
+        ///     HBoxContainer-driven layout, "offset" doesn't map cleanly to a property without
+        ///     fighting the container. It's kept on the public API because existing definitions may
+        ///     supply it, but mods that relied on nudging their button by a few pixels should
+        ///     instead adjust their registration order or wait for a dedicated spacing knob.
+        /// </remarks>
+        public static bool Place(NTopBar topBar, NModCardPileButton button, Vector2 offset = default)
+        {
+            ArgumentNullException.ThrowIfNull(topBar);
+            ArgumentNullException.ThrowIfNull(button);
+            _ = offset;
+
+            var container = GetRightAlignedContainer(topBar);
+            var anchor = GetDeckSlotAnchor(topBar);
+            if (container == null || anchor == null)
+                return false;
+
+            // Re-parent into the HBoxContainer if the injector dropped the button somewhere else
+            // (e.g. directly on NTopBar). Don't carry over Position / Size — the container will
+            // assign them based on CustomMinimumSize and the HBoxContainer's alignment rules.
+            if (button.GetParent() != container)
+            {
+                button.GetParent()?.RemoveChild(button);
+                container.AddChildSafely(button);
+            }
+
+            // Reset any stray transform state so HBoxContainer layout isn't fighting leftover values
+            // from an earlier "manual Position" implementation.
+            button.Position = Vector2.Zero;
+            button.Scale = Vector2.One;
+
+            // Slide the button into the slot immediately before the deck anchor. The anchor index
+            // must be re-read AFTER the reparent above because move_child shifts indices.
+            var anchorIndex = anchor.GetIndex();
+            var currentIndex = button.GetIndex();
+            var targetIndex = currentIndex < anchorIndex ? anchorIndex - 1 : anchorIndex;
+            if (currentIndex != targetIndex)
+                container.MoveChild(button, targetIndex);
+
+            return true;
+        }
+
+        /// <summary>
+        ///     System.Numerics-flavoured overload for callers (e.g. <see cref="ModTopBarButtonSpec" />)
+        ///     that carry offsets as <see cref="NVec2" />.
+        /// </summary>
+        public static bool Place(NTopBar topBar, NModCardPileButton button, NVec2 offset)
+        {
+            return Place(topBar, button, new Vector2(offset.X, offset.Y));
+        }
+    }
+}

--- a/TopBar/Patches/ModTopBarButtonPatches.cs
+++ b/TopBar/Patches/ModTopBarButtonPatches.cs
@@ -1,0 +1,105 @@
+using MegaCrit.Sts2.Core.Context;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
+using MegaCrit.Sts2.Core.Runs;
+using STS2RitsuLib.CardPiles.Nodes;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.TopBar.Patches
+{
+    /// <summary>
+    ///     Mounts every registered <see cref="ModTopBarButtonDefinition" /> onto <see cref="NTopBar" /> after
+    ///     its vanilla <c>_Ready</c> has populated <c>%Deck</c>. Buttons are <see cref="NModCardPileButton" />
+    ///     instances in "action mode" — that is, they look and animate exactly like <b>pile-backed</b>
+    ///     <see cref="STS2RitsuLib.CardPiles.ModCardPileRegistry" /> top-bar buttons, but dispatch clicks
+    ///     through <see cref="ModTopBarButtonSpec.OnClick" /> and draw their count label from
+    ///     <see cref="ModTopBarButtonSpec.CountProvider" />. The two registries share one placement
+    ///     algorithm (see <see cref="ModTopBarLayout" />) so the player-side cluster next to <c>%Deck</c>
+    ///     never splits into "pile row" vs "action row".
+    /// </summary>
+    public sealed class ModTopBarActionButtonReadyPatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_top_bar_ready_action_inject";
+
+        /// <inheritdoc />
+        public static string Description => "Inject mod action buttons into NTopBar";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(NTopBar), nameof(NTopBar._Ready))];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>
+        ///     Wires generic mod top-bar buttons alongside the vanilla deck/map/pause nodes and any
+        ///     pile-backed <see cref="STS2RitsuLib.CardPiles.ModCardPileUiStyle.TopBarDeck" /> buttons.
+        /// </summary>
+        public static void Postfix(NTopBar __instance)
+        {
+            var definitions = ModTopBarButtonRegistry.GetDefinitionsSnapshot();
+            if (definitions.Length == 0)
+                return;
+
+            // The right-side cluster (%Deck / %Map / %Pause / Options …) lives inside the
+            // `RightAlignedStuff` container, not directly on NTopBar. `ModTopBarLayout.Place` handles
+            // that re-parenting for us so buttons end up as siblings of %Deck.
+            foreach (var definition in definitions)
+            {
+                var button = NModCardPileButton.CreateAction(definition);
+                __instance.AddChildSafely(button);
+                ModTopBarLayout.Place(__instance, button, definition.Offset);
+            }
+        }
+        // ReSharper restore InconsistentNaming
+    }
+
+    /// <summary>
+    ///     Binds every injected action-mode <see cref="NModCardPileButton" /> to the local
+    ///     <see cref="Player" /> on <see cref="NTopBar.Initialize" />, mirroring
+    ///     <c>ModCardPileTopBarInitializePatch</c>.
+    /// </summary>
+    public sealed class ModTopBarActionButtonInitializePatch : IPatchMethod
+    {
+        /// <inheritdoc />
+        public static string PatchId => "ritsulib_top_bar_initialize_action_bind";
+
+        /// <inheritdoc />
+        public static string Description =>
+            "Bind mod action buttons to the local player on NTopBar.Initialize";
+
+        /// <inheritdoc />
+        public static bool IsCritical => false;
+
+        /// <inheritdoc />
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(NTopBar), nameof(NTopBar.Initialize), [typeof(IRunState)]),
+            ];
+        }
+
+        // ReSharper disable InconsistentNaming
+        /// <summary>Binds each injected action button to the local <see cref="Player" />.</summary>
+        public static void Postfix(NTopBar __instance, IRunState runState)
+        {
+            var player = LocalContext.GetMe(runState);
+            if (player == null)
+                return;
+            // Action buttons live inside `RightAlignedStuff` (Deck's parent), not on NTopBar directly.
+            var container = ModTopBarLayout.GetRightAlignedContainer(__instance);
+            if (container == null)
+                return;
+            foreach (var button in container.GetChildren().OfType<NModCardPileButton>())
+                if (button.IsActionMode)
+                    button.Initialize(player);
+        }
+        // ReSharper restore InconsistentNaming
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive set of new types and utilities to support mod-defined card piles in the `STS2RitsuLib.CardPiles` namespace. It establishes the core data structures, UI anchoring system, and injection/layout logic needed for mod card piles to integrate seamlessly with the game's UI, including support for custom handlers, localization, and flexible placement.

Key changes include:

**Core Data Structures and Contracts**

* Added `ModCardPileDefinition`, an immutable registry entry representing a mod card pile, including metadata such as style, anchor, icon, localization stem, and UI behavior callbacks. This enables mods to define new card piles with rich metadata and custom behavior.
* Introduced `IModCardPileHandler`, an optional interface for classes that want to handle custom pile open events, allowing mods to override default pile UI behavior.
* Added `ModCardPile`, a runtime instance of a mod card pile that extends the vanilla `CardPile` and references its definition for metadata lookups.

**UI Placement and Anchoring**

* Defined `ModCardPileAnchorKind` and `ModCardPileAnchor`, which together provide a flexible system for specifying where a pile's UI should appear (e.g., bottom left, top bar, custom position), including pixel offsets and auto-stacking behavior.

**UI Integration and Layout**

* Implemented `ModCardPileInjector`, which mounts mod pile UI elements into the appropriate game UI containers based on their style and anchor, and initializes them for the local player. This includes support for combat buttons, top bar buttons, and extra hand containers.
* Added `ModCardPileLayout`, which determines the screen-space target positions for card fly-in animations based on pile definitions and current UI state, ensuring cards animate to the correct mod pile location.

**Localization and Hover Tips**

* Added `ModCardPileHoverTipFactory`, which generates localized hover tips for mod piles using their definition's metadata and icon, mirroring the vanilla keyword hover tip UX.