### PR TITLE
fix: Guard ModelDb getter merges and warm resolved caches

### DIFF
--- a/.vscode/ritsulib-csharp.code-snippets
+++ b/.vscode/ritsulib-csharp.code-snippets
@@ -1,0 +1,24 @@
+{
+  "RitsuLib bilingual summary": {
+    "scope": "csharp",
+    "prefix": "docbi",
+    "description": "Bilingual XML doc summary with xml:lang paras",
+    "body": [
+      "/// <summary>",
+      "/// <para xml:lang=\"en\">${1:English summary.}</para>",
+      "/// <para xml:lang=\"zh-CN\">${2:中文摘要。}</para>",
+      "/// </summary>"
+    ]
+  },
+  "RitsuLib bilingual summary with cref": {
+    "scope": "csharp",
+    "prefix": "docbic",
+    "description": "Bilingual XML doc summary with see cref",
+    "body": [
+      "/// <summary>",
+      "/// <para xml:lang=\"en\">${1:Summary referencing} <see cref=\"${2:TypeName}\" />.</para>",
+      "/// <para xml:lang=\"zh-CN\">${3:中文摘要，引用} <see cref=\"$2\" />。</para>",
+      "/// </summary>"
+    ]
+  }
+}

--- a/Content/ContentCatalogEntry.cs
+++ b/Content/ContentCatalogEntry.cs
@@ -1,0 +1,39 @@
+namespace STS2RitsuLib.Content
+{
+    /// <summary>
+    /// <para xml:lang="en">One mod content catalog: global type set or act-scoped registrations, warm hooks, and merge mode.</para>
+    /// <para xml:lang="zh-CN">一条 mod 内容目录：全局类型集或 act 作用域注册、预热钩子与合并模式。</para>
+    /// </summary>
+    internal sealed class ContentCatalogEntry
+    {
+        internal required ContentCatalogId Id { get; init; }
+
+        /// <summary>
+        /// <para xml:lang="en">Registered types for global getters.</para>
+        /// <para xml:lang="zh-CN">全局 getter 的已注册类型。</para>
+        /// </summary>
+        internal Func<IEnumerable<Type>>? GlobalTypes { get; init; }
+
+        /// <summary>
+        /// <para xml:lang="en">Act type to registered model types.</para>
+        /// <para xml:lang="zh-CN">Act 类型到已注册模型类型的映射。</para>
+        /// </summary>
+        internal Func<Dictionary<Type, HashSet<Type>>>? ScopedRegistry { get; init; }
+
+        /// <summary>
+        /// <para xml:lang="en">Warm hook: global types to resolved model array.</para>
+        /// <para xml:lang="zh-CN">预热钩子：全局类型到已解析模型数组。</para>
+        /// </summary>
+        internal Func<IEnumerable<Type>, object>? WarmGlobal { get; init; }
+
+        /// <summary>
+        /// <para xml:lang="en">Warm hook: scoped registry to per-act arrays.</para>
+        /// <para xml:lang="zh-CN">预热钩子：作用域注册表到各 act 数组。</para>
+        /// </summary>
+        internal Func<Dictionary<Type, HashSet<Type>>, Dictionary<Type, object>>? WarmScoped { get; init; }
+
+        internal ContentMergeMode MergeMode { get; init; } = ContentMergeMode.AppendDistinctById;
+
+        internal bool IsScoped => ScopedRegistry != null;
+    }
+}

--- a/Content/ContentCatalogId.cs
+++ b/Content/ContentCatalogId.cs
@@ -1,0 +1,27 @@
+namespace STS2RitsuLib.Content
+{
+    /// <summary>
+    /// <para xml:lang="en">Keys for <see cref="ContentCatalogEntry" /> rows wired into patched <see cref="MegaCrit.Sts2.Core.Models.ModelDb" /> getters.</para>
+    /// <para xml:lang="zh-CN">接入 patched <see cref="MegaCrit.Sts2.Core.Models.ModelDb" /> getter 的 <see cref="ContentCatalogEntry" /> 行键。</para>
+    /// </summary>
+    internal enum ContentCatalogId
+    {
+        Characters,
+        Acts,
+        Monsters,
+        Powers,
+        Orbs,
+        SharedEvents,
+        SharedAncients,
+        Enchantments,
+        Afflictions,
+        Achievements,
+        SharedRelicPools,
+        SharedPotionPools,
+        SharedCardPools,
+        GlobalEncounters,
+        ActEvents,
+        ActEncounters,
+        ActAncients,
+    }
+}

--- a/Content/ContentMergeMode.cs
+++ b/Content/ContentMergeMode.cs
@@ -1,0 +1,21 @@
+namespace STS2RitsuLib.Content
+{
+    /// <summary>
+    /// <para xml:lang="en">How patched <see cref="MegaCrit.Sts2.Core.Models.ModelDb" /> getter postfixes merge vanilla output with mod models.</para>
+    /// <para xml:lang="zh-CN">patched <see cref="MegaCrit.Sts2.Core.Models.ModelDb" /> getter postfix 如何合并原版输出与 mod 模型。</para>
+    /// </summary>
+    internal enum ContentMergeMode
+    {
+        /// <summary>
+        /// <para xml:lang="en">Vanilla first, then mod; first <see cref="MegaCrit.Sts2.Core.Models.AbstractModel.Id" /> wins; materialize as array.</para>
+        /// <para xml:lang="zh-CN">原版在前、mod 在后；首个 <see cref="MegaCrit.Sts2.Core.Models.AbstractModel.Id" /> 胜出；物化为数组。</para>
+        /// </summary>
+        AppendDistinctById = 0,
+
+        /// <summary>
+        /// <para xml:lang="en">Skip materialization when mod is empty; otherwise union by id into a list.</para>
+        /// <para xml:lang="zh-CN">mod 为空时不物化 vanilla；否则按 id 合并为列表。</para>
+        /// </summary>
+        MergeDistinctById = 1,
+    }
+}

--- a/Content/ContentMergeStrategies.cs
+++ b/Content/ContentMergeStrategies.cs
@@ -1,0 +1,105 @@
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2RitsuLib.Content
+{
+    /// <summary>
+    /// <para xml:lang="en">Merge strategies for combining vanilla <see cref="ModelDb" /> getter output with resolved mod models.</para>
+    /// <para xml:lang="zh-CN">将原版 <see cref="ModelDb" /> getter 输出与已解析 mod 模型合并的策略。</para>
+    /// </summary>
+    internal interface IContentEnumerableMergeStrategy<TModel>
+        where TModel : AbstractModel
+    {
+        IEnumerable<TModel> Merge(IEnumerable<TModel> source, TModel[] additional);
+    }
+
+    /// <summary>
+    /// <para xml:lang="en">Merge strategy for <see cref="IReadOnlyList{T}" /> getter output.</para>
+    /// <para xml:lang="zh-CN">用于 <see cref="IReadOnlyList{T}" /> getter 输出的合并策略。</para>
+    /// </summary>
+    internal interface IContentListMergeStrategy<TModel>
+        where TModel : AbstractModel
+    {
+        IReadOnlyList<TModel> Merge(IReadOnlyList<TModel> source, TModel[] additional);
+    }
+
+    internal static class ContentMergeStrategies
+    {
+        internal static IContentEnumerableMergeStrategy<TModel> GetEnumerable<TModel>(ContentMergeMode mode)
+            where TModel : AbstractModel
+        {
+            return mode switch
+            {
+                ContentMergeMode.MergeDistinctById => MergeDistinctByIdEnumerableStrategy<TModel>.Instance,
+                _ => AppendDistinctByIdEnumerableStrategy<TModel>.Instance,
+            };
+        }
+
+        internal static IContentListMergeStrategy<TModel> GetList<TModel>()
+            where TModel : AbstractModel
+        {
+            return DistinctByIdListStrategy<TModel>.Instance;
+        }
+
+        /// <summary>
+        /// <para xml:lang="en">Appends items whose <see cref="AbstractModel.Id" /> is not already in <paramref name="destination" />.</para>
+        /// <para xml:lang="zh-CN">追加 Id 尚未出现在 <paramref name="destination" /> 中的项。</para>
+        /// </summary>
+        internal static void AppendDistinctById<TModel>(List<TModel> destination, IEnumerable<TModel> items)
+            where TModel : AbstractModel
+        {
+            var known = destination.Count == 0
+                ? []
+                : destination.Select(static model => model.Id).ToHashSet();
+
+            foreach (var item in items)
+            {
+                if (known.Add(item.Id))
+                    destination.Add(item);
+            }
+        }
+    }
+
+    internal sealed class AppendDistinctByIdEnumerableStrategy<TModel> : IContentEnumerableMergeStrategy<TModel>
+        where TModel : AbstractModel
+    {
+        internal static readonly AppendDistinctByIdEnumerableStrategy<TModel> Instance = new();
+
+        public IEnumerable<TModel> Merge(IEnumerable<TModel> source, TModel[] additional)
+        {
+            if (additional.Length == 0)
+                return source as TModel[] ?? source.ToArray();
+
+            return source.Concat(additional).DistinctBy(static model => model.Id).ToArray();
+        }
+    }
+
+    internal sealed class MergeDistinctByIdEnumerableStrategy<TModel> : IContentEnumerableMergeStrategy<TModel>
+        where TModel : AbstractModel
+    {
+        internal static readonly MergeDistinctByIdEnumerableStrategy<TModel> Instance = new();
+
+        public IEnumerable<TModel> Merge(IEnumerable<TModel> source, TModel[] additional)
+        {
+            if (additional.Length == 0)
+                return source;
+
+            return source.Concat(additional).DistinctBy(static model => model.Id).ToList();
+        }
+    }
+
+    internal sealed class DistinctByIdListStrategy<TModel> : IContentListMergeStrategy<TModel>
+        where TModel : AbstractModel
+    {
+        internal static readonly DistinctByIdListStrategy<TModel> Instance = new();
+
+        public IReadOnlyList<TModel> Merge(IReadOnlyList<TModel> source, TModel[] additional)
+        {
+            if (additional.Length == 0)
+                return source;
+
+            var result = source as List<TModel> ?? source.ToList();
+            ContentMergeStrategies.AppendDistinctById(result, additional);
+            return result;
+        }
+    }
+}

