### PR TITLE
Recollect particles after scene conversion

### DIFF
--- a/src/Scaffolding/Godot/NodeFactories/RitsuNEnergyCounterNodeFactory.cs
+++ b/src/Scaffolding/Godot/NodeFactories/RitsuNEnergyCounterNodeFactory.cs
@@ -3,6 +3,7 @@ using Godot.Collections;
 using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.Nodes.Combat;
+using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Nodes.Vfx.Utilities;
 
 namespace STS2RitsuLib.Scaffolding.Godot.NodeFactories
@@ -54,6 +55,9 @@ namespace STS2RitsuLib.Scaffolding.Godot.NodeFactories
             }
 
             TransferAndCreateNodes(target, source);
+
+            foreach (var container in target.GetChildrenRecursive<NParticlesContainer>())
+                SetParticles(container);
         }
 
         protected override void GenerateNode(NEnergyCounter target, IRitsuGodotNodeSlot required)
@@ -64,11 +68,11 @@ namespace STS2RitsuLib.Scaffolding.Godot.NodeFactories
                     target.AddChild(CreateDefaultLabel());
                     break;
                 case "%RotationLayers":
-                {
-                    var control = CreateFullRectControl(null);
-                    target.AddUniqueChild(control, "RotationLayers");
-                    break;
-                }
+                    {
+                        var control = CreateFullRectControl(null);
+                        target.AddUniqueChild(control, "RotationLayers");
+                        break;
+                    }
                 case "%EnergyVfxBack":
                     target.AddUniqueChild(CreateParticlesContainer(null, "EnergyVfxBack"));
                     break;
@@ -131,7 +135,6 @@ namespace STS2RitsuLib.Scaffolding.Godot.NodeFactories
             {
                 container.AddChild(singleParticle);
                 singleParticle.Owner = container;
-                SetParticles(container);
                 return container;
             }
 
@@ -141,7 +144,6 @@ namespace STS2RitsuLib.Scaffolding.Godot.NodeFactories
                 container.AddChild(source);
             }
 
-            SetParticles(container);
             return container;
         }
 


### PR DESCRIPTION
## Summary / 概要
- `RitsuNEnergyCounterNodeFactory` 中先取走子节点再调用了 `SetParticles`，导致 `_particles` 写入空数组，粒子发射器无法通过 `Restart()` 或 `SetEmitting()` 控制。

## Why / 背景与动机
在 `RitsuGodotNodeFactory` 里的 `TransferAndCreateNodes` ：
```csharp
                    if (!missing.IsValidType(node))
                    {
                        node.ReplaceBy(placeholder);
                        node = ConvertNodeType(node, missing.ExpectedNodeType);
                        placeholder.ReplaceBy(node);
                    }
```
这里 `node` 被 `placeholder` 替换以后，自己没有子节点了，而 `SetParticles` 是在 `ConvertNodeType` 里调用的，导致它找不到子节点，于是 `ParticlesContainer` 的 `_particles` 没有任何元素。

## What changed / 变更点
- `src/Scaffolding/Godot/NodeFactories/RitsuNEnergyCounterNodeFactory.cs`:  删除 `CreateParticlesContainer` 内部的 `SetParticles` 调用，在 `TransferAndCreateNodes` 后才调用 `SetParticles`。

## Notes / 备注
- 不知道其他地方是否会有问题？可以做一个统一的修改，例如在第二次replace后添加一个处理函数