### PR TITLE
perf: optimize log viewer frontend performance

### DIFF
--- a/components/viewer/src/App.vue
+++ b/components/viewer/src/App.vue
@@ -143,6 +143,7 @@ function formatTime(timestamp: string) {
 
         <LogList
             v-model:follow="viewer.follow.value"
+            :appended-record-keys="viewer.appendedRecordKeys.value"
             :all-selected="viewer.areAllFilteredSelected.value"
             :record-key="viewer.recordKey"
             :records="viewer.filteredRecords.value"

--- a/components/viewer/src/components/LogList.vue
+++ b/components/viewer/src/components/LogList.vue
@@ -8,6 +8,7 @@ import type {ColumnId} from "../viewerConfig";
 
 const props = defineProps<{
   records: LogRecord[];
+  appendedRecordKeys: string[];
   selectedIds: Set<string>;
   selectedRecord: LogRecord | null;
   visibleColumns: Set<ColumnId>;
@@ -30,8 +31,6 @@ const logList = ref<HTMLElement | null>(null);
 const scrollTop = ref(0);
 const enteringKeys = ref(new Set<string>());
 let programmaticScroll = false;
-let knownRecordKeys = new Set<string>();
-let initializedRecordKeys = false;
 
 const gridTemplate = computed(() => {
   if (compact.value)
@@ -67,20 +66,11 @@ watch(() => props.records.length, async () => {
     scrollToBottom();
 });
 
-watch(() => props.records.map((record) => props.recordKey(record)), (keys) => {
-  const nextKnownKeys = new Set(keys);
-  if (!initializedRecordKeys) {
-    knownRecordKeys = nextKnownKeys;
-    initializedRecordKeys = true;
-    return;
-  }
-
-  const addedKeys = keys.filter((key) => !knownRecordKeys.has(key));
-  knownRecordKeys = nextKnownKeys;
-  if (addedKeys.length === 0)
+watch(() => props.appendedRecordKeys, (keys) => {
+  if (keys.length === 0)
     return;
 
-  const animatedKeys = addedKeys.length > 80 ? addedKeys.slice(-20) : addedKeys;
+  const animatedKeys = keys.length > 80 ? keys.slice(-20) : keys;
   enteringKeys.value = new Set([...enteringKeys.value, ...animatedKeys]);
   window.setTimeout(() => {
     const next = new Set(enteringKeys.value);

--- a/components/viewer/src/components/LogList.vue
+++ b/components/viewer/src/components/LogList.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import {useVirtualizer} from "@tanstack/vue-virtual";
 import {useMediaQuery} from "@vueuse/core";
-import {type ComponentPublicInstance, computed, nextTick, ref, watch} from "vue";
+import {type ComponentPublicInstance, computed, onUnmounted, ref, watch} from "vue";
 import {useI18n} from "vue-i18n";
 import type {LogRecord, MessageSegment} from "../logTypes";
 import type {ColumnId} from "../viewerConfig";
@@ -31,6 +31,7 @@ const logList = ref<HTMLElement | null>(null);
 const scrollTop = ref(0);
 const enteringKeys = ref(new Set<string>());
 let programmaticScroll = false;
+let followScrollFrame: number | null = null;
 
 const gridTemplate = computed(() => {
   if (compact.value)
@@ -60,10 +61,21 @@ const virtualRows = computed(() => {
       .filter((row): row is { item: typeof row.item; record: LogRecord } => Boolean(row.record));
 });
 
-watch(() => props.records.length, async () => {
-  await nextTick();
+watch(() => props.records.length, () => {
   if (props.follow)
-    scrollToBottom();
+    scheduleFollowScroll();
+});
+
+watch(() => props.follow, (value) => {
+  if (value)
+    scheduleFollowScroll();
+});
+
+onUnmounted(() => {
+  if (followScrollFrame != null) {
+    window.cancelAnimationFrame(followScrollFrame);
+    followScrollFrame = null;
+  }
 });
 
 watch(() => props.appendedRecordKeys, (keys) => {
@@ -88,6 +100,17 @@ function handleScroll() {
     return;
 
   emit("update:follow", isAtBottom());
+}
+
+function scheduleFollowScroll() {
+  if (followScrollFrame != null)
+    return;
+
+  followScrollFrame = window.requestAnimationFrame(() => {
+    followScrollFrame = null;
+    if (props.follow)
+      scrollToBottom();
+  });
 }
 
 function scrollToBottom() {

--- a/components/viewer/src/components/LogList.vue
+++ b/components/viewer/src/components/LogList.vue
@@ -82,6 +82,9 @@ watch(() => props.appendedRecordKeys, (keys) => {
   if (keys.length === 0)
     return;
 
+  if (props.follow)
+    scheduleFollowScroll();
+
   const animatedKeys = keys.length > 80 ? keys.slice(-20) : keys;
   enteringKeys.value = new Set([...enteringKeys.value, ...animatedKeys]);
   window.setTimeout(() => {

--- a/components/viewer/src/composables/useLogViewer.ts
+++ b/components/viewer/src/composables/useLogViewer.ts
@@ -33,6 +33,7 @@ export function useLogViewer() {
     let activeSessionId: string | null = null;
     let events: EventSource | null = null;
     let statusTimer: number | null = null;
+    let recordKeys = new Set<string>();
 
     const api = (path: string) => {
         const join = path.includes("?") ? "&" : "?";
@@ -114,7 +115,7 @@ export function useLogViewer() {
     watch(clearOnNewSession, (value) => saveValue("clearOnNewSession", value ? "1" : "0"));
 
     async function loadHistory() {
-        records.value = await fetchHistory(activeSessionId);
+        replaceRecords(await fetchHistory(activeSessionId));
     }
 
     async function loadStatus() {
@@ -165,8 +166,10 @@ export function useLogViewer() {
         selectedRecord.value = null;
         payloadOpen.value = false;
         clearSelection();
-        if (clearOnNewSession.value)
+        if (clearOnNewSession.value) {
             records.value = [];
+            recordKeys.clear();
+        }
 
         void replaceCurrentSessionHistory(nextSessionId);
     }
@@ -187,7 +190,7 @@ export function useLogViewer() {
             const otherSessionRecords = clearOnNewSession.value
                 ? []
                 : records.value.filter((record) => record.sessionId !== sessionId);
-            records.value = trimRecordList(mergeRecords([...otherSessionRecords, ...history], currentSessionEvents));
+            replaceRecords(mergeRecords([...otherSessionRecords, ...history], currentSessionEvents));
             await nextTick();
         } catch {
             status.value = null;
@@ -200,11 +203,13 @@ export function useLogViewer() {
             sessionId: record.sessionId ?? sessionId ?? undefined
         };
         const key = recordKey(next);
-        if (records.value.some((existing) => recordKey(existing) === key))
+        if (recordKeys.has(key))
             return;
 
+        recordKeys.add(key);
         records.value.push(next);
-        records.value = trimRecordList(records.value);
+        if (records.value.length > 20000)
+            replaceRecords(trimRecordList(records.value));
     }
 
     function mergeRecords(base: LogRecord[], incoming: LogRecord[]) {
@@ -223,6 +228,11 @@ export function useLogViewer() {
 
     function trimRecordList(items: LogRecord[]) {
         return items.length > 20000 ? items.slice(items.length - 20000) : items;
+    }
+
+    function replaceRecords(items: LogRecord[]) {
+        records.value = trimRecordList(items);
+        recordKeys = new Set(records.value.map(recordKey));
     }
 
     function summarize(field: "source") {
@@ -279,6 +289,7 @@ export function useLogViewer() {
 
     function clearView() {
         records.value = [];
+        recordKeys.clear();
         selectedRecord.value = null;
         clearSelection();
     }

--- a/components/viewer/src/composables/useLogViewer.ts
+++ b/components/viewer/src/composables/useLogViewer.ts
@@ -1,4 +1,4 @@
-import {computed, nextTick, onMounted, onUnmounted, ref, watch} from "vue";
+import {computed, nextTick, onMounted, onUnmounted, ref, shallowRef, watch} from "vue";
 import type {ConnectionState, LogRecord, NoiseRule, Status, ThemeMode} from "../logTypes";
 import {type ColumnId, defaultNoiseRules, logLevels, storagePrefix} from "../viewerConfig";
 
@@ -6,7 +6,7 @@ export function useLogViewer() {
     const params = new URLSearchParams(location.search);
     const token = params.get("token") ?? "";
 
-    const records = ref<LogRecord[]>([]);
+    const records = shallowRef<LogRecord[]>([]);
     const status = ref<Status | null>(null);
     const connection = ref<ConnectionState>("connecting");
     const paused = ref(false);
@@ -230,9 +230,16 @@ export function useLogViewer() {
         if (additions.length === 0)
             return;
 
-        records.value.push(...additions);
-        if (records.value.length > 20000)
-            replaceRecords(trimRecordList(records.value));
+        const combined = records.value.concat(additions);
+        if (combined.length <= 20000) {
+            records.value = combined;
+            return;
+        }
+
+        const removed = combined.slice(0, combined.length - 20000);
+        for (const record of removed)
+            recordKeys.delete(recordKey(record));
+        records.value = combined.slice(combined.length - 20000);
     }
 
     function discardPendingRecords() {

--- a/components/viewer/src/composables/useLogViewer.ts
+++ b/components/viewer/src/composables/useLogViewer.ts
@@ -7,6 +7,7 @@ export function useLogViewer() {
     const token = params.get("token") ?? "";
 
     const records = shallowRef<LogRecord[]>([]);
+    const appendedRecordKeys = shallowRef<string[]>([]);
     const status = ref<Status | null>(null);
     const connection = ref<ConnectionState>("connecting");
     const paused = ref(false);
@@ -172,6 +173,7 @@ export function useLogViewer() {
         if (clearOnNewSession.value) {
             discardPendingRecords();
             records.value = [];
+            appendedRecordKeys.value = [];
             recordKeys.clear();
         }
 
@@ -233,6 +235,7 @@ export function useLogViewer() {
         const combined = records.value.concat(additions);
         if (combined.length <= 20000) {
             records.value = combined;
+            appendedRecordKeys.value = additions.map(recordKey);
             return;
         }
 
@@ -240,6 +243,7 @@ export function useLogViewer() {
         for (const record of removed)
             recordKeys.delete(recordKey(record));
         records.value = combined.slice(combined.length - 20000);
+        appendedRecordKeys.value = additions.map(recordKey);
     }
 
     function discardPendingRecords() {
@@ -270,6 +274,7 @@ export function useLogViewer() {
 
     function replaceRecords(items: LogRecord[]) {
         records.value = trimRecordList(items);
+        appendedRecordKeys.value = [];
         recordKeys = new Set(records.value.map(recordKey));
     }
 
@@ -328,6 +333,7 @@ export function useLogViewer() {
     function clearView() {
         discardPendingRecords();
         records.value = [];
+        appendedRecordKeys.value = [];
         recordKeys.clear();
         selectedRecord.value = null;
         clearSelection();
@@ -496,6 +502,7 @@ export function useLogViewer() {
 
     return {
         records,
+        appendedRecordKeys,
         status,
         connection,
         paused,

--- a/components/viewer/src/composables/useLogViewer.ts
+++ b/components/viewer/src/composables/useLogViewer.ts
@@ -208,12 +208,21 @@ export function useLogViewer() {
             ...record,
             sessionId: record.sessionId ?? sessionId ?? undefined
         });
+        if (pendingRecords.length >= 256) {
+            flushPendingRecords();
+            return;
+        }
+
         if (pendingRecordsFrame == null)
             pendingRecordsFrame = window.requestAnimationFrame(flushPendingRecords);
     }
 
     function flushPendingRecords() {
-        pendingRecordsFrame = null;
+        if (pendingRecordsFrame != null) {
+            window.cancelAnimationFrame(pendingRecordsFrame);
+            pendingRecordsFrame = null;
+        }
+
         if (pendingRecords.length === 0)
             return;
 

--- a/components/viewer/src/composables/useLogViewer.ts
+++ b/components/viewer/src/composables/useLogViewer.ts
@@ -34,6 +34,8 @@ export function useLogViewer() {
     let events: EventSource | null = null;
     let statusTimer: number | null = null;
     let recordKeys = new Set<string>();
+    let pendingRecords: LogRecord[] = [];
+    let pendingRecordsFrame: number | null = null;
 
     const api = (path: string) => {
         const join = path.includes("?") ? "&" : "?";
@@ -99,6 +101,7 @@ export function useLogViewer() {
     onUnmounted(() => {
         events?.close();
         events = null;
+        discardPendingRecords();
         if (statusTimer != null) {
             window.clearInterval(statusTimer);
             statusTimer = null;
@@ -144,7 +147,7 @@ export function useLogViewer() {
                 return;
 
             const record = JSON.parse((event as MessageEvent).data) as LogRecord;
-            appendRecord(record, activeSessionId);
+            enqueueRecord(record, activeSessionId);
         });
     }
 
@@ -167,6 +170,7 @@ export function useLogViewer() {
         payloadOpen.value = false;
         clearSelection();
         if (clearOnNewSession.value) {
+            discardPendingRecords();
             records.value = [];
             recordKeys.clear();
         }
@@ -197,19 +201,46 @@ export function useLogViewer() {
         }
     }
 
-    function appendRecord(record: LogRecord, sessionId: string | null) {
-        const next = {
+    function enqueueRecord(record: LogRecord, sessionId: string | null) {
+        pendingRecords.push({
             ...record,
             sessionId: record.sessionId ?? sessionId ?? undefined
-        };
-        const key = recordKey(next);
-        if (recordKeys.has(key))
+        });
+        if (pendingRecordsFrame == null)
+            pendingRecordsFrame = window.requestAnimationFrame(flushPendingRecords);
+    }
+
+    function flushPendingRecords() {
+        pendingRecordsFrame = null;
+        if (pendingRecords.length === 0)
             return;
 
-        recordKeys.add(key);
-        records.value.push(next);
+        const incoming = pendingRecords;
+        pendingRecords = [];
+        const additions: LogRecord[] = [];
+        for (const record of incoming) {
+            const key = recordKey(record);
+            if (recordKeys.has(key))
+                continue;
+
+            recordKeys.add(key);
+            additions.push(record);
+        }
+
+        if (additions.length === 0)
+            return;
+
+        records.value.push(...additions);
         if (records.value.length > 20000)
             replaceRecords(trimRecordList(records.value));
+    }
+
+    function discardPendingRecords() {
+        if (pendingRecordsFrame != null) {
+            window.cancelAnimationFrame(pendingRecordsFrame);
+            pendingRecordsFrame = null;
+        }
+        pendingRecords = [];
     }
 
     function mergeRecords(base: LogRecord[], incoming: LogRecord[]) {
@@ -288,6 +319,7 @@ export function useLogViewer() {
     }
 
     function clearView() {
+        discardPendingRecords();
         records.value = [];
         recordKeys.clear();
         selectedRecord.value = null;


### PR DESCRIPTION
## Summary / 概要

- 优化日志查看器在高频、大批量日志场景下的前端性能。
- 降低单条日志到达时的重复计算、响应式代理和列表更新开销。

## Why / 背景与动机

当日志查看器短时间内收到大量日志（例如超过 1,000 条）时，前端原本会对每条日志重复执行：

- 全量日志过滤；
- 全量统计；
- 全量 record key 扫描；
- 逐条滚动到底部；
- 完整日志对象的深层响应式处理。

这会导致浏览器主线程出现明显卡顿，严重时页面暂时无响应。

虽然日志列表使用了虚拟滚动，但虚拟滚动只能减少 DOM 数量，无法解决上述数据处理成本。

## What changed / 变更点

- 使用 `Set<string>` 维护日志 key，替代数组遍历去重。
- 将 SSE 收到的日志先加入 pending 队列，按 animation frame 批量刷新。
- 当 pending 日志达到 256 条时立即 flush，避免后台标签页暂停 `requestAnimationFrame` 后队列无限增长。
- 将日志记录数组改为 `shallowRef`，避免 Vue 深度代理完整 Payload、Attributes、Resource 和 Scope。
- 使用不可变数组批量更新日志记录。
- 移除日志列表中对全部记录执行 `map + Set` 的 key watcher。
- 由 composable 显式传递当前新增批次的日志 key，用于新增日志动画。
- 将 follow 模式下的滚动请求合并到单个 animation frame。
- 在清空视图、切换会话和组件卸载时清理 pending 队列及待执行任务。

## Test plan / 测试计划

- [x] Build passes
- [x] Basic runtime smoke test

已执行：

- `npm exec vue-tsc -- --noEmit`
- `npm run build`
- `git diff --check`

构建通过。已经在单人和多人模式中测试过高频日志场景，卡顿现象有明显改善。

## Notes / 备注

- 本 PR 仅修改日志查看器前端实现。
- 未修改 mod 侧日志采集、服务端 SSE 协议或日志记录格式。
- 相关优化按独立提交拆分，便于逐项 review 和回退。