### PR TITLE
ReplaceHueShader Material

### DIFF
--- a/Utils/MaterialUtils.ShaderSources.cs
+++ b/Utils/MaterialUtils.ShaderSources.cs
@@ -1,0 +1,38 @@
+namespace STS2RitsuLib.Utils
+{
+    public static partial class MaterialUtils
+    {
+        private const string ReplaceHueShaderSource = """
+            shader_type canvas_item;
+
+            const vec3 LUMA_WEIGHTS = vec3(0.2126, 0.7152, 0.0722);
+            const float EPSILON = 1e-7;
+            const float MAX_COLOR_GAIN = 1.12;
+
+            uniform vec3 target_color : source_color = vec3(1.0);
+            uniform float brightness : hint_range(0.0, 2.0) = 1.0;
+
+            varying vec4 modulate_color;
+
+            void vertex() {
+                modulate_color = COLOR;
+            }
+
+            void fragment() {
+                vec4 col = texture(TEXTURE, UV);
+
+                float max_rgb = max(max(col.r, col.g), col.b);
+                float min_rgb = min(min(col.r, col.g), col.b);
+                float value = max_rgb * brightness;
+                float saturation = (max_rgb - min_rgb) / (max_rgb + EPSILON);
+
+                float target_value = max(max(target_color.r, target_color.g), target_color.b);
+                vec3 target_hue = target_color / max(target_value, EPSILON);
+                float color_gain = min(1.0 / max(dot(target_hue, LUMA_WEIGHTS), EPSILON), MAX_COLOR_GAIN);
+
+                vec3 final = mix(vec3(value), target_color * value * color_gain, saturation);
+                COLOR = vec4(final, col.a) * modulate_color;
+            }
+            """;
+    }
+}

--- a/Utils/MaterialUtils.cs
+++ b/Utils/MaterialUtils.cs
@@ -6,7 +6,7 @@ namespace STS2RitsuLib.Utils
     ///     Factory helpers for Godot materials that mirror vanilla game shaders.
     ///     用于镜像原版游戏着色器的 Godot 材质工厂辅助方法。
     /// </summary>