--- a/Content/DynamicActContentPatcher.cs
+++ b/Content/DynamicActContentPatcher.cs
@@ -188,20 +188,26 @@ namespace STS2RitsuLib.Content
 
         private static void AllEventsPostfix(ActModel __instance, ref IEnumerable<EventModel> __result)
         {
-            __result = ModContentRegistry.AppendActEvents(__instance, __result);
+            __result = ModelDbGetterMerge.MergeEnumerable(
+                __result,
+                source => ModContentRegistry.AppendActEvents(__instance, source));
         }
 
         private static void AllAncientsPostfix(ActModel __instance, ref IEnumerable<AncientEventModel> __result)
         {
-            __result = ModContentRegistry.AppendActAncients(__instance, __result);
+            __result = ModelDbGetterMerge.MergeEnumerable(
+                __result,
+                source => ModContentRegistry.AppendActAncients(__instance, source));
         }
 
         private static void AllEncountersPostfix(ActModel __instance, ref IEnumerable<EncounterModel> __result)
         {
-            __result = ModEncounterActValidityFilter.FilterForAct(
-                __instance,
-                ModContentRegistry.AppendGlobalEncounters(
-                    ModContentRegistry.AppendActEncounters(__instance, __result)));
+            __result = ModelDbGetterMerge.MergeEnumerable(
+                __result,
+                source => ModEncounterActValidityFilter.FilterForAct(
+                    __instance,
+                    ModContentRegistry.AppendGlobalEncounters(
+                        ModContentRegistry.AppendActEncounters(__instance, source))));
         }
 
         private static void BossDiscoveryOrderPostfix(ActModel __instance, ref IEnumerable<EncounterModel> __result)
@@ -220,7 +226,9 @@ namespace STS2RitsuLib.Content
             __result = ModAncientActValidityFilter.FilterForAct(
                 __instance,
                 ModUnlockRegistry.FilterUnlocked(
-                    ModContentRegistry.AppendActAncients(__instance, __result),
+                    ModelDbGetterMerge.MergeEnumerable(
+                        __result,
+                        source => ModContentRegistry.AppendActAncients(__instance, source)),
                     unlockState));
         }
     }

--- a/Content/ModContentRegistry.ContentCatalogs.cs
+++ b/Content/ModContentRegistry.ContentCatalogs.cs
@@ -1,0 +1,104 @@
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2RitsuLib.Content
+{
+    public sealed partial class ModContentRegistry
+    {
+        /// <summary>
+        /// <para xml:lang="en">Catalog table for patched <see cref="ModelDb" /> getters: registration source, warm path, and merge mode per row.</para>
+        /// <para xml:lang="zh-CN">patched <see cref="ModelDb" /> getter 的目录表：每行绑定注册源、预热路径与合并模式。</para>
+        /// </summary>
+        private static readonly IReadOnlyList<ContentCatalogEntry> ModelCatalogs =
+        [
+            GlobalEntry<CharacterModel>(ContentCatalogId.Characters, static () => RegisteredCharacters),
+            GlobalEntry<ActModel>(ContentCatalogId.Acts, static () => RegisteredActs),
+            GlobalEntry<MonsterModel>(ContentCatalogId.Monsters, static () => RegisteredMonsters,
+                ContentMergeMode.MergeDistinctById),
+            GlobalEntry<PowerModel>(ContentCatalogId.Powers, static () => RegisteredPowers),
+            GlobalEntry<OrbModel>(ContentCatalogId.Orbs, static () => RegisteredOrbs),
+            GlobalEntry<EventModel>(ContentCatalogId.SharedEvents, static () => RegisteredSharedEvents),
+            GlobalEntry<AncientEventModel>(ContentCatalogId.SharedAncients, static () => RegisteredSharedAncients),
+            GlobalEntry<EnchantmentModel>(ContentCatalogId.Enchantments, static () => RegisteredEnchantments),
+            GlobalEntry<AfflictionModel>(ContentCatalogId.Afflictions, static () => RegisteredAfflictions),
+            GlobalEntry<AchievementModel>(ContentCatalogId.Achievements, static () => RegisteredAchievements),
+            GlobalEntry<RelicPoolModel>(ContentCatalogId.SharedRelicPools, static () => RegisteredSharedRelicPools),
+            GlobalEntry<PotionPoolModel>(ContentCatalogId.SharedPotionPools, static () => RegisteredSharedPotionPools),
+            GlobalEntry<CardPoolModel>(ContentCatalogId.SharedCardPools, static () => RegisteredSharedCardPools),
+            GlobalEntry<EncounterModel>(ContentCatalogId.GlobalEncounters, static () => RegisteredGlobalEncounters),
+            ScopedEntry<EventModel>(ContentCatalogId.ActEvents, static () => RegisteredActEvents),
+            ScopedEntry<EncounterModel>(ContentCatalogId.ActEncounters, static () => RegisteredActEncounters),
+            ScopedEntry<AncientEventModel>(ContentCatalogId.ActAncients, static () => RegisteredActAncients),
+        ];
+
+        private static readonly Dictionary<ContentCatalogId, ContentCatalogEntry> CatalogById =
+            ModelCatalogs.ToDictionary(static entry => entry.Id);
+
+        static ModContentRegistry()
+        {
+            ResolvedModelCache.Configure(ModelCatalogs);
+        }
+
+        internal static ContentCatalogEntry GetCatalog(ContentCatalogId id) => CatalogById[id];
+
+        /// <summary>
+        /// <para xml:lang="en">Warms resolved model caches once after <see cref="ModelDb.Init" /> to avoid repeated <see cref="ModelDb.GetId" /> during Preload.</para>
+        /// <para xml:lang="zh-CN">在 <see cref="ModelDb.Init" /> 后一次性预热已解析模型缓存，避免 Preload 期间重复 <see cref="ModelDb.GetId" />。</para>
+        /// </summary>
+        internal static void WarmResolvedModelCaches()
+        {
+            ResolvedModelCache.Warm();
+        }
+
+        private static ContentCatalogEntry GlobalEntry<TModel>(
+            ContentCatalogId id,
+            Func<IEnumerable<Type>> globalTypes,
+            ContentMergeMode mergeMode = ContentMergeMode.AppendDistinctById)
+            where TModel : AbstractModel
+        {
+            return GlobalCatalog(
+                id,
+                globalTypes,
+                static types => ResolvedModelCache.ResolveUncached<TModel>(types),
+                mergeMode);
+        }
+
+        private static ContentCatalogEntry ScopedEntry<TModel>(
+            ContentCatalogId id,
+            Func<Dictionary<Type, HashSet<Type>>> scopedRegistry)
+            where TModel : AbstractModel
+        {
+            return ScopedCatalog(
+                id,
+                scopedRegistry,
+                static registry => ResolvedModelCache.ResolveScopedUncached<TModel>(registry));
+        }
+
+        private static ContentCatalogEntry GlobalCatalog(
+            ContentCatalogId id,
+            Func<IEnumerable<Type>> globalTypes,
+            Func<IEnumerable<Type>, object> warmGlobal,
+            ContentMergeMode mergeMode = ContentMergeMode.AppendDistinctById)
+        {
+            return new()
+            {
+                Id = id,
+                GlobalTypes = globalTypes,
+                WarmGlobal = warmGlobal,
+                MergeMode = mergeMode,
+            };
+        }
+
+        private static ContentCatalogEntry ScopedCatalog(
+            ContentCatalogId id,
+            Func<Dictionary<Type, HashSet<Type>>> scopedRegistry,
+            Func<Dictionary<Type, HashSet<Type>>, Dictionary<Type, object>> warmScoped)
+        {
+            return new()
+            {
+                Id = id,
+                ScopedRegistry = scopedRegistry,
+                WarmScoped = warmScoped,
+            };
+        }
+    }
+}

