### PR TITLE
Add content source inspection

### DIFF
--- a/Content/ContentSourceHoverTipFactory.cs
+++ b/Content/ContentSourceHoverTipFactory.cs
@@ -1,9 +1,11 @@
 using System.Reflection;
+using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.HoverTips;
 using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using STS2RitsuLib.Compat;
 using STS2RitsuLib.Data;
+using STS2RitsuLib.Keywords;
 using STS2RitsuLib.Localization;
 using STS2RitsuLib.Settings;
 
@@ -46,14 +48,14 @@ namespace STS2RitsuLib.Content
             };
         }
 
-        private static LocString GetTitle()
+        internal static LocString GetTitle()
         {
             I18NLocTableBridge.TryRegister(Const.ModId, ModSettingsLocalization.Instance, LocTableStem);
             var tableId = I18NLocTableBridge.GetTableId(Const.ModId, LocTableStem);
             return new(tableId, TitleKey);
         }
 
-        private static ContentSourceInfo Resolve(Type modelType)
+        internal static ContentSourceInfo Resolve(Type modelType)
         {
             lock (SyncRoot)
             {
@@ -68,6 +70,16 @@ namespace STS2RitsuLib.Content
             }
 
             return resolved;
+        }
+
+        internal static ContentSourceInfo ResolveKeyword(CardKeyword keyword)
+        {
+            if (ModKeywordRegistry.TryGetByCardKeyword(keyword, out var def))
+            {
+                return ResolveMod(def.ModId);
+            }
+
+            return ContentSourceInfo.Vanilla;
         }
 
         private static ContentSourceInfo ResolveUncached(Type modelType)
@@ -128,7 +140,7 @@ namespace STS2RitsuLib.Content
             return string.IsNullOrWhiteSpace(displayName) ? fallback : displayName.Trim();
         }
 
