### PR TITLE
Add localization support for filter tooltips

### DIFF
--- a/Scaffolding/Characters/Patches/CardLibraryCompendiumPatch.cs
+++ b/Scaffolding/Characters/Patches/CardLibraryCompendiumPatch.cs
@@ -281,7 +281,7 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
             filter.AddChild(reticle);
             reticle.Owner = filter;
 
-            var id = registration.StableId.ToUpperInvariant();
+            var id = ModContentRegistry.GetCompoundId(registration.OwningModId, "POOLFILTER",registration.StableId);
             if (LocManager.Instance.GetTable("card_library").HasEntry(id))
                 filter.Loc = new LocString("card_library", id);
 

--- a/Scaffolding/Characters/Patches/CardLibraryCompendiumPatch.cs
+++ b/Scaffolding/Characters/Patches/CardLibraryCompendiumPatch.cs
@@ -2,6 +2,7 @@ using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using MegaCrit.Sts2.Core.Nodes.Screens.CardLibrary;
@@ -279,6 +280,10 @@ namespace STS2RitsuLib.Scaffolding.Characters.Patches
             reticle.UniqueNameInOwner = true;
             filter.AddChild(reticle);
             reticle.Owner = filter;
+
+            var id = registration.StableId.ToUpperInvariant();
+            if (LocManager.Instance.GetTable("card_library").HasEntry(id))
+                filter.Loc = new LocString("card_library", id);
 
             return filter;
         }


### PR DESCRIPTION
## Summary / 概要
- 给通过`RegisterCardLibraryCompendiumSharedPoolFilter`注册的共享卡牌池添加显示tooltip的能力。

<img width="686" height="236" alt="QQ20260511-143339" src="https://github.com/user-attachments/assets/378483bc-b159-4a55-a76b-c01b63df6b27" />

## Why / 背景与动机
- 原版无色、杂项、先古池都有tooltip，只需给`loc`变量赋值即可展示tooltip。

## What changed / 变更点
- 在`CardLibraryCompendiumPatch.CreateSharedPoolFilter`中判断`card_library`表是否有`stableId`大写的id的本地化文本，如果有就给filter的loc赋值以添加tooltip。

## Notes / 备注
- 该修改较为简陋，仅作为个人临时实现，~~可当做issue看待~~
- loc table为`card_library`。和原版一致。
- `GetCompoundId`使用了`POOLFILTER`。
- 未修改文档和xml注释。