--- a/Content/ModContentRegistry.ContentMerging.cs
+++ b/Content/ModContentRegistry.ContentMerging.cs
@@ -1,0 +1,49 @@
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2RitsuLib.Content
+{
+    public sealed partial class ModContentRegistry
+    {
+        /// <summary>
+        /// <para xml:lang="en">Merges vanilla getter output with a global catalog row via <see cref="ResolvedModelCache" /> and <see cref="ContentMergeStrategies" />.</para>
+        /// <para xml:lang="zh-CN">通过 <see cref="ResolvedModelCache" /> 与 <see cref="ContentMergeStrategies" /> 将原版 getter 输出与全局 catalog 行合并。</para>
+        /// </summary>
+        internal static IEnumerable<TModel> MergeGlobalCatalog<TModel>(
+            ContentCatalogId catalogId,
+            IEnumerable<TModel> source)
+            where TModel : AbstractModel
+        {
+            var catalog = GetCatalog(catalogId);
+            var additional = ResolvedModelCache.GetGlobal<TModel>(catalogId);
+            return ContentMergeStrategies.GetEnumerable<TModel>(catalog.MergeMode).Merge(source, additional);
+        }
+
+        /// <summary>
+        /// <para xml:lang="en">Merges vanilla getter output with an act-scoped catalog row.</para>
+        /// <para xml:lang="zh-CN">将原版 getter 输出与 act 作用域 catalog 行合并。</para>
+        /// </summary>
+        internal static IEnumerable<TModel> MergeScopedCatalog<TModel>(
+            ContentCatalogId catalogId,
+            Type scopeType,
+            IEnumerable<TModel> source)
+            where TModel : AbstractModel
+        {
+            var catalog = GetCatalog(catalogId);
+            var additional = ResolvedModelCache.GetScoped<TModel>(catalogId, scopeType);
+            return ContentMergeStrategies.GetEnumerable<TModel>(catalog.MergeMode).Merge(source, additional);
+        }
+
+        /// <summary>
+        /// <para xml:lang="en">Merges a read-only list getter with a global catalog row.</para>
+        /// <para xml:lang="zh-CN">将只读列表 getter 与全局 catalog 行合并。</para>
+        /// </summary>
+        internal static IReadOnlyList<TModel> MergeGlobalCatalogList<TModel>(
+            ContentCatalogId catalogId,
+            IReadOnlyList<TModel> source)
+            where TModel : AbstractModel
+        {
+            var additional = ResolvedModelCache.GetGlobal<TModel>(catalogId);
+            return ContentMergeStrategies.GetList<TModel>().Merge(source, additional);
+        }
+    }
+}

--- a/Content/ModContentRegistry.cs
+++ b/Content/ModContentRegistry.cs
@@ -1246,6 +1246,8 @@ namespace STS2RitsuLib.Content
                     registry._freezeReason = reason;
             }
 
+            ResolvedModelCache.MarkFrozen();
+
             foreach (var registry in Registries.Values)
                 registry._logger.Info($"[Content] Content registration is now frozen ({reason}).");
 
@@ -1356,12 +1358,12 @@ namespace STS2RitsuLib.Content
 
         internal static IEnumerable<CharacterModel> AppendCharacters(IEnumerable<CharacterModel> source)
         {
-            return AppendResolved(source, ResolveModels<CharacterModel>(RegisteredCharacters));
+            return MergeGlobalCatalog(ContentCatalogId.Characters, source);
         }
 
         internal static IEnumerable<CharacterModel> GetModCharacters()
         {
-            return ResolveModels<CharacterModel>(RegisteredCharacters);
+            return ResolvedModelCache.GetGlobal<CharacterModel>(ContentCatalogId.Characters);
         }
 
         /// <summary>
@@ -1458,12 +1460,12 @@ namespace STS2RitsuLib.Content
 
         internal static IEnumerable<EventModel> AppendSharedEvents(IEnumerable<EventModel> source)
         {
-            return AppendResolved(source, ResolveModels<EventModel>(RegisteredSharedEvents));
+            return MergeGlobalCatalog(ContentCatalogId.SharedEvents, source);
         }
 
         internal static IEnumerable<ActModel> AppendActs(IEnumerable<ActModel> source)
         {
-            return AppendResolved(source, ResolveModels<ActModel>(RegisteredActs));
+            return MergeGlobalCatalog(ContentCatalogId.Acts, source);
         }
 
         internal static Type[] GetRegisteredActTypes()
@@ -1476,28 +1478,27 @@ namespace STS2RitsuLib.Content
 
         internal static IEnumerable<PowerModel> AppendPowers(IEnumerable<PowerModel> source)
         {
-            return AppendResolved(source, ResolveModels<PowerModel>(RegisteredPowers));
+            return MergeGlobalCatalog(ContentCatalogId.Powers, source);
         }
 
         internal static IEnumerable<OrbModel> AppendOrbs(IEnumerable<OrbModel> source)
         {
-            return AppendResolved(source, ResolveModels<OrbModel>(RegisteredOrbs));
+            return MergeGlobalCatalog(ContentCatalogId.Orbs, source);
         }
 
         internal static IEnumerable<EnchantmentModel> AppendEnchantments(IEnumerable<EnchantmentModel> source)
         {
-            return AppendResolved(source, ResolveModels<EnchantmentModel>(RegisteredEnchantments));
+            return MergeGlobalCatalog(ContentCatalogId.Enchantments, source);
         }
 
         internal static IEnumerable<AfflictionModel> AppendAfflictions(IEnumerable<AfflictionModel> source)
         {
-            return AppendResolved(source, ResolveModels<AfflictionModel>(RegisteredAfflictions));
+            return MergeGlobalCatalog(ContentCatalogId.Afflictions, source);
         }
 
         internal static IReadOnlyList<AchievementModel> AppendAchievements(IReadOnlyList<AchievementModel> source)
         {
-            var additional = ResolveModels<AchievementModel>(RegisteredAchievements);
-            return additional.Length == 0 ? source : MergeDistinctByModelId(source, additional);
+            return MergeGlobalCatalogList(ContentCatalogId.Achievements, source);
         }
 
         internal static IReadOnlyList<ModifierModel> AppendGoodModifiers(IReadOnlyList<ModifierModel> source)
@@ -1528,50 +1529,49 @@ namespace STS2RitsuLib.Content
 
         internal static IEnumerable<RelicPoolModel> AppendSharedRelicPools(IEnumerable<RelicPoolModel> source)
         {
-            return AppendResolved(source, ResolveModels<RelicPoolModel>(RegisteredSharedRelicPools));
+            return MergeGlobalCatalog(ContentCatalogId.SharedRelicPools, source);
         }
 
         internal static IEnumerable<PotionPoolModel> AppendSharedPotionPools(IEnumerable<PotionPoolModel> source)
         {
-            return AppendResolved(source, ResolveModels<PotionPoolModel>(RegisteredSharedPotionPools));
+            return MergeGlobalCatalog(ContentCatalogId.SharedPotionPools, source);
         }
 
         internal static IEnumerable<CardPoolModel> AppendSharedCardPools(IEnumerable<CardPoolModel> source)
         {
-            return AppendResolved(source, ResolveModels<CardPoolModel>(RegisteredSharedCardPools));
+            return MergeGlobalCatalog(ContentCatalogId.SharedCardPools, source);
         }
 
         internal static IEnumerable<EventModel> AppendActEvents(ActModel act, IEnumerable<EventModel> source)
         {
-            return AppendResolved(source, ResolveScopedModels<EventModel>(RegisteredActEvents, act.GetType()));
+            return MergeScopedCatalog(ContentCatalogId.ActEvents, act.GetType(), source);
         }
 
         internal static IEnumerable<EncounterModel> AppendActEncounters(ActModel act,
             IEnumerable<EncounterModel> source)
         {
-            return AppendResolved(source, ResolveScopedModels<EncounterModel>(RegisteredActEncounters, act.GetType()));
+            return MergeScopedCatalog(ContentCatalogId.ActEncounters, act.GetType(), source);
         }
 
         internal static IEnumerable<EncounterModel> AppendGlobalEncounters(IEnumerable<EncounterModel> source)
         {
-            return AppendResolved(source, ResolveModels<EncounterModel>(RegisteredGlobalEncounters));
+            return MergeGlobalCatalog(ContentCatalogId.GlobalEncounters, source);
         }
 
         internal static IEnumerable<MonsterModel> AppendRegisteredMonsters(IEnumerable<MonsterModel> source)
         {
-            var additional = ResolveModels<MonsterModel>(RegisteredMonsters);
-            return MergeDistinctByModelId(source, additional);
+            return MergeGlobalCatalog(ContentCatalogId.Monsters, source);
         }
 
         internal static IEnumerable<AncientEventModel> AppendSharedAncients(IEnumerable<AncientEventModel> source)
         {
-            return AppendResolved(source, ResolveModels<AncientEventModel>(RegisteredSharedAncients));
+            return MergeGlobalCatalog(ContentCatalogId.SharedAncients, source);
         }
 
         internal static IEnumerable<AncientEventModel> AppendActAncients(ActModel act,
             IEnumerable<AncientEventModel> source)
         {
-            return AppendResolved(source, ResolveScopedModels<AncientEventModel>(RegisteredActAncients, act.GetType()));
+            return MergeScopedCatalog(ContentCatalogId.ActAncients, act.GetType(), source);
         }
 
         internal static Type[] GetRegisteredBadgeTypes()
