### PR TITLE
Add epoch vfx & prevent add NotObtained epoch into timeline

### DIFF
--- a/Timeline/ModTimelineNeowCoExpansion.cs
+++ b/Timeline/ModTimelineNeowCoExpansion.cs
@@ -83,7 +83,10 @@ namespace STS2RitsuLib.Timeline
                 if (model is not ModEpochTemplate)
                     continue;
 
-                slotsToAdd.Add(new(model, ResolveMergedModSlotState(id, progress)));
+                var state = ResolveMergedModSlotState(id, progress);
+                if (state == EpochSlotState.NotObtained)
+                    continue;
+                slotsToAdd.Add(new(model, state));
                 existing.Add(id);
             }
 

--- a/Unlocks/ModUnlockRegistry.cs
+++ b/Unlocks/ModUnlockRegistry.cs
@@ -1,5 +1,8 @@
 using MegaCrit.Sts2.Core.Context;
+using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Vfx;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Runs;
@@ -671,6 +674,7 @@ namespace STS2RitsuLib.Unlocks
                     continue;
 
                 SaveManager.Instance.ObtainEpoch(rule.EpochId);
+                NGame.Instance?.AddChildSafely(NGainEpochVfx.Create(EpochModel.Get(rule.EpochId)));
                 if (!localPlayer.DiscoveredEpochs.Contains(rule.EpochId, StringComparer.Ordinal))
                     localPlayer.DiscoveredEpochs.Add(rule.EpochId);
 

--- a/Unlocks/Patches/AscensionOneEpochCompatibilityPatch.cs
+++ b/Unlocks/Patches/AscensionOneEpochCompatibilityPatch.cs
@@ -1,9 +1,13 @@
 using HarmonyLib;
+using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Multiplayer.Game.Lobby;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Vfx;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Managers;
 using MegaCrit.Sts2.Core.Saves.Runs;
+using MegaCrit.Sts2.Core.Timeline;
 using STS2RitsuLib.Compat;
 using STS2RitsuLib.Content;
 using STS2RitsuLib.Patching.Models;
@@ -80,6 +84,7 @@ namespace STS2RitsuLib.Unlocks.Patches
                 return false;
 
             SaveManager.Instance.ObtainEpoch(epochId);
+            NGame.Instance?.AddChildSafely(NGainEpochVfx.Create(EpochModel.Get(epochId)));
             if (!serializablePlayer.DiscoveredEpochs.Contains(epochId, StringComparer.Ordinal))
                 serializablePlayer.DiscoveredEpochs.Add(epochId);
 
@@ -155,6 +160,7 @@ namespace STS2RitsuLib.Unlocks.Patches
                 return false;
 
             SaveManager.Instance.ObtainEpoch(epochId);
+            NGame.Instance?.AddChildSafely(NGainEpochVfx.Create(EpochModel.Get(epochId)));
             if (!serializablePlayer.DiscoveredEpochs.Contains(epochId, StringComparer.Ordinal))
                 serializablePlayer.DiscoveredEpochs.Add(epochId);
 

--- a/Unlocks/Patches/BossEpochCompatibilityPatch.cs
+++ b/Unlocks/Patches/BossEpochCompatibilityPatch.cs
@@ -1,7 +1,11 @@
 using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Vfx;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Managers;
+using MegaCrit.Sts2.Core.Timeline;
 using STS2RitsuLib.Content;
 using STS2RitsuLib.Patching.Models;
 using STS2RitsuLib.Scaffolding.Characters;
@@ -73,6 +77,7 @@ namespace STS2RitsuLib.Unlocks.Patches
                 return false;
 
             SaveManager.Instance.ObtainEpoch(rule.EpochId);
+            NGame.Instance?.AddChildSafely(NGainEpochVfx.Create(EpochModel.Get(rule.EpochId)));
             if (!localPlayer.DiscoveredEpochs.Contains(rule.EpochId, StringComparer.Ordinal))
                 localPlayer.DiscoveredEpochs.Add(rule.EpochId);
 

--- a/Unlocks/Patches/EliteEpochModHandling.cs
+++ b/Unlocks/Patches/EliteEpochModHandling.cs
@@ -1,8 +1,12 @@
 using System.Reflection;
 using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Vfx;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Managers;
+using MegaCrit.Sts2.Core.Timeline;
 using STS2RitsuLib.Compat;
 using STS2RitsuLib.Content;
 using STS2RitsuLib.Scaffolding.Characters;
@@ -84,6 +88,7 @@ namespace STS2RitsuLib.Unlocks.Patches
                 return;
 
             SaveManager.Instance.ObtainEpoch(rule.EpochId);
+            NGame.Instance?.AddChildSafely(NGainEpochVfx.Create(EpochModel.Get(rule.EpochId)));
             if (!localPlayer.DiscoveredEpochs.Contains(rule.EpochId, StringComparer.Ordinal))
                 localPlayer.DiscoveredEpochs.Add(rule.EpochId);
 


### PR DESCRIPTION
## Summary / 概要
- 为所有解锁epoch的时机添加解锁动画`NGainEpochVfx`
- `NTimelineScreen.AddEpochSlots`时，去掉`NotObtained`的slot，否则会提前获得UI

## Why / 背景与动机
1. 没有epoch解锁动画。`NGainEpochVfx`会自动进行顺序排队播放无需更改。
2. 在新存档点击捏奥epoch时，会出现所有自定义的epoch（包括`NotObtained`的），点击解锁自定义角色的epoch后会无视重复创建UI。

<img width="2560" height="1528" alt="图片" src="https://github.com/user-attachments/assets/0262dbb5-b132-4dd3-baf7-f176eb1174c3" />

## What changed / 变更点
- `Timeline/ModTimelineNeowCoExpansion.cs`: `MergeModEpochTemplateSlotsInto`
- `Unlocks/ModUnlockRegistry.cs`: `ProcessRunEnded`
- `Unlocks/Patches/AscensionOneEpochCompatibilityPatch.cs`: `Prefix`
- `Unlocks/Patches/BossEpochCompatibilityPatch.cs`: `Prefix`
- `Unlocks/Patches/EliteEpochModHandling.cs`: `TryHandleModEliteEpoch`

## Test plan / 测试计划
- [x] Build passes
- [x] Basic runtime smoke test (if applicable)

## Notes / 备注
此外`ModTimelineNeowCoExpansion.UnlockModEpochSlotsCore`中的`SaveManager.Instance.UnlockSlot`会产生错误log噪音，暂未修复

```
[ERROR] Slot unlocked for TEST_ASCENSION_ONE_EPOCH but it's in an invalid state: NotObtained
   at MegaCrit.Sts2.Core.Saves.ProgressState.UnlockSlot(String epochId)
   at MegaCrit.Sts2.Core.Timeline.EpochModel.QueueTimelineExpansion_Patch2(EpochModel[] epochs)
   at STS2RitsuLib.Timeline.Scaffolding.CharacterUnlockEpochTemplate`1.QueueUnlocks()
```