-        private readonly record struct ContentSourceInfo(string Id, string DisplayName)
+        internal readonly record struct ContentSourceInfo(string Id, string DisplayName)
         {
             public static ContentSourceInfo Vanilla { get; } = new("Vanilla", "Slay The Spire2");
 

--- a/Content/IContentSourceSupplier.cs
+++ b/Content/IContentSourceSupplier.cs
@@ -1,0 +1,17 @@
+namespace STS2RitsuLib.Content
+{
+    /// <summary>
+    ///     Allows a model to dynamically supply its own content source format string for UI displays,
+    ///     overriding the default mod source resolution.
+    ///     允许模型动态提供用于 UI 显示的内容来源格式化字符串，
+    ///     从而覆盖其默认 mod 内容来源解析。
+    /// </summary>
+    public interface IContentSourceSupplier
+    {
+        /// <summary>
+        ///     The pre-formatted source string to display (e.g., "[Vanilla]", "My Mod").
+        ///     要显示的预格式化来源字符串（例如 "[Vanilla]"、"My Mod"）。
+        /// </summary>
+        string ContentSource { get; }
+    }
+}

--- a/Content/Patches/ContentSourceHoverTipPatches.cs
+++ b/Content/Patches/ContentSourceHoverTipPatches.cs
@@ -1,102 +1,153 @@
+using System.Reflection;
+using Godot;
 using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.HoverTips;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.HoverTips;
+using MegaCrit.Sts2.Core.Nodes.Screens;
+using MegaCrit.Sts2.Core.Nodes.Screens.InspectScreens;
+using STS2RitsuLib.Data;
 using STS2RitsuLib.Patching.Models;
 
 namespace STS2RitsuLib.Content.Patches
 {
     internal static class ContentSourceHoverTipPatchHelper
     {
+        internal static void Append(string info, ref HoverTip tip) => tip.Description = $"[purple]{info}[/purple]\n{tip.Description}";
+
         internal static void Append(AbstractModel model, ref IEnumerable<IHoverTip> result)
         {
+            if (model is IContentSourceSupplier supplier)
+            {
+                result = [new HoverTip(ContentSourceHoverTipFactory.GetTitle(), supplier.ContentSource), .. result];
+                return;
+            }
+
             if (!ContentSourceHoverTipFactory.TryCreate(model, out var tip))
                 return;
 
-            result = result.Concat([tip]).ToArray();
+            result = [tip, .. result];
         }
     }
 
-    internal sealed class CardModelSourceHoverTipPatch : IPatchMethod
+    internal sealed class ContentSourceKeywordHoverTipPatch : IPatchMethod
     {
-        public static string PatchId => "ritsulib_card_model_source_hover_tip";
+        public static string PatchId => "content_source_keyword_hover_tip";
 
-        public static string Description => "Append content source hover tip to card hover tips";
+        public static string Description => "Add content source hover tip to keyword hover tips, if available from ContentSourceHoverTipFactory";
+
+        public static bool IsCritical => false;
+
+        public static ModPatchTarget[] GetTargets() => [new(typeof(HoverTipFactory), "FromKeyword")];
+
+        // ReSharper disable once InconsistentNaming
+        public static void Postfix(CardKeyword keyword, ref IHoverTip __result)
+        // ReSharper restore once InconsistentNaming
+        {
+            if (!RitsuLibSettingsStore.IsModSourceHoverTipsEnabled())
+                return;
+
+            var info = ContentSourceHoverTipFactory.ResolveKeyword(keyword);
+            if (info.Id == "Vanilla")
+                return;
+
+            if (__result is HoverTip tip)
+            {
+                ContentSourceHoverTipPatchHelper.Append(info.Format(), ref tip);
+                __result = tip;
+            }
+        }
+    }
+
+    internal sealed class ContentSourceModelHoverTipPatch : IPatchMethod
+    {
+        public static string PatchId => "content_source_model_hover_tip";
+
+        public static string Description => "Add content source hover tip to all models that have a source registered in ContentSourceHoverTipFactory";
+
+        public static bool IsCritical => false;
+
+        public static ModPatchTarget[] GetTargets() => [
+                new(typeof(PotionModel), "HoverTip", MethodType.Getter),
+                new(typeof(PowerModel), "DumbHoverTip", MethodType.Getter),
+                new(typeof(RelicModel), "HoverTip", MethodType.Getter),
+                new(typeof(OrbModel), "DumbHoverTip", MethodType.Getter),
+                new(typeof(EnchantmentModel), "HoverTip", MethodType.Getter),
+                new(typeof(AfflictionModel), "HoverTip", MethodType.Getter),
+            ];
+
+        // ReSharper disable once InconsistentNaming
+        public static void Postfix(AbstractModel __instance, ref HoverTip __result)
+        // ReSharper restore once InconsistentNaming
+        {
+            if (!RitsuLibSettingsStore.IsModSourceHoverTipsEnabled())
+                return;
+
+            if (__instance is IContentSourceSupplier supplier)
+            {
+                ContentSourceHoverTipPatchHelper.Append(supplier.ContentSource, ref __result);
+                return;
+            }
+
+            var info = ContentSourceHoverTipFactory.Resolve(__instance.GetType());
+            if (info.Id == "Vanilla")
+                return;
+
+            ContentSourceHoverTipPatchHelper.Append(info.Format(), ref __result);
+        }
+    }
+
+    internal sealed class ContentSourceNHoverTipSetShowPatch : IPatchMethod
+    {
+        public static string PatchId => "nhover_tip_set_inspect_screen_show_source";
+
+        public static string Description =>
+            "Show content source in NInspectCardScreen and NInspectRelicScreen, if available from ContentSourceHoverTipFactory";
 
         public static bool IsCritical => false;
 
         public static ModPatchTarget[] GetTargets()
         {
-            return [new(typeof(CardModel), "HoverTips", MethodType.Getter)];
+            return [new(typeof(NHoverTipSet), "CreateAndShow", [typeof(Control), typeof(IEnumerable<IHoverTip>), typeof(HoverTipAlignment)])];
         }
 
-        // ReSharper disable InconsistentNaming
-        public static void Postfix(CardModel __instance, ref IEnumerable<IHoverTip> __result)
-            // ReSharper restore InconsistentNaming
+        private static readonly FieldInfo? CardsField = AccessTools.Field(typeof(NInspectCardScreen), "_cards");
+        private static readonly FieldInfo? CardsIndexField = AccessTools.Field(typeof(NInspectCardScreen), "_index");
+        private static readonly FieldInfo? RelicsField = AccessTools.Field(typeof(NInspectRelicScreen), "_relics");
+        private static readonly FieldInfo? RelicsIndexField = AccessTools.Field(typeof(NInspectRelicScreen), "_index");
+
+        private static void AppendTip<T>(FieldInfo? listField, FieldInfo? indexField, Control screen, ref IEnumerable<IHoverTip> hoverTips) where T : AbstractModel
         {
-            ContentSourceHoverTipPatchHelper.Append(__instance, ref __result);
-        }
-    }
+            if (listField == null || indexField == null)
+                return;
 
-    internal sealed class RelicModelSourceHoverTipPatch : IPatchMethod
-    {
-        public static string PatchId => "ritsulib_relic_model_source_hover_tip";
+            var index = (int)indexField.GetValue(screen)!;
+            if (listField.GetValue(screen) is not IList<T> list || index < 0 || index >= list.Count)
+                return;
 
-        public static string Description => "Append content source hover tip to relic hover tips";
+            if (list[index] is not AbstractModel model)
+                return;
 
-        public static bool IsCritical => false;
-
-        public static ModPatchTarget[] GetTargets()
-        {
-            return [new(typeof(RelicModel), "HoverTips", MethodType.Getter)];
-        }
-
-        // ReSharper disable InconsistentNaming
-        public static void Postfix(RelicModel __instance, ref IEnumerable<IHoverTip> __result)
-            // ReSharper restore InconsistentNaming
-        {
-            ContentSourceHoverTipPatchHelper.Append(__instance, ref __result);
-        }
-    }
-
-    internal sealed class RelicModelSourceHoverTipExcludingRelicPatch : IPatchMethod
-    {
-        public static string PatchId => "ritsulib_relic_model_source_hover_tip_excluding_relic";
-
-        public static string Description => "Append content source hover tip to relic side hover tips";
-
-        public static bool IsCritical => false;
-
-        public static ModPatchTarget[] GetTargets()
-        {
-            return [new(typeof(RelicModel), "HoverTipsExcludingRelic", MethodType.Getter)];
+            ContentSourceHoverTipPatchHelper.Append(model, ref hoverTips);
         }
 
-        // ReSharper disable InconsistentNaming
-        public static void Postfix(RelicModel __instance, ref IEnumerable<IHoverTip> __result)
-            // ReSharper restore InconsistentNaming
+        // ReSharper disable once InconsistentNaming
+        public static void Prefix(Control owner, ref IEnumerable<IHoverTip> hoverTips)
+        // ReSharper restore once InconsistentNaming
         {
-            ContentSourceHoverTipPatchHelper.Append(__instance, ref __result);
-        }
-    }
+            if (!RitsuLibSettingsStore.IsModSourceHoverTipsEnabled())
+                return;
 
-    internal sealed class PotionModelSourceHoverTipPatch : IPatchMethod
-    {
-        public static string PatchId => "ritsulib_potion_model_source_hover_tip";
+            if (owner is NInspectCardScreen cardScreen)
+            {
+                AppendTip<CardModel>(CardsField, CardsIndexField, cardScreen, ref hoverTips);
+            }
 
-        public static string Description => "Append content source hover tip to potion hover tips";
-
-        public static bool IsCritical => false;
-
-        public static ModPatchTarget[] GetTargets()
-        {
-            return [new(typeof(PotionModel), "HoverTips", MethodType.Getter)];
-        }
-
-        // ReSharper disable InconsistentNaming
-        public static void Postfix(PotionModel __instance, ref IEnumerable<IHoverTip> __result)
-            // ReSharper restore InconsistentNaming
-        {
-            ContentSourceHoverTipPatchHelper.Append(__instance, ref __result);
+            if (owner is NInspectRelicScreen relicScreen)
+            {
+                AppendTip<RelicModel>(RelicsField, RelicsIndexField, relicScreen, ref hoverTips);
+            }
         }
     }
 }

--- a/RitsuLibFramework.PatcherSetup.cs
+++ b/RitsuLibFramework.PatcherSetup.cs
@@ -264,10 +264,9 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<CardBannerMaterialPatch>();
             patcher.RegisterPatch<CardDynamicVarTooltipPatch>();
             patcher.RegisterPatch<DynamicVarTooltipClonePatch>();
-            patcher.RegisterPatch<CardModelSourceHoverTipPatch>();
-            patcher.RegisterPatch<RelicModelSourceHoverTipPatch>();
-            patcher.RegisterPatch<RelicModelSourceHoverTipExcludingRelicPatch>();
-            patcher.RegisterPatch<PotionModelSourceHoverTipPatch>();
+            patcher.RegisterPatch<ContentSourceKeywordHoverTipPatch>();
+            patcher.RegisterPatch<ContentSourceModelHoverTipPatch>();
+            patcher.RegisterPatch<ContentSourceNHoverTipSetShowPatch>();
             patcher.RegisterPatch<ModKeywordCardDescriptionPatches>();
             patcher.RegisterPatch<EnergyIconHelperPathPatch>();
             patcher.RegisterPatch<EnergyIconFormatterPatch>();

--- a/Settings/Localization/ModSettingsUi/eng.json
+++ b/Settings/Localization/ModSettingsUi/eng.json
@@ -93,7 +93,7 @@
   "ritsulib.updateCheck.enabled.description": "Checks for RitsuLib updates once after the first main menu load.",
   "ritsulib.modSourceHoverTips.enabled.label": "Show content source hover tips",
   "ritsulib.modSourceHoverTips.enabled.description": "Adds a hover tip to cards, relics, and potions showing which mod provides them.",
-  "ritsulib.modSourceHoverTip.title": "what mod is this from",
+  "ritsulib.modSourceHoverTip.title": "what mod is this from?",
   "ritsulib.updateCheck.now.label": "Check now",
   "ritsulib.updateCheck.now.button": "Check for updates",
   "ritsulib.updateCheck.now.description": "Checks the bundled RitsuLib update source immediately and shows a toast with the result.",

--- a/Settings/Localization/ModSettingsUi/zhs.json
+++ b/Settings/Localization/ModSettingsUi/zhs.json
@@ -93,7 +93,7 @@
   "ritsulib.updateCheck.enabled.description": "首次进入主菜单后检查一次 RitsuLib 更新。",
   "ritsulib.modSourceHoverTips.enabled.label": "显示内容来源悬停提示",
   "ritsulib.modSourceHoverTips.enabled.description": "为卡牌、遗物和药水追加悬停提示，显示提供该内容的模组。",
-  "ritsulib.modSourceHoverTip.title": "这是什么 Mod 的内容",
+  "ritsulib.modSourceHoverTip.title": "来自哪个Mod？",
   "ritsulib.updateCheck.now.label": "立即检查",
   "ritsulib.updateCheck.now.button": "检查更新",
   "ritsulib.updateCheck.now.description": "立即检查 RitsuLib 内置更新源，并用 Toast 显示结果。",


### PR DESCRIPTION
## Summary / 概要
- 在模组的HoverTip里添加一行该内容的mod来源
- 将原来的hovertip改为只在卡牌和遗物的InspectScreen里添加
- 提供一个`IContentSourceSupplier`以实现自定义模组来源显示（例如联动的模组卡牌）

<img width="1455" height="1302" alt="图片" src="https://github.com/user-attachments/assets/20549dd0-4d43-4a29-a18f-67d2486c74eb" />
<img width="1113" height="727" alt="图片" src="https://github.com/user-attachments/assets/67fc9e0b-44a0-4774-92f8-29e72311faae" />

## Why / 背景与动机
- 基础mod必备

## What changed / 变更点
- Content/ContentSourceHoverTipFactory.cs
- Content/IContentSourceSupplier.cs
- RitsuLibFramework.PatcherSetup.cs
- Settings/Localization/ModSettingsUi/eng.json 以及 zhs.json

## Notes / 备注
- 自定义模组的`WithTooltip`未添加来源显示。
- `IContentSourceSupplier`只提供了string类型并且已被颜色bbcode包裹。也许可以提供更好的接口。
