### PR TITLE
次要资源bug修复&优化

### DIFF
--- a/Combat/SecondaryResources/SecondaryResourceCardCostUi.cs
+++ b/Combat/SecondaryResources/SecondaryResourceCardCostUi.cs
@@ -302,10 +302,11 @@ namespace STS2RitsuLib.Combat.SecondaryResources
                 MinFontSize = Math.Max(8, _style.FontSize - 10),
                 MaxFontSize = _style.FontSize,
             };
-            AddChild(_label);
 
             ApplyLayout();
             ApplyLabelTheme();
+            AddChild(_label);
+
             ApplyDefinition();
 
             if (_plan != null && _line != null)

--- a/Combat/SecondaryResources/SecondaryResourceCounterNodes.cs
+++ b/Combat/SecondaryResources/SecondaryResourceCounterNodes.cs
@@ -217,10 +217,17 @@ namespace STS2RitsuLib.Combat.SecondaryResources
         private int _amount;
         private MegaLabel _amountLabel = null!;
 
+        private Player? _boundPlayer;
         private SecondaryResourceDefinition? _definition;
         private NSecondaryResourceIcon _icon = null!;
         private int? _maxAmount;
         private SecondaryResourceCounterStyle _style = SecondaryResourceCounterStyle.Default;
+
+        /// <summary>
+        ///     Whether this counter refreshes the bound player's resource every frame.
+        ///     该计数器是否每帧刷新已绑定玩家的资源数量。
+        /// </summary>
+        public bool AutoRefresh { get; set; }
 
         /// <summary>
         ///     Creates and configures a counter for <paramref name="definition" />.
@@ -252,6 +259,17 @@ namespace STS2RitsuLib.Combat.SecondaryResources
         }
 
         /// <summary>
+        ///     Binds this counter to a player for automatic or manual refreshes.
+        ///     将该计数器绑定到一名玩家，用于自动或手动刷新。
+        /// </summary>
+        public void Bind(Player? player, bool autoRefresh = true)
+        {
+            _boundPlayer = player;
+            AutoRefresh = autoRefresh;
+            Refresh(_boundPlayer);
+        }
+
+        /// <summary>
         ///     Refreshes the displayed amount from <paramref name="player" />.
         ///     从 <paramref name="player" /> 刷新显示数量。
         /// </summary>
@@ -263,6 +281,7 @@ namespace STS2RitsuLib.Combat.SecondaryResources
                 return;
             }
 
+            Visible = true;
             SetAmount(
                 SecondaryResourceCmd.Get(player, _definition.Id),
                 SecondaryResourceCmd.GetMax(player, _definition.Id));
@@ -321,6 +340,15 @@ namespace STS2RitsuLib.Combat.SecondaryResources
 
             ApplyDefinition();
             SetAmount(_amount, _maxAmount);
+        }
+
+        /// <inheritdoc />
+        public override void _Process(double delta)
+        {
+            if (AutoRefresh && _boundPlayer != null)
+            {
+                Refresh(_boundPlayer);
+            }
         }
 
         private Vector2 GetIconPosition()
@@ -759,8 +787,14 @@ namespace STS2RitsuLib.Combat.SecondaryResources
         /// </summary>
         public override void _Process(double delta)
         {
-            if (AutoRefresh && _boundDefinitions != null)
-                Refresh(_boundPlayer, _boundDefinitions);
+            if (!AutoRefresh || _boundDefinitions == null || _boundPlayer == null)
+                return;
+
+            foreach (var definition in _boundDefinitions)
+            {
+                if (_counters.TryGetValue(definition.Id, out var counter))
+                    counter.Refresh(_boundPlayer);
+            }
         }
 
         private NSecondaryResourceCounter GetOrCreateCounter(SecondaryResourceDefinition definition)


### PR DESCRIPTION
1. `ResourceCardCostUi`会打印大量font相关的error log，原因是应用theme在addchild之前
2. `NSecondaryResourceCounterRow`无法显示hovertip，原因是godot设置节点Visible为false时会触发一次`mouse_exited`信号，导致即使鼠标放在上面还是无论如何都不会创建tip。把`_progress`修改成了只刷新数量。
3. 给`NSecondaryResourceCounter`单个计数器加了能独自用的bind，如果不是设计意图可以删除

其他可优化的：
1. `RegisterCombatUi`和`RegisterCardUi`貌似只能设置`TParent`泛型为唯一的类型，只能是`NCombatUi`和`NCard`？那传递TParent似乎没有意义，虽然可以通过`AttachParentSelector`重新选择
2. CardUi我想绝大部分需求都是通过`AttachParentSelector = parent => parent.GetNode<Control>("%CardContainer")`来获得旋转和缩放

与此无关但不想再开一个issue：
希望给组件加一个泛型的`ModelCapabilityRegistry.Create<>`，貌似只能通过先拿id再create还要cast一遍类型