### PR TITLE
fix(character): merge registered starter content

### DIFF
--- a/Content/DynamicCharacterStarterContentPatcher.cs
+++ b/Content/DynamicCharacterStarterContentPatcher.cs
@@ -5,6 +5,7 @@ using MegaCrit.Sts2.Core.Logging;
 using MegaCrit.Sts2.Core.Models;
 using STS2RitsuLib.Patching.Builders;
 using STS2RitsuLib.Patching.Core;
+using STS2RitsuLib.Scaffolding.Characters;
 
 namespace STS2RitsuLib.Content
 {
@@ -84,7 +85,7 @@ namespace STS2RitsuLib.Content
             Logger logger)
         {
             var getter = FindDeclaredPropertyGetter(concreteCharacterType, propertyName);
-            if (getter == null || !queuedGetters.Add(getter))
+            if (getter == null || IsModCharacterTemplateGetter(getter) || !queuedGetters.Add(getter))
                 return;
 
             try
@@ -116,6 +117,13 @@ namespace STS2RitsuLib.Content
             }
 
             return null;
+        }
+
+        private static bool IsModCharacterTemplateGetter(MethodInfo getter)
+        {
+            var declaringType = getter.DeclaringType;
+            return declaringType is { IsGenericType: true }
+                   && declaringType.GetGenericTypeDefinition() == typeof(ModCharacterTemplate<,,>);
         }
 
         // ReSharper disable InconsistentNaming

--- a/Scaffolding/Characters/ModCharacterTemplate.cs
+++ b/Scaffolding/Characters/ModCharacterTemplate.cs
@@ -611,10 +611,12 @@ namespace STS2RitsuLib.Scaffolding.Characters
 
         private IEnumerable<CardModel> ResolveStartingDeck()
         {
-            var localEntries = GetLocalStartingDeckEntries();
+            var localTypes = GetLocalStartingDeckEntries()
+                .SelectMany(static entry => Enumerable.Repeat(entry.CardType, Math.Max(entry.Count, 0)));
+            var registeredTypes = ModContentRegistry.GetRegisteredCharacterStarterCards(GetType());
 
-            return localEntries
-                .SelectMany(static entry => Enumerable.Repeat(entry.CardType, Math.Max(entry.Count, 0)))
+            return localTypes
+                .Concat(registeredTypes)
                 .Select(type => ModelDb.GetById<CardModel>(ModelDb.GetId(type)))
                 .ToArray();
         }
@@ -622,6 +624,7 @@ namespace STS2RitsuLib.Scaffolding.Characters
         private IReadOnlyList<RelicModel> ResolveStartingRelics()
         {
             return GetLocalStartingRelicTypes()
+                .Concat(ModContentRegistry.GetRegisteredCharacterStarterRelics(GetType()))
                 .Select(type => ModelDb.GetById<RelicModel>(ModelDb.GetId(type)))
                 .ToArray();
         }
@@ -629,6 +632,7 @@ namespace STS2RitsuLib.Scaffolding.Characters
         private IReadOnlyList<PotionModel> ResolveStartingPotions()
         {
             return GetLocalStartingPotionTypes()
+                .Concat(ModContentRegistry.GetRegisteredCharacterStarterPotions(GetType()))
                 .Select(type => ModelDb.GetById<PotionModel>(ModelDb.GetId(type)))
                 .ToArray();
         }


### PR DESCRIPTION
## Summary / 概要
- Fix `ModCharacterTemplate` starter content resolution so registered starter cards, relics, and potions are merged directly into template character models.
- Prevent template character starter getters from also receiving the dynamic starter postfix, avoiding duplicate starter content.

## Why / 背景与动机
- The vanilla character select screen reads `StartingRelics[0]` directly for non-random characters.
- Mod characters such as Hiro successfully registered starter relics through RitsuLib, but `ModCharacterTemplate` only resolved legacy local starter hooks, so `StartingRelics` could remain empty.
- This caused `ArgumentOutOfRangeException` when selecting affected mod characters.

## What changed / 变更点
- Updated `ModCharacterTemplate` to append registered starter content from `ModContentRegistry`:
  - `GetRegisteredCharacterStarterCards(GetType())`
  - `GetRegisteredCharacterStarterRelics(GetType())`
  - `GetRegisteredCharacterStarterPotions(GetType())`
- Kept legacy local starter hooks first, then appended registered starter content without deduplication.
- Updated `DynamicCharacterStarterContentPatcher` to skip `ModCharacterTemplate<,,>` getters, since template characters now merge registered starter content directly.
- Preserved dynamic starter postfix behavior for non-template `CharacterModel` implementations.

## Test plan / 测试计划
- [x] Build passes
- [ ] Basic runtime smoke test: launch the game and select Hiro / another template mod character that uses registered starter relics

## Notes / 备注
- Dynamic starter patch count may be lower after this change because `ModCharacterTemplate<,,>` getters are intentionally skipped.
- This change does not require modifying ManosabaLin/Hiro character code.