@@ -1810,35 +1810,6 @@ namespace STS2RitsuLib.Content
                 );
         }
 
-        private static TModel[] ResolveModels<TModel>(IEnumerable<Type> modelTypes)
-            where TModel : AbstractModel
-        {
-            lock (SyncRoot)
-            {
-                return modelTypes
-                    .OrderBy(static t => t.FullName ?? t.Name, StringComparer.Ordinal)
-                    .Select(ModelDb.GetId)
-                    .Select(ModelDb.GetById<TModel>)
-                    .ToArray();
-            }
-        }
-
-        private static TModel[] ResolveScopedModels<TModel>(Dictionary<Type, HashSet<Type>> registry,
-            Type scopeType)
-            where TModel : AbstractModel
-        {
-            lock (SyncRoot)
-            {
-                return !registry.TryGetValue(scopeType, out var modelTypes)
-                    ? []
-                    : modelTypes
-                        .OrderBy(static t => t.FullName ?? t.Name, StringComparer.Ordinal)
-                        .Select(ModelDb.GetId)
-                        .Select(ModelDb.GetById<TModel>)
-                        .ToArray();
-            }
-        }
-
         private static bool MatchesRegisteredStarterCharacter(Type registeredCharacterType, Type runtimeCharacterType)
         {
             if (registeredCharacterType == runtimeCharacterType)
@@ -1872,20 +1843,6 @@ namespace STS2RitsuLib.Content
                     .SelectMany(static x => Enumerable.Repeat(x.entry.ModelType, x.entry.Count))
                     .ToArray();
             }
-        }
-
-        private static TModel[] AppendResolved<TModel>(IEnumerable<TModel> source,
-            IEnumerable<TModel> additional)
-            where TModel : AbstractModel
-        {
-            return source.Concat(additional).DistinctBy(static model => model.Id).ToArray();
-        }
-
-        private static List<TModel> MergeDistinctByModelId<TModel>(IEnumerable<TModel> first,
-            IEnumerable<TModel> second)
-            where TModel : AbstractModel
-        {
-            return first.Concat(second).DistinctBy(static m => m.Id).ToList();
         }
 
         /// <summary>

--- a/Content/ModelDbGetterMerge.cs
+++ b/Content/ModelDbGetterMerge.cs
@@ -1,0 +1,56 @@
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2RitsuLib.Content
+{
+    /// <summary>
+    /// <para xml:lang="en">Snapshots lazy patched <see cref="ModelDb" /> getter output once; nested getter calls pass through unchanged.</para>
+    /// <para xml:lang="zh-CN">对 lazy patched <see cref="ModelDb" /> getter 输出做一次快照；嵌套 getter 调用原样透传。</para>
+    /// </summary>
+    internal static class ModelDbGetterMerge
+    {
+        static int _depth;
+
+        internal static IEnumerable<TModel> MergeEnumerable<TModel>(
+            IEnumerable<TModel> source,
+            Func<IEnumerable<TModel>, IEnumerable<TModel>> append)
+            where TModel : AbstractModel
+        {
+            if (Interlocked.Increment(ref _depth) > 1)
+            {
+                Interlocked.Decrement(ref _depth);
+                return source;
+            }
+
+            try
+            {
+                var materialized = source as TModel[] ?? source.ToArray();
+                return append(materialized);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _depth);
+            }
+        }
+
+        internal static IReadOnlyList<TItem> MergeReadOnlyList<TItem>(
+            IReadOnlyList<TItem> source,
+            Func<IReadOnlyList<TItem>, IReadOnlyList<TItem>> append)
+        {
+            if (Interlocked.Increment(ref _depth) > 1)
+            {
+                Interlocked.Decrement(ref _depth);
+                return source;
+            }
+
+            try
+            {
+                var materialized = source as TItem[] ?? source.ToArray();
+                return append(materialized);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _depth);
+            }
+        }
+    }
+}

--- a/Content/ModifierContentMerge.cs
+++ b/Content/ModifierContentMerge.cs
@@ -3,15 +3,14 @@ using MegaCrit.Sts2.Core.Models;
 namespace STS2RitsuLib.Content
 {
     /// <summary>
-    ///     Merges RitsuLib-registered run modifiers and exclusivity groups into <see cref="ModelDb" /> lists.
-    ///     将 RitsuLib 注册的运行修饰符与互斥组合并到 <see cref="ModelDb" /> 列表中。
+    /// <para xml:lang="en">Merges RitsuLib-registered run modifiers and exclusivity groups into <see cref="ModelDb" /> lists.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的运行修饰符与互斥组合并到 <see cref="ModelDb" /> 列表中。</para>
     /// </summary>
     internal static class ModifierContentMerge
     {
         /// <summary>
-        ///     Inserts registered modifiers before or after <paramref name="source" /> using
-        ///     <see cref="ModifierRegistration.ModifierListSortOrder" />.
-        ///     按 <see cref="ModifierRegistration.ModifierListSortOrder" /> 在 <paramref name="source" /> 前后插入已注册修饰符。
+        /// <para xml:lang="en">Inserts registered modifiers before or after <paramref name="source" /> using <see cref="ModifierRegistration.ModifierListSortOrder" />.</para>
+        /// <para xml:lang="zh-CN">按 <see cref="ModifierRegistration.ModifierListSortOrder" /> 在 <paramref name="source" /> 前后插入已注册修饰符。</para>
         /// </summary>
         public static IReadOnlyList<ModifierModel> InsertModifiers(
             IReadOnlyList<ModifierModel> source,
@@ -29,8 +28,8 @@ namespace STS2RitsuLib.Content
         }
 
         /// <summary>
-        ///     Merges registered exclusivity groups into <paramref name="source" />, combining overlapping sets.
-        ///     将已注册互斥组合并到 <paramref name="source" />，并合并存在交集的集合。
+        /// <para xml:lang="en">Merges registered exclusivity groups into <paramref name="source" />, combining overlapping sets.</para>
+        /// <para xml:lang="zh-CN">将已注册互斥组合并到 <paramref name="source" />，并合并存在交集的集合。</para>
         /// </summary>
         public static IReadOnlyList<IReadOnlySet<ModifierModel>> MergeMutuallyExclusiveModifiers(
             IReadOnlyList<IReadOnlySet<ModifierModel>> source,
@@ -106,27 +105,24 @@ namespace STS2RitsuLib.Content
             ModifierModel[] after)
         {
             var result = new List<ModifierModel>(before.Length + source.Count + after.Length);
-            AppendDistinct(result, before);
-            AppendDistinct(result, source);
-            AppendDistinct(result, after);
+            ContentMergeStrategies.AppendDistinctById(result, before);
+            ContentMergeStrategies.AppendDistinctById(result, source);
+            ContentMergeStrategies.AppendDistinctById(result, after);
             return result;
-        }
-
-        private static void AppendDistinct(List<ModifierModel> destination, IEnumerable<ModifierModel> items)
-        {
-            var known = destination.Select(static model => model.Id).ToHashSet();
-            destination.AddRange(items.Where(item => known.Add(item.Id)));
         }
     }
 
     /// <summary>
-    ///     Registration metadata for a mod run modifier list entry.
-    ///     mod 运行修饰符列表条目的注册元数据。
+    /// <para xml:lang="en">Registration metadata for a mod run modifier list entry.</para>
+    /// <para xml:lang="zh-CN">mod 运行修饰符列表条目的注册元数据。</para>
     /// </summary>
-    /// <param name="ModifierType">Concrete <see cref="ModifierModel" /> type. 具体 <see cref="ModifierModel" /> 类型。</param>
+    /// <param name="ModifierType">
+    /// <para xml:lang="en">Concrete <see cref="ModifierModel" /> type.</para>
+    /// <para xml:lang="zh-CN">具体 <see cref="ModifierModel" /> 类型。</para>
+    /// </param>
     /// <param name="ModifierListSortOrder">
-    ///     Negative values insert before the current list segment; non-negative values insert after.
-    ///     负值插入当前列表段之前；非负值插入之后。
+    /// <para xml:lang="en">Negative values insert before the current list segment; non-negative values insert after.</para>
+    /// <para xml:lang="zh-CN">负值插入当前列表段之前；非负值插入之后。</para>
     /// </param>
     internal readonly record struct ModifierRegistration(Type ModifierType, int ModifierListSortOrder);
 }