-    public static class MaterialUtils
+    public static partial class MaterialUtils
     {
         private const string HsvShaderPath = "res://shaders/hsv.gdshader";
         private const string DoomBarShaderPath = "res://scenes/combat/doom_bar.gdshader";
@@ -14,34 +14,45 @@ namespace STS2RitsuLib.Utils
         private static NoiseTexture2D? _vanillaDoomBarNoiseTexture;
         private static ShaderMaterial? _unmodulatedHsvMaterial;
 
-        private static Shader? GameHsvShader => (Shader?)GD.Load<Shader>(HsvShaderPath)?.Duplicate();
+        private static Shader? _gameHsvShader;
+        private static Shader GameHsvShader => _gameHsvShader ??= GD.Load<Shader>(HsvShaderPath) ?? throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
 
-        private static Shader? GameDoomBarShader => (Shader?)GD.Load<Shader>(DoomBarShaderPath)?.Duplicate();
+        private static Shader? _gameDoomBarShader;
+        private static Shader? GameDoomBarShader => _gameDoomBarShader ??= GD.Load<Shader>(DoomBarShaderPath) ?? throw new InvalidOperationException($"Failed to load doom bar shader ({DoomBarShaderPath}).");
+
+        private static Shader? _replaceHueShader;
+        private static Shader ReplaceHueShader => _replaceHueShader ??= new Shader
+        {
+            Code = ReplaceHueShaderSource,
+        };
 
         private static NoiseTexture2D VanillaDoomBarNoiseTexture =>
             _vanillaDoomBarNoiseTexture ??= CreateVanillaDoomBarNoiseTexture();
 
         /// <summary>
+        ///     Builds a <c>ShaderMaterial</c> using a custom shader that replaces the hue of the input texture
+        ///     with a caller-specified RGB color, while preserving the original brightness and saturation.
+        ///     Suitable for replacing hues when using vanilla card frames. A brightness parameter can be used 
+        ///     to adjust output brightness (range 0-2, default is 1).
+        ///     使用一个自定义着色器构建 <c>ShaderMaterial</c>，该着色器将输入纹理的色调替换为调用方指定的 RGB 颜色，
+        ///     同时保留原始亮度和饱和度。适用于使用原版卡框时替换色调。可传入亮度参数以调整输出亮度（范围 0-2，默认值为 1）。
+        /// </summary>
+        public static ShaderMaterial CreateReplaceHueShaderMaterial(float r, float g, float b, float brightness = 1f)
+        {
+            var material = new ShaderMaterial { Shader = ReplaceHueShader };
+            material.SetShaderParameter("target_color", new Vector3(r, g, b));
+            material.SetShaderParameter("brightness", brightness);
+            return material;
+        }
+
+        /// <summary>
         ///     Builds a <c>ShaderMaterial</c> using the game's HSV shader with the given RGB parameters.
         ///     使用游戏的 HSV 着色器和给定 RGB 参数构建 <c>ShaderMaterial</c>。
         /// </summary>
+        [Obsolete("Prefer MaterialUtils.CreateReplaceHueShaderMaterial instead.")]
         public static ShaderMaterial CreateRgbShaderMaterial(float r, float g, float b)
         {
-            var max = Math.Max(r, Math.Max(g, b));
-            var min = Math.Min(r, Math.Min(g, b));
-            var delta = max - min;
-
-            float h = 0;
-            if (delta != 0)
-            {
-                if (Mathf.IsEqualApprox(max, r)) h = (g - b) / delta + (g < b ? 6 : 0);
-                else if (Mathf.IsEqualApprox(max, g)) h = (b - r) / delta + 2;
-                else h = (r - g) / delta + 4;
-                h /= 6;
-            }
-
-            var s = max == 0 ? 0 : delta / max;
-            return CreateHsvShaderMaterial(h, s, max);
+            return CreateReplaceHueShaderMaterial(r, g, b);
         }
 
         /// <summary>
@@ -50,18 +61,10 @@ namespace STS2RitsuLib.Utils
         /// </summary>
         public static ShaderMaterial CreateHsvShaderMaterial(float h, float s, float v)
         {
-            var shader = GameHsvShader ??
-                         throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
-
-            var material = new ShaderMaterial
-            {
-                Shader = shader,
-            };
-
+            var material = new ShaderMaterial { Shader = GameHsvShader };
             material.SetShaderParameter("h", h);
             material.SetShaderParameter("s", s);
             material.SetShaderParameter("v", v);
-
             return material;
         }
 
@@ -100,11 +103,7 @@ namespace STS2RitsuLib.Utils
         {
             ArgumentNullException.ThrowIfNull(gradientTexture);
 
-            var shader = GameDoomBarShader;
-            if (shader == null)
-                throw new InvalidOperationException($"Failed to load doom bar shader ({DoomBarShaderPath}).");
-
-            var material = new ShaderMaterial { Shader = shader };
+            var material = new ShaderMaterial { Shader = GameDoomBarShader };
             material.SetShaderParameter("noise_tex", VanillaDoomBarNoiseTexture);
             material.SetShaderParameter("gradient_tex", gradientTexture);
             return material;

--- a/Utils/MaterialUtils.cs
+++ b/Utils/MaterialUtils.cs
@@ -14,11 +14,9 @@ namespace STS2RitsuLib.Utils
         private static NoiseTexture2D? _vanillaDoomBarNoiseTexture;
         private static ShaderMaterial? _unmodulatedHsvMaterial;
 
-        private static Shader? _gameHsvShader;
-        private static Shader GameHsvShader => _gameHsvShader ??= GD.Load<Shader>(HsvShaderPath) ?? throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
+        private static Shader? GameHsvShader => (Shader?)GD.Load<Shader>(HsvShaderPath)?.Duplicate();
 
-        private static Shader? _gameDoomBarShader;
-        private static Shader? GameDoomBarShader => _gameDoomBarShader ??= GD.Load<Shader>(DoomBarShaderPath) ?? throw new InvalidOperationException($"Failed to load doom bar shader ({DoomBarShaderPath}).");
+        private static Shader? GameDoomBarShader => (Shader?)GD.Load<Shader>(DoomBarShaderPath)?.Duplicate();
 
         private static Shader? _replaceHueShader;
         private static Shader ReplaceHueShader => _replaceHueShader ??= new Shader
@@ -53,7 +51,21 @@ namespace STS2RitsuLib.Utils
         [Obsolete("Prefer MaterialUtils.CreateReplaceHueShaderMaterial instead.")]
         public static ShaderMaterial CreateRgbShaderMaterial(float r, float g, float b)
         {
-            return CreateReplaceHueShaderMaterial(r, g, b);
+            var max = Math.Max(r, Math.Max(g, b));
+            var min = Math.Min(r, Math.Min(g, b));
+            var delta = max - min;
+
+            float h = 0;
+            if (delta != 0)
+            {
+                if (Mathf.IsEqualApprox(max, r)) h = (g - b) / delta + (g < b ? 6 : 0);
+                else if (Mathf.IsEqualApprox(max, g)) h = (b - r) / delta + 2;
+                else h = (r - g) / delta + 4;
+                h /= 6;
+            }
+
+            var s = max == 0 ? 0 : delta / max;
+            return CreateHsvShaderMaterial(h, s, max);
         }
 
         /// <summary>
@@ -62,10 +74,18 @@ namespace STS2RitsuLib.Utils
         /// </summary>
         public static ShaderMaterial CreateHsvShaderMaterial(float h, float s, float v)
         {
-            var material = new ShaderMaterial { Shader = GameHsvShader };
+            var shader = GameHsvShader ??
+                         throw new InvalidOperationException($"Failed to load HSV shader ({HsvShaderPath}).");
+
+            var material = new ShaderMaterial
+            {
+                Shader = shader,
+            };
+
             material.SetShaderParameter("h", h);
             material.SetShaderParameter("s", s);
             material.SetShaderParameter("v", v);
+
             return material;
         }
 
@@ -84,7 +104,7 @@ namespace STS2RitsuLib.Utils
         public static ShaderMaterial CreateUnmodulatedHsvShaderMaterial()
         {
             _unmodulatedHsvMaterial ??= CreateHsvShaderMaterial(0f, 1f, 1f);
-            return _unmodulatedHsvMaterial;
+            return (ShaderMaterial)_unmodulatedHsvMaterial.Duplicate();
         }
 
         /// <summary>
@@ -104,7 +124,11 @@ namespace STS2RitsuLib.Utils
         {
             ArgumentNullException.ThrowIfNull(gradientTexture);
 
-            var material = new ShaderMaterial { Shader = GameDoomBarShader };
+            var shader = GameDoomBarShader;
+            if (shader == null)
+                throw new InvalidOperationException($"Failed to load doom bar shader ({DoomBarShaderPath}).");
+
+            var material = new ShaderMaterial { Shader = shader };
             material.SetShaderParameter("noise_tex", VanillaDoomBarNoiseTexture);
             material.SetShaderParameter("gradient_tex", gradientTexture);
             return material;

--- a/Utils/MaterialUtils.cs
+++ b/Utils/MaterialUtils.cs
@@ -32,10 +32,11 @@ namespace STS2RitsuLib.Utils
         /// <summary>
         ///     Builds a <c>ShaderMaterial</c> using a custom shader that replaces the hue of the input texture
         ///     with a caller-specified RGB color, while preserving the original brightness and saturation.
-        ///     Suitable for replacing hues when using vanilla card frames. A brightness parameter can be used 
-        ///     to adjust output brightness (range 0-2, default is 1).
+        ///     Suitable for replacing hues when using vanilla card frames.
+        ///     parameters r, g, b are in the range 0-1, brightness is in the range 0-2 with a default of 1.
         ///     使用一个自定义着色器构建 <c>ShaderMaterial</c>，该着色器将输入纹理的色调替换为调用方指定的 RGB 颜色，
-        ///     同时保留原始亮度和饱和度。适用于使用原版卡框时替换色调。可传入亮度参数以调整输出亮度（范围 0-2，默认值为 1）。
+        ///     同时保留原始亮度和饱和度。适用于替换色调，例如给原版卡框换色。
+        ///     参数r，g，b的范围是0-1，brightness的范围是0-2，默认值为1。
         /// </summary>
         public static ShaderMaterial CreateReplaceHueShaderMaterial(float r, float g, float b, float brightness = 1f)
         {
@@ -83,7 +84,7 @@ namespace STS2RitsuLib.Utils
         public static ShaderMaterial CreateUnmodulatedHsvShaderMaterial()
         {
             _unmodulatedHsvMaterial ??= CreateHsvShaderMaterial(0f, 1f, 1f);
-            return (ShaderMaterial)_unmodulatedHsvMaterial.Duplicate();
+            return _unmodulatedHsvMaterial;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary / 概要
- 添加了`CreateReplaceHueShaderMaterial`以替代`CreateRgbShaderMaterial`，并添加一个亮度参数可供调整
- 让shader只创建一个实例，`UnmodulatedHsvShaderMaterial`只创建一个实例

<div align="center">
<table>
  <tr>
    <td align="center" width="500">
        <img width="2560" height="1528" alt="97b9a02339cae4081cde6155729b84ec" src="https://github.com/user-attachments/assets/ac587a79-62d7-4635-b1db-f4834c01a5fb" />
      <sub>CreateRgbShaderMaterial</sub>
    </td>
    <td align="center" width="500">
        <img width="1922" height="1385" alt="图片" src="https://github.com/user-attachments/assets/1668e2b3-43a7-4d2c-b780-a4e455ba1201" />
      <sub>CreateReplaceHueShaderMaterial</sub>
    </td>
  </tr>
    <td align="center" width="300">
        <img width="1304" height="1032" alt="图片" src="https://github.com/user-attachments/assets/2b6869c5-3dd5-4ae5-b919-3887a5e249c4" />
      <sub>可用于其他图片换色</sub>
    </td>
</table>
</div>

## Why / 背景与动机
- `CreateRgbShaderMaterial`只是使用yiq偏移基于原始卡框换色，这对于原始红色卡框也许有一定作用，但无法作用其他色调的图片。
- `CreateReplaceHueShaderMaterial`新建了一个shader，保留目标图片的饱和度、明度数值并直接对色调进行替换，填入颜色基本就是所写颜色，同时对较暗的颜色提供一定的亮度补偿。可传入目标颜色和自定义亮度增益制作更丰富的颜色。
- 此外修改Shader为只生成一次实例，之前每次创建ShaderMaterial时都会创建一次shader和复制一次，开销较大。对于shader仅存一份实例即可，可提高渲染速度。
- 此外修改CreateUnmodulatedHsvShaderMaterial为只生成一次实例。UnmodulatedHsvShaderMaterial参数不会变化，仅存一份实例即可，可提高渲染速度。

## What changed / 变更点
- Utils/MaterialUtils.ShaderSources.cs
- Utils/MaterialUtils.cs

## Notes / 备注
- ReplaceHueShaderMaterial的自动亮度补偿只做了简单的min限制，可继续优化成非线性增益。
- ShaderMaterial也许可以建个字典缓存
