### PR TITLE
Ergonomic: Add CreateRgbShaderMaterial and pageDescription

### DIFF
--- a/Scaffolding/Content/ModEventTemplate.cs
+++ b/Scaffolding/Content/ModEventTemplate.cs
@@ -1,5 +1,6 @@
 using Godot;
 using MegaCrit.Sts2.Core.Events;
+using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using STS2RitsuLib.Scaffolding.Content.Patches;
 
@@ -93,6 +94,11 @@ namespace STS2RitsuLib.Scaffolding.Content
         {
             return ModOptionKey("INITIAL", optionName);
         }
+
+        /// <summary>
+        ///     Gets the localized description for a page.
+        /// </summary>
+        protected LocString PageDescription(string pageName) => L10NLookup($"{Id.Entry}.pages.{pageName}.description");
 
         /// <summary>
         ///     Creates a relic-grant option for a mutable relic resolved from <typeparamref name="T" />.

--- a/Scaffolding/Content/TypeListCardPoolModel.cs
+++ b/Scaffolding/Content/TypeListCardPoolModel.cs
@@ -11,6 +11,8 @@ namespace STS2RitsuLib.Scaffolding.Content
     public abstract class TypeListCardPoolModel : CardPoolModel, IModBigEnergyIconPool, IModTextEnergyIconPool,
         IModCardPoolFrameMaterial
     {
+        public override string Title => EnergyColorName;
+
         /// <summary>
         ///     Legacy hook: enumerating card types on the pool class. Prefer registering each card through
         ///     <c>ModContentRegistry.RegisterCard&lt;TPool, TCard&gt;()</c>, <c>CreateContentPack.Card&lt;TPool, TCard&gt;()</c>,

--- a/Scaffolding/Content/TypeListCardPoolModel.cs
+++ b/Scaffolding/Content/TypeListCardPoolModel.cs
@@ -11,8 +11,6 @@ namespace STS2RitsuLib.Scaffolding.Content
     public abstract class TypeListCardPoolModel : CardPoolModel, IModBigEnergyIconPool, IModTextEnergyIconPool,
         IModCardPoolFrameMaterial
     {
-        public override string Title => EnergyColorName;
-
         /// <summary>
         ///     Legacy hook: enumerating card types on the pool class. Prefer registering each card through
         ///     <c>ModContentRegistry.RegisterCard&lt;TPool, TCard&gt;()</c>, <c>CreateContentPack.Card&lt;TPool, TCard&gt;()</c>,

--- a/Utils/MaterialUtils.cs
+++ b/Utils/MaterialUtils.cs
@@ -20,13 +20,31 @@ namespace STS2RitsuLib.Utils
             _vanillaDoomBarNoiseTexture ??= CreateVanillaDoomBarNoiseTexture();
 
         /// <summary>
+        ///     Builds a <c>ShaderMaterial</c> using the game's HSV shader with the given RGB parameters.
+        /// </summary>
+        public static ShaderMaterial CreateRgbShaderMaterial(float r, float g, float b)
+        {
+            var shader = GameHsvShader ?? throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
+            var color = new Color(r, g, b);
+
+            var material = new ShaderMaterial
+            {
+                Shader = shader,
+            };
+
+            material.SetShaderParameter("h", color.H);
+            material.SetShaderParameter("s", color.S);
+            material.SetShaderParameter("v", color.V);
+
+            return material;
+        }
+
+        /// <summary>
         ///     Builds a <c>ShaderMaterial</c> using the game's HSV shader with the given parameters.
         /// </summary>
         public static ShaderMaterial CreateHsvShaderMaterial(float h, float s, float v)
         {
-            var shader = GameHsvShader;
-            if (shader == null)
-                throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
+            var shader = GameHsvShader ?? throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
 
             var material = new ShaderMaterial
             {

--- a/Utils/MaterialUtils.cs
+++ b/Utils/MaterialUtils.cs
@@ -24,19 +24,22 @@ namespace STS2RitsuLib.Utils
         /// </summary>
         public static ShaderMaterial CreateRgbShaderMaterial(float r, float g, float b)
         {
-            var shader = GameHsvShader ?? throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
-            var color = new Color(r, g, b);
+            var max = Math.Max(r, Math.Max(g, b));
+            var min = Math.Min(r, Math.Min(g, b));
+            var delta = max - min;
 
-            var material = new ShaderMaterial
+            float h = 0;
+            if (delta != 0)
             {
-                Shader = shader,
-            };
+                if (max == r) h = (g - b) / delta + (g < b ? 6 : 0);
+                else if (max == g) h = (b - r) / delta + 2;
+                else h = (r - g) / delta + 4;
+                h /= 6;
+            }
 
-            material.SetShaderParameter("h", color.H);
-            material.SetShaderParameter("s", color.S);
-            material.SetShaderParameter("v", color.V);
-
-            return material;
+            var s = (max == 0) ? 0 : (delta / max);
+            var v = max;
+            return CreateHsvShaderMaterial(h, s, v);
         }
 
         /// <summary>


### PR DESCRIPTION
1. CreateRgbShaderMaterial

添加了`CreateRgbShaderMaterial`，用于在CardPool中生成`PoolFrameMaterial`。
原先只能使用`CreateHsvShaderMaterial`，可用于丰富开发者颜色选择。

2. PageDescription

在`ModEventTemplate`中添加了`pageDescription`，替代`L10NLookup($"{Id.Entry}.pages.{pageName}.description")`，减少重复代码的编写。