--- a/Content/Patches/ModelDbContentPatchHelper.cs
+++ b/Content/Patches/ModelDbContentPatchHelper.cs
@@ -1,0 +1,27 @@
+using MegaCrit.Sts2.Core.Models;
+using STS2RitsuLib.Content;
+
+namespace STS2RitsuLib.Content.Patches
+{
+    /// <summary>
+    /// <para xml:lang="en">Applies <see cref="ModelDbGetterMerge" /> then mod append delegates for patched <see cref="ModelDb" /> getter postfixes.</para>
+    /// <para xml:lang="zh-CN">为已修补的 <see cref="ModelDb" /> getter postfix 应用 <see cref="ModelDbGetterMerge" /> 与 mod 追加委托。</para>
+    /// </summary>
+    internal static class ModelDbContentPatchHelper
+    {
+        internal static void Append<TModel>(
+            ref IEnumerable<TModel> result,
+            Func<IEnumerable<TModel>, IEnumerable<TModel>> append)
+            where TModel : AbstractModel
+        {
+            result = ModelDbGetterMerge.MergeEnumerable(result, append);
+        }
+
+        internal static void Append<TItem>(
+            ref IReadOnlyList<TItem> result,
+            Func<IReadOnlyList<TItem>, IReadOnlyList<TItem>> append)
+        {
+            result = ModelDbGetterMerge.MergeReadOnlyList(result, append);
+        }
+    }
+}

--- a/Content/Patches/ModelDbContentPatches.cs
+++ b/Content/Patches/ModelDbContentPatches.cs
@@ -5,8 +5,8 @@ using STS2RitsuLib.Patching.Models;
 namespace STS2RitsuLib.Content.Patches
 {
     /// <summary>
-    ///     Appends RitsuLib-registered characters to <see cref="ModelDb.AllCharacters" />.
-    ///     将 RitsuLib 注册的角色追加到 <see cref="ModelDb.AllCharacters" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered characters to <see cref="ModelDb.AllCharacters" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的角色追加到 <see cref="ModelDb.AllCharacters" />。</para>
     /// </summary>
     public class AllCharactersPatch : IPatchMethod
     {
@@ -26,20 +26,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod-registered characters onto the vanilla sequence.
-        ///     将 mod 注册的角色拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod-registered characters onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 注册的角色拼接到原版序列之后。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IEnumerable<CharacterModel> __result)
         {
-            __result = ModContentRegistry.AppendCharacters(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendCharacters);
         }
     }
 
     /// <summary>
-    ///     Merges RitsuLib-registered monster types into <see cref="ModelDb.Monsters" /> by <see cref="AbstractModel.Id" />.
-    ///     按 <see cref="AbstractModel.Id" /> 将 RitsuLib 注册的怪物类型合并到 <see cref="ModelDb.Monsters" />。
+    /// <para xml:lang="en">Merges RitsuLib-registered monster types into <see cref="ModelDb.Monsters" /> by <see cref="AbstractModel.Id" />.</para>
+    /// <para xml:lang="zh-CN">按 <see cref="AbstractModel.Id" /> 将 RitsuLib 注册的怪物类型合并到 <see cref="ModelDb.Monsters" />。</para>
     /// </summary>
     public class AllMonstersPatch : IPatchMethod
     {
@@ -59,18 +59,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Ensures standalone-registered monsters appear in global monster enumeration even before every act lists them.
-        ///     确保独立注册的怪物即使在每个章节列出它们之前，也会出现在全局怪物枚举中。
+        /// <para xml:lang="en">Ensures standalone-registered monsters appear in global monster enumeration even before every act lists them.</para>
+        /// <para xml:lang="zh-CN">确保独立注册的怪物即使在每个章节列出它们之前，也会出现在全局怪物枚举中。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<MonsterModel> __result)
         {
-            __result = ModContentRegistry.AppendRegisteredMonsters(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendRegisteredMonsters);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered acts to <see cref="ModelDb.Acts" />.
-    ///     将 RitsuLib 注册的章节追加到 <see cref="ModelDb.Acts" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered acts to <see cref="ModelDb.Acts" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的章节追加到 <see cref="ModelDb.Acts" />。</para>
     /// </summary>
     public class ActsPatch : IPatchMethod
     {
@@ -90,20 +90,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod-registered acts onto the vanilla sequence.
-        ///     将 mod 注册的章节拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod-registered acts onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 注册的章节拼接到原版序列之后。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IEnumerable<ActModel> __result)
         {
-            __result = ModContentRegistry.AppendActs(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendActs);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered shared events to <see cref="ModelDb.AllSharedEvents" />.
-    ///     将 RitsuLib 注册的共享事件追加到 <see cref="ModelDb.AllSharedEvents" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered shared events to <see cref="ModelDb.AllSharedEvents" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的共享事件追加到 <see cref="ModelDb.AllSharedEvents" />。</para>
     /// </summary>
     public class AllSharedEventsPatch : IPatchMethod
     {
@@ -123,20 +123,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod shared events onto the vanilla sequence.
-        ///     将 mod 共享事件拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod shared events onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 共享事件拼接到原版序列之后。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IEnumerable<EventModel> __result)
         {
-            __result = ModContentRegistry.AppendSharedEvents(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendSharedEvents);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered powers to <see cref="ModelDb.AllPowers" />.
-    ///     将 RitsuLib 注册的能力追加到 <see cref="ModelDb.AllPowers" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered powers to <see cref="ModelDb.AllPowers" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的能力追加到 <see cref="ModelDb.AllPowers" />。</para>
     /// </summary>
     public class AllPowersPatch : IPatchMethod
     {
@@ -156,18 +156,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod powers onto the vanilla sequence.
-        ///     将 mod 能力拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod powers onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 能力拼接到原版序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<PowerModel> __result)
         {
-            __result = ModContentRegistry.AppendPowers(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendPowers);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered orbs to <see cref="ModelDb.Orbs" />.
-    ///     将 RitsuLib 注册的充能球追加到 <see cref="ModelDb.Orbs" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered orbs to <see cref="ModelDb.Orbs" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的充能球追加到 <see cref="ModelDb.Orbs" />。</para>
     /// </summary>
     public class AllOrbsPatch : IPatchMethod
     {
@@ -187,18 +187,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod orbs onto the vanilla sequence.
-        ///     将 mod 充能球拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod orbs onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 充能球拼接到原版序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<OrbModel> __result)
         {
-            __result = ModContentRegistry.AppendOrbs(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendOrbs);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered shared card pools to <see cref="ModelDb.AllSharedCardPools" />.
-    ///     将 RitsuLib 注册的共享卡牌池追加到 <see cref="ModelDb.AllSharedCardPools" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered shared card pools to <see cref="ModelDb.AllSharedCardPools" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的共享卡牌池追加到 <see cref="ModelDb.AllSharedCardPools" />。</para>
     /// </summary>
     public class AllSharedCardPoolsPatch : IPatchMethod
     {
@@ -218,20 +218,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod shared card pools onto the vanilla sequence.
-        ///     将 mod 共享卡牌池拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod shared card pools onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 共享卡牌池拼接到原版序列之后。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IEnumerable<CardPoolModel> __result)
         {
-            __result = ModContentRegistry.AppendSharedCardPools(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendSharedCardPools);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered shared events to <see cref="ModelDb.AllEvents" />.
-    ///     将 RitsuLib 注册的共享事件追加到 <see cref="ModelDb.AllEvents" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered shared events to <see cref="ModelDb.AllEvents" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的共享事件追加到 <see cref="ModelDb.AllEvents" />。</para>
     /// </summary>
     public class AllEventsPatch : IPatchMethod
     {
@@ -251,18 +251,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod shared events onto the <see cref="ModelDb.AllEvents" /> sequence.
-        ///     将 mod 共享事件拼接到 <see cref="ModelDb.AllEvents" /> 序列之后。
+        /// <para xml:lang="en">Concatenates mod shared events onto the <see cref="ModelDb.AllEvents" /> sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 共享事件拼接到 <see cref="ModelDb.AllEvents" /> 序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<EventModel> __result)
         {
-            __result = ModContentRegistry.AppendSharedEvents(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendSharedEvents);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered shared ancients to <see cref="ModelDb.AllSharedAncients" />.
-    ///     将 RitsuLib 注册的共享ancient追加到 <see cref="ModelDb.AllSharedAncients" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered shared ancients to <see cref="ModelDb.AllSharedAncients" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的共享ancient追加到 <see cref="ModelDb.AllSharedAncients" />。</para>
     /// </summary>
     public class AllSharedAncientsPatch : IPatchMethod
     {
@@ -282,20 +282,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod shared ancients onto the vanilla sequence.
-        ///     将 mod 共享ancient拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod shared ancients onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 共享ancient拼接到原版序列之后。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IEnumerable<AncientEventModel> __result)
         {
-            __result = ModContentRegistry.AppendSharedAncients(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendSharedAncients);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered shared ancients to <see cref="ModelDb.AllAncients" />.
-    ///     将 RitsuLib 注册的共享ancient追加到 <see cref="ModelDb.AllAncients" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered shared ancients to <see cref="ModelDb.AllAncients" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的共享ancient追加到 <see cref="ModelDb.AllAncients" />。</para>
     /// </summary>
     public class AllAncientsPatch : IPatchMethod
     {
@@ -315,19 +315,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod shared ancients onto the <see cref="ModelDb.AllAncients" /> sequence.
-        ///     将 mod 共享远古事件拼接到 <see cref="ModelDb.AllAncients" /> 序列之后。
+        /// <para xml:lang="en">Concatenates mod shared ancients onto the <see cref="ModelDb.AllAncients" /> sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 共享远古事件拼接到 <see cref="ModelDb.AllAncients" /> 序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<AncientEventModel> __result)
         {
-            __result = ModContentRegistry.AppendSharedAncients(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendSharedAncients);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered enchantments to <see cref="ModelDb.DebugEnchantments" /> (covers dynamic types not in
-    ///     subtype scan).
-    ///     将 RitsuLib 注册的附魔追加到 <see cref="ModelDb.DebugEnchantments" />（覆盖子类型扫描之外的动态类型）。
+    /// <para xml:lang="en">Appends RitsuLib-registered enchantments to <see cref="ModelDb.DebugEnchantments" /> (covers dynamic types not in subtype scan).</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的附魔追加到 <see cref="ModelDb.DebugEnchantments" />（覆盖子类型扫描之外的动态类型）。</para>
     /// </summary>
     public class DebugEnchantmentsPatch : IPatchMethod
     {
@@ -347,18 +346,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod enchantments onto the vanilla sequence.
-        ///     将 mod 附魔拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod enchantments onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 附魔拼接到原版序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<EnchantmentModel> __result)
         {
-            __result = ModContentRegistry.AppendEnchantments(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendEnchantments);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered afflictions to <see cref="ModelDb.DebugAfflictions" />.
-    ///     将 RitsuLib 注册的苦痛追加到 <see cref="ModelDb.DebugAfflictions" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered afflictions to <see cref="ModelDb.DebugAfflictions" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的苦痛追加到 <see cref="ModelDb.DebugAfflictions" />。</para>
     /// </summary>
     public class DebugAfflictionsPatch : IPatchMethod
     {
@@ -378,18 +377,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod afflictions onto the vanilla sequence.
-        ///     将 mod 苦痛拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod afflictions onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 苦痛拼接到原版序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<AfflictionModel> __result)
         {
-            __result = ModContentRegistry.AppendAfflictions(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendAfflictions);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered achievements to <see cref="ModelDb.Achievements" />.
-    ///     将 RitsuLib 注册的成就追加到 <see cref="ModelDb.Achievements" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered achievements to <see cref="ModelDb.Achievements" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的成就追加到 <see cref="ModelDb.Achievements" />。</para>
     /// </summary>
     public class AchievementsPatch : IPatchMethod
     {
@@ -409,18 +408,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Merges mod achievements into the vanilla list by <see cref="AbstractModel.Id" />.
-        ///     按 <see cref="AbstractModel.Id" /> 将 mod 成就合并到原版列表中。
+        /// <para xml:lang="en">Merges mod achievements into the vanilla list by <see cref="AbstractModel.Id" />.</para>
+        /// <para xml:lang="zh-CN">按 <see cref="AbstractModel.Id" /> 将 mod 成就合并到原版列表中。</para>
         /// </summary>
         public static void Postfix(ref IReadOnlyList<AchievementModel> __result)
         {
-            __result = ModContentRegistry.AppendAchievements(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendAchievements);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered modifiers to <see cref="ModelDb.GoodModifiers" />.
-    ///     将 RitsuLib 注册的修饰符追加到 <see cref="ModelDb.GoodModifiers" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered modifiers to <see cref="ModelDb.GoodModifiers" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的修饰符追加到 <see cref="ModelDb.GoodModifiers" />。</para>
     /// </summary>
     public class GoodModifiersPatch : IPatchMethod
     {
@@ -440,20 +439,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Merges mod good modifiers into the current list using <see cref="ModifierRegistration.ModifierListSortOrder" />.
-        ///     按 <see cref="ModifierRegistration.ModifierListSortOrder" /> 将 mod 正面修饰符合并到当前列表中。
+        /// <para xml:lang="en">Merges mod good modifiers into the current list using <see cref="ModifierRegistration.ModifierListSortOrder" />.</para>
+        /// <para xml:lang="zh-CN">按 <see cref="ModifierRegistration.ModifierListSortOrder" /> 将 mod 正面修饰符合并到当前列表中。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IReadOnlyList<ModifierModel> __result)
         {
-            __result = ModContentRegistry.AppendGoodModifiers(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendGoodModifiers);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered modifiers to <see cref="ModelDb.BadModifiers" />.
-    ///     将 RitsuLib 注册的修饰符追加到 <see cref="ModelDb.BadModifiers" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered modifiers to <see cref="ModelDb.BadModifiers" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的修饰符追加到 <see cref="ModelDb.BadModifiers" />。</para>
     /// </summary>
     public class BadModifiersPatch : IPatchMethod
     {
@@ -473,20 +472,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Merges mod bad modifiers into the current list using <see cref="ModifierRegistration.ModifierListSortOrder" />.
-        ///     按 <see cref="ModifierRegistration.ModifierListSortOrder" /> 将 mod 负面修饰符合并到当前列表中。
+        /// <para xml:lang="en">Merges mod bad modifiers into the current list using <see cref="ModifierRegistration.ModifierListSortOrder" />.</para>
+        /// <para xml:lang="zh-CN">按 <see cref="ModifierRegistration.ModifierListSortOrder" /> 将 mod 负面修饰符合并到当前列表中。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IReadOnlyList<ModifierModel> __result)
         {
-            __result = ModContentRegistry.AppendBadModifiers(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendBadModifiers);
         }
     }
 
     /// <summary>
-    ///     Merges RitsuLib-registered modifier exclusivity groups into <see cref="ModelDb.MutuallyExclusiveModifiers" />.
-    ///     将 RitsuLib 注册的修饰符互斥组合并到 <see cref="ModelDb.MutuallyExclusiveModifiers" />。
+    /// <para xml:lang="en">Merges RitsuLib-registered modifier exclusivity groups into <see cref="ModelDb.MutuallyExclusiveModifiers" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的修饰符互斥组合并到 <see cref="ModelDb.MutuallyExclusiveModifiers" />。</para>
     /// </summary>
     public class MutuallyExclusiveModifiersPatch : IPatchMethod
     {
@@ -507,20 +506,20 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Merges mod exclusivity groups into the current list, including overlapping vanilla sets.
-        ///     将 mod 互斥组合并到当前列表，并与存在交集的原版集合合并。
+        /// <para xml:lang="en">Merges mod exclusivity groups into the current list, including overlapping vanilla sets.</para>
+        /// <para xml:lang="zh-CN">将 mod 互斥组合并到当前列表，并与存在交集的原版集合合并。</para>
         /// </summary>
         [HarmonyAfter(Const.BaseLibHarmonyId)]
         [HarmonyPriority(Priority.Last)]
         public static void Postfix(ref IReadOnlyList<IReadOnlySet<ModifierModel>> __result)
         {
-            __result = ModContentRegistry.AppendMutuallyExclusiveModifiers(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendMutuallyExclusiveModifiers);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered shared relic pools to <see cref="ModelDb.AllRelicPools" />.
-    ///     将 RitsuLib 注册的共享遗物池追加到 <see cref="ModelDb.AllRelicPools" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered shared relic pools to <see cref="ModelDb.AllRelicPools" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的共享遗物池追加到 <see cref="ModelDb.AllRelicPools" />。</para>
     /// </summary>
     public class AllRelicPoolsPatch : IPatchMethod
     {
@@ -540,18 +539,18 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod shared relic pools onto the vanilla sequence.
-        ///     将 mod 共享遗物池拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod shared relic pools onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 共享遗物池拼接到原版序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<RelicPoolModel> __result)
         {
-            __result = ModContentRegistry.AppendSharedRelicPools(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendSharedRelicPools);
         }
     }
 
     /// <summary>
-    ///     Appends RitsuLib-registered shared potion pools to <see cref="ModelDb.AllPotionPools" />.
-    ///     将 RitsuLib 注册的共享药水池追加到 <see cref="ModelDb.AllPotionPools" />。
+    /// <para xml:lang="en">Appends RitsuLib-registered shared potion pools to <see cref="ModelDb.AllPotionPools" />.</para>
+    /// <para xml:lang="zh-CN">将 RitsuLib 注册的共享药水池追加到 <see cref="ModelDb.AllPotionPools" />。</para>
     /// </summary>
     public class AllPotionPoolsPatch : IPatchMethod
     {
@@ -571,12 +570,12 @@ namespace STS2RitsuLib.Content.Patches
         }
 
         /// <summary>
-        ///     Concatenates mod shared potion pools onto the vanilla sequence.
-        ///     将 mod 共享药水池拼接到原版序列之后。
+        /// <para xml:lang="en">Concatenates mod shared potion pools onto the vanilla sequence.</para>
+        /// <para xml:lang="zh-CN">将 mod 共享药水池拼接到原版序列之后。</para>
         /// </summary>
         public static void Postfix(ref IEnumerable<PotionPoolModel> __result)
         {
-            __result = ModContentRegistry.AppendSharedPotionPools(__result);
+            ModelDbContentPatchHelper.Append(ref __result, ModContentRegistry.AppendSharedPotionPools);
         }
     }
 }

--- a/Content/ResolvedModelCache.cs
+++ b/Content/ResolvedModelCache.cs
@@ -1,0 +1,151 @@
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2RitsuLib.Content
+{
+    /// <summary>
+    /// <para xml:lang="en">Resolves registered types after <see cref="ModelDb.Init" /> and serves cached models for getter merges.</para>
+    /// <para xml:lang="zh-CN">在 <see cref="ModelDb.Init" /> 后解析已注册类型，并为 getter 合并提供缓存模型。</para>
+    /// </summary>
+    internal static class ResolvedModelCache
+    {
+        private static readonly Lock Gate = new();
+
+        private static Dictionary<ContentCatalogId, ContentCatalogEntry> _catalogs = [];
+        private static Dictionary<ContentCatalogId, object> _globalCache = [];
+        private static Dictionary<ContentCatalogId, Dictionary<Type, object>> _scopedCache = [];
+        private static ContentRegistryPhase _phase = ContentRegistryPhase.Open;
+
+        internal static ContentRegistryPhase Phase
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return _phase;
+                }
+            }
+        }
+
+        internal static void Configure(IReadOnlyList<ContentCatalogEntry> catalogs)
+        {
+            lock (Gate)
+            {
+                _catalogs = catalogs.ToDictionary(static entry => entry.Id);
+            }
+        }
+
+        internal static void MarkFrozen()
+        {
+            lock (Gate)
+            {
+                if (_phase == ContentRegistryPhase.Open)
+                    _phase = ContentRegistryPhase.Frozen;
+            }
+        }
+
+        internal static void Warm()
+        {
+            lock (Gate)
+            {
+                if (_phase >= ContentRegistryPhase.Resolved)
+                    return;
+
+                foreach (var catalog in _catalogs.Values)
+                {
+                    if (catalog.IsScoped)
+                    {
+                        _scopedCache[catalog.Id] = catalog.WarmScoped!(catalog.ScopedRegistry!());
+                    }
+                    else
+                    {
+                        _globalCache[catalog.Id] = catalog.WarmGlobal!(catalog.GlobalTypes!());
+                    }
+                }
+
+                _phase = ContentRegistryPhase.Resolved;
+            }
+        }
+
+        internal static TModel[] GetGlobal<TModel>(ContentCatalogId id)
+            where TModel : AbstractModel
+        {
+            lock (Gate)
+            {
+                if (_phase >= ContentRegistryPhase.Resolved &&
+                    _globalCache.TryGetValue(id, out var cached))
+                {
+                    return (TModel[])cached;
+                }
+
+                return ResolveUncached<TModel>(_catalogs[id].GlobalTypes!());
+            }
+        }
+
+        internal static TModel[] GetScoped<TModel>(ContentCatalogId id, Type scopeType)
+            where TModel : AbstractModel
+        {
+            ArgumentNullException.ThrowIfNull(scopeType);
+
+            lock (Gate)
+            {
+                if (_phase >= ContentRegistryPhase.Resolved &&
+                    _scopedCache.TryGetValue(id, out var byScope) &&
+                    byScope.TryGetValue(scopeType, out var cached))
+                {
+                    return (TModel[])cached;
+                }
+
+                var registry = _catalogs[id].ScopedRegistry!();
+                return !registry.TryGetValue(scopeType, out var modelTypes)
+                    ? []
+                    : ResolveUncached<TModel>(modelTypes);
+            }
+        }
+
+        internal static TModel[] ResolveUncached<TModel>(IEnumerable<Type> modelTypes)
+            where TModel : AbstractModel
+        {
+            return modelTypes
+                .OrderBy(static t => t.FullName ?? t.Name, StringComparer.Ordinal)
+                .Select(ModelDb.GetId)
+                .Select(ModelDb.GetById<TModel>)
+                .ToArray();
+        }
+
+        internal static Dictionary<Type, object> ResolveScopedUncached<TModel>(
+            Dictionary<Type, HashSet<Type>> registry)
+            where TModel : AbstractModel
+        {
+            var cache = new Dictionary<Type, object>();
+            foreach (var (scopeType, modelTypes) in registry)
+                cache[scopeType] = ResolveUncached<TModel>(modelTypes);
+
+            return cache;
+        }
+    }
+
+    /// <summary>
+    /// <para xml:lang="en">Registration freeze and resolved-model cache lifecycle.</para>
+    /// <para xml:lang="zh-CN">注册冻结与已解析模型缓存的生命周期。</para>
+    /// </summary>
+    internal enum ContentRegistryPhase
+    {
+        /// <summary>
+        /// <para xml:lang="en">Open for mod registration.</para>
+        /// <para xml:lang="zh-CN">允许 mod 注册。</para>
+        /// </summary>
+        Open = 0,
+
+        /// <summary>
+        /// <para xml:lang="en">Registrations frozen at <see cref="ModelDb.Init" /> prefix.</para>
+        /// <para xml:lang="zh-CN">在 <see cref="ModelDb.Init" /> Prefix 冻结注册。</para>
+        /// </summary>
+        Frozen = 1,
+
+        /// <summary>
+        /// <para xml:lang="en">Caches warmed after <see cref="ModelDb.Init" />.</para>
+        /// <para xml:lang="zh-CN"><see cref="ModelDb.Init" /> 后缓存已预热。</para>
+        /// </summary>
+        Resolved = 2,
+    }
+}

--- a/Lifecycle/Patches/CoreLifecyclePatches.cs
+++ b/Lifecycle/Patches/CoreLifecyclePatches.cs
@@ -19,11 +19,8 @@ using STS2RitsuLib.Unlocks;
 namespace STS2RitsuLib.Lifecycle.Patches
 {
     /// <summary>
-    ///     Publishes <see cref="EssentialInitializationStartingEvent" /> / <see cref="DeferredInitializationStartingEvent" />
-    ///     and matching completed events around vanilla one-time initialization.
-    ///     在原版一次性初始化前后发布 <see cref="EssentialInitializationStartingEvent" /> /
-    ///     <see cref="DeferredInitializationStartingEvent" />
-    ///     以及对应的 completed 事件。
+    /// <para xml:lang="en">Publishes <see cref="EssentialInitializationStartingEvent" /> / <see cref="DeferredInitializationStartingEvent" /> and matching completed events around vanilla one-time initialization.</para>
+    /// <para xml:lang="zh-CN">在原版一次性初始化前后发布 <see cref="EssentialInitializationStartingEvent" /> / <see cref="DeferredInitializationStartingEvent" /> 以及对应的 completed 事件。</para>
     /// </summary>
     public class CoreInitializationLifecyclePatch : IPatchMethod
     {
@@ -48,8 +45,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Emits “starting” lifecycle events before essential or deferred initialization runs.
-        ///     在必要或延迟初始化运行前发出“starting”生命周期事件。
+        /// <para xml:lang="en">Emits “starting” lifecycle events before essential or deferred initialization runs.</para>
+        /// <para xml:lang="zh-CN">在必要或延迟初始化运行前发出“starting”生命周期事件。</para>
         /// </summary>
         public static void Prefix(MethodBase __originalMethod)
         {
@@ -71,8 +68,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Emits “completed” lifecycle events after essential or deferred initialization runs.
-        ///     在必要或延迟初始化运行后发出“completed”生命周期事件。
+        /// <para xml:lang="en">Emits “completed” lifecycle events after essential or deferred initialization runs.</para>
+        /// <para xml:lang="zh-CN">在必要或延迟初始化运行后发出“completed”生命周期事件。</para>
         /// </summary>
         public static void Postfix(MethodBase __originalMethod)
         {
@@ -95,10 +92,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
     }
 
     /// <summary>
-    ///     Hooks <see cref="ModelDb" /> and related init to freeze registries, inject models, and publish model lifecycle
-    ///     events.
-    ///     hook <see cref="ModelDb" /> 和相关 init，以冻结注册表、注入模型并发布模型生命周期
-    ///     事件。
+    /// <para xml:lang="en">Hooks <see cref="ModelDb" /> and related init to freeze registries, inject models, and publish model lifecycle events.</para>
+    /// <para xml:lang="zh-CN">hook <see cref="ModelDb" /> 和相关 init，以冻结注册表、注入模型并发布模型生命周期事件。</para>
     /// </summary>
     public class ModelRegistryLifecyclePatch : IPatchMethod
     {
@@ -127,8 +122,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Runs registry freezes, validation, and “starting” model lifecycle events before targeted init methods.
-        ///     在目标初始化方法前运行注册表冻结、验证和“starting”模型生命周期事件。
+        /// <para xml:lang="en">Runs registry freezes, validation, and “starting” model lifecycle events before targeted init methods.</para>
+        /// <para xml:lang="zh-CN">在目标初始化方法前运行注册表冻结、验证和“starting”模型生命周期事件。</para>
         /// </summary>
         public static void Prefix(MethodBase __originalMethod)
         {
@@ -172,8 +167,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Publishes “completed” model lifecycle events after <see cref="ModelDb" /> init phases.
-        ///     在 <see cref="ModelDb" /> 初始化阶段后发布“completed”模型生命周期事件。
+        /// <para xml:lang="en">Publishes “completed” model lifecycle events after <see cref="ModelDb" /> init phases.</para>
+        /// <para xml:lang="zh-CN">在 <see cref="ModelDb" /> 初始化阶段后发布“completed”模型生命周期事件。</para>
         /// </summary>
         public static void Postfix(MethodBase __originalMethod)
         {
@@ -181,6 +176,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
             {
                 case nameof(ModelDb.Init):
                     ValidateFrozenRegistrations(nameof(ModelDb.Init));
+                    RitsuLibStartupAudit.Measure("modelDb.warmResolvedCaches",
+                        ModContentRegistry.WarmResolvedModelCaches);
                     RitsuLibFramework.PublishLifecycleEvent(
                         new ModelRegistryInitializedEvent(ModelDb.AllAbstractModelSubtypes.Length,
                             DateTimeOffset.UtcNow),
@@ -218,8 +215,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
     }
 
     /// <summary>
-    ///     Publishes <see cref="GameTreeEnteredEvent" /> and <see cref="GameReadyEvent" /> for <see cref="NGame" />.
-    ///     为 <see cref="NGame" /> 发布 <see cref="GameTreeEnteredEvent" /> 和 <see cref="GameReadyEvent" />。
+    /// <para xml:lang="en">Publishes <see cref="GameTreeEnteredEvent" /> and <see cref="GameReadyEvent" /> for <see cref="NGame" />.</para>
+    /// <para xml:lang="zh-CN">为 <see cref="NGame" /> 发布 <see cref="GameTreeEnteredEvent" /> 和 <see cref="GameReadyEvent" />。</para>
     /// </summary>
     public class GameNodeLifecyclePatch : IPatchMethod
     {
@@ -243,8 +240,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Dispatches game tree / ready lifecycle events based on which <see cref="NGame" /> method was patched.
-        ///     根据被补丁的 <see cref="NGame" /> 方法分发游戏树/就绪生命周期事件。
+        /// <para xml:lang="en">Dispatches game tree / ready lifecycle events based on which <see cref="NGame" /> method was patched.</para>
+        /// <para xml:lang="zh-CN">根据被补丁的 <see cref="NGame" /> 方法分发游戏树/就绪生命周期事件。</para>
         /// </summary>
         public static void Postfix(MethodBase __originalMethod, NGame __instance)
         {
@@ -267,8 +264,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
     }
 
     /// <summary>
-    ///     Publishes <see cref="RunStartedEvent" /> and <see cref="RunLoadedEvent" /> from <see cref="RunManager" />.
-    ///     从 <see cref="RunManager" /> 发布 <see cref="RunStartedEvent" /> 和 <see cref="RunLoadedEvent" />。
+    /// <para xml:lang="en">Publishes <see cref="RunStartedEvent" /> and <see cref="RunLoadedEvent" /> from <see cref="RunManager" />.</para>
+    /// <para xml:lang="zh-CN">从 <see cref="RunManager" /> 发布 <see cref="RunStartedEvent" /> 和 <see cref="RunLoadedEvent" />。</para>
     /// </summary>
     public class RunLifecyclePatch : IPatchMethod
     {
@@ -292,8 +289,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Emits run started/loaded events after new or saved run initialization.
-        ///     在新跑局或存档跑局初始化后发出跑局开始/加载事件。
+        /// <para xml:lang="en">Emits run started/loaded events after new or saved run initialization.</para>
+        /// <para xml:lang="zh-CN">在新跑局或存档跑局初始化后发出跑局开始/加载事件。</para>
         /// </summary>
         public static void Postfix(
             MethodBase __originalMethod,
@@ -322,8 +319,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
     }
 
     /// <summary>
-    ///     Publishes <see cref="RunEndedEvent" /> and forwards run end to <see cref="ModUnlockRegistry" />.
-    ///     发布 <see cref="RunEndedEvent" />，并将跑局结束转发给 <see cref="ModUnlockRegistry" />。
+    /// <para xml:lang="en">Publishes <see cref="RunEndedEvent" /> and forwards run end to <see cref="ModUnlockRegistry" />.</para>
+    /// <para xml:lang="zh-CN">发布 <see cref="RunEndedEvent" />，并将跑局结束转发给 <see cref="ModUnlockRegistry" />。</para>
     /// </summary>
     public class RunEndedLifecyclePatch : IPatchMethod
     {
@@ -349,8 +346,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Captures vanilla's own run-end guard before <see cref="RunManager.OnEnded" /> mutates it.
-        ///     在 <see cref="RunManager.OnEnded" /> 修改原版跑局结束保护标记前捕获它。
+        /// <para xml:lang="en">Captures vanilla's own run-end guard before <see cref="RunManager.OnEnded" /> mutates it.</para>
+        /// <para xml:lang="zh-CN">在 <see cref="RunManager.OnEnded" /> 修改原版跑局结束保护标记前捕获它。</para>
         /// </summary>
         public static void Prefix(RunManager __instance, out bool __state)
         {
@@ -358,8 +355,8 @@ namespace STS2RitsuLib.Lifecycle.Patches
         }
 
         /// <summary>
-        ///     Runs unlock bookkeeping and publishes <see cref="RunEndedEvent" /> when a run terminates.
-        ///     当跑局终止时运行解锁记账并发布 <see cref="RunEndedEvent" />。
+        /// <para xml:lang="en">Runs unlock bookkeeping and publishes <see cref="RunEndedEvent" /> when a run terminates.</para>
+        /// <para xml:lang="zh-CN">当跑局终止时运行解锁记账并发布 <see cref="RunEndedEvent" />。</para>
         /// </summary>
         public static void Postfix(RunManager __instance, bool isVictory, SerializableRun __result, bool __state)
         {


### PR DESCRIPTION
## Summary

Fixes `ModelDb.Preload` hanging when patched enumerable getters (`AllPotionPools`, etc.) re-enter during lazy `IEnumerable` materialization, causing unbounded `GetId` recursion.

Reproduced with RitsuLib + large content mods on STS2 0.103.3 (compat 0.103.2 build). Verified locally.

## Changes

- Snapshot lazy getter output once; pass through on nested calls (`ModelDbGetterMerge`)
- Route getter postfixes through `ModelDbContentPatchHelper`
- Warm resolved mod models after `ModelDb.Init` (`ResolvedModelCache`) so merges don't call `GetId` on every access