### PR TITLE
feat(saves): add conditional raw progress commit bridge

### DIFF
--- a/src/RitsuLibFramework.PatcherSetup.cs
+++ b/src/RitsuLibFramework.PatcherSetup.cs
@@ -38,6 +38,7 @@ using STS2RitsuLib.Relics.Visibility.Patches;
 using STS2RitsuLib.RunData.Patches;
 using STS2RitsuLib.RuntimeInput.Patches;
 using STS2RitsuLib.Saves.Patches;
+using STS2RitsuLib.Saves.RawProgress.Patches;
 using STS2RitsuLib.Scaffolding.Cards.HandGlow.Patches;
 using STS2RitsuLib.Scaffolding.Cards.HandOutline.Patches;
 using STS2RitsuLib.Scaffolding.Characters.Patches;
@@ -168,6 +169,9 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<ProgressStatePreserveUnknownRecordsFromSerializablePatch>();
             patcher.RegisterPatch<ProgressStatePreserveUnknownRecordsToSerializablePatch>();
             patcher.RegisterPatch<ProgressStatePreserveUnknownRecordsLoadProgressPatch>();
+            patcher.RegisterPatch<RawProgressOrdinarySavePatch>();
+            patcher.RegisterPatch<RawProgressLoadPatch>();
+            patcher.RegisterPatch<RawProgressProfileMutationPatch>();
             patcher.RegisterPatch<ModelCloneRegistryPatch>();
             patcher.RegisterPatch<CoreInitializationLifecyclePatch>();
             patcher.RegisterPatch<DevConsoleAutocompleteEnhancementPatch>();

--- a/src/Saves/Patches/ProgressStatePreserveUnknownRecordsPatches.cs
+++ b/src/Saves/Patches/ProgressStatePreserveUnknownRecordsPatches.cs
@@ -2,6 +2,7 @@ using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Managers;
 using MegaCrit.Sts2.Core.Saves.Validation;
 using STS2RitsuLib.Patching.Models;
+using STS2RitsuLib.Saves.RawProgress;
 
 namespace STS2RitsuLib.Saves.Patches
 {
@@ -33,7 +34,8 @@ namespace STS2RitsuLib.Saves.Patches
 
         public static void Prefix(SerializableProgress save, out PreservedProgressRecords? __state)
         {
-            ProgressMirrorStore.MergeMirrorInto(save);
+            if (!RawProgressCommitBridge.IsPreparingCommitProjection)
+                ProgressMirrorStore.MergeMirrorInto(save);
             __state = PreservedProgressRecords.Capture(save);
         }
 
@@ -70,7 +72,8 @@ namespace STS2RitsuLib.Saves.Patches
         public static void Postfix(ProgressState __instance, SerializableProgress __result)
         {
             PreservedProgressRecords.MergeInto(__instance, __result);
-            ProgressMirrorStore.SaveMirror(__result);
+            if (!RawProgressCommitBridge.IsPreparingCommitProjection)
+                ProgressMirrorStore.SaveMirror(__result);
         }
     }
 

--- a/src/Saves/RawProgress/Patches/RawProgressSavePatches.cs
+++ b/src/Saves/RawProgress/Patches/RawProgressSavePatches.cs
@@ -1,0 +1,80 @@
+﻿using MegaCrit.Sts2.Core.Saves;
+using MegaCrit.Sts2.Core.Saves.Managers;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.Saves.RawProgress.Patches
+{
+    internal sealed class RawProgressOrdinarySavePatch : IPatchMethod
+    {
+        public static string PatchId => "raw_progress_exclusive_ordinary_save";
+        public static string Description => "Route ordinary progress saves through the shared exclusive window";
+
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(ProgressSaveManager), nameof(ProgressSaveManager.SaveProgress), Type.EmptyTypes)];
+        }
+
+        public static bool Prefix(ProgressSaveManager __instance)
+        {
+            RawProgressCommitBridge.SaveOrdinaryProgress(__instance);
+            return false;
+        }
+    }
+
+    internal sealed class RawProgressLoadPatch : IPatchMethod
+    {
+        public static string PatchId => "raw_progress_exclusive_load";
+        public static string Description => "Capture and attach the raw progress shadow inside the exclusive window";
+
+        public static ModPatchTarget[] GetTargets()
+        {
+            return [new(typeof(ProgressSaveManager), nameof(ProgressSaveManager.LoadProgress), Type.EmptyTypes)];
+        }
+
+        public static void Prefix(ProgressSaveManager __instance, out RawProgressCommitBridge.LoadCapture? __state)
+        {
+            __state = RawProgressCommitBridge.BeginProgressLoad(__instance);
+        }
+
+        public static void Postfix(
+            ProgressSaveManager __instance,
+            ReadSaveResult<SerializableProgress> __result,
+            RawProgressCommitBridge.LoadCapture? __state)
+        {
+            RawProgressCommitBridge.CompleteProgressLoad(__instance, __result, __state);
+        }
+
+        public static Exception? Finalizer(Exception? __exception)
+        {
+            RawProgressCommitBridge.EndProgressLoad();
+            return __exception;
+        }
+    }
+
+    internal sealed class RawProgressProfileMutationPatch : IPatchMethod
+    {
+        public static string PatchId => "raw_progress_exclusive_profile_mutation";
+        public static string Description => "Keep profile switches and deletion outside raw progress commits";
+
+        public static ModPatchTarget[] GetTargets()
+        {
+            return
+            [
+                new(typeof(SaveManager), nameof(SaveManager.InitProfileId), [typeof(int?)]),
+                new(typeof(SaveManager), nameof(SaveManager.SwitchProfileId), [typeof(int)]),
+                new(typeof(SaveManager), nameof(SaveManager.DeleteProfile), [typeof(int)]),
+            ];
+        }
+
+        public static void Prefix()
+        {
+            RawProgressCommitBridge.EnterProfileMutation();
+        }
+
+        public static Exception? Finalizer(Exception? __exception)
+        {
+            RawProgressCommitBridge.ExitProfileMutation();
+            return __exception;
+        }
+    }
+}

--- a/src/Saves/RawProgress/RawProgressBridgeContracts.cs
+++ b/src/Saves/RawProgress/RawProgressBridgeContracts.cs
@@ -151,11 +151,12 @@
 
         /// <summary>
         ///     <para xml:lang="en">
-        ///         Gets the progress schemas currently accepted by the active game's migration manager. Callers should use
-        ///         the schema returned by the snapshot they intend to replace.
+        ///         Gets the progress schemas currently available for raw-progress operations. The set is empty when no game
+        ///         runtime schema is available. Callers should use the schema returned by the snapshot they intend to replace.
         ///     </para>
         ///     <para xml:lang="zh-CN">
-        ///         获取当前游戏迁移管理器所接受的进度 schema。调用方应使用待替换快照所返回的 schema。
+        ///         获取当前可用于原始进度操作的进度 schema。游戏运行时 schema 不可用时，该集合为空。调用方应使用待替换快照
+        ///         所返回的 schema。
         ///     </para>
         /// </summary>
         public required IReadOnlySet<int> SupportedSchemas { get; init; }
@@ -1033,8 +1034,14 @@
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        ///     <para xml:lang="en">Returns immutable provider capability metadata without reading or changing a profile.</para>
-        ///     <para xml:lang="zh-CN">返回不可变的提供方能力元数据，不读取或改变任何档案。</para>
+        ///     <para xml:lang="en">
+        ///         Returns immutable point-in-time provider metadata without requiring an initialized game runtime or reading
+        ///         or changing a profile. Schema availability may change between calls.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         返回不可变的时点提供方元数据，无需游戏运行时完成初始化，也不会读取或改变任何档案。schema 可用性可能在
+        ///         多次调用之间变化。
+        ///     </para>
         /// </summary>
         /// <returns>
         ///     <para xml:lang="en">The provider descriptor.</para>

--- a/src/Saves/RawProgress/RawProgressBridgeContracts.cs
+++ b/src/Saves/RawProgress/RawProgressBridgeContracts.cs
@@ -103,6 +103,26 @@
         ///     <para xml:lang="zh-CN">可以枚举保留的恢复日志，并有条件地恢复其中的原始文档。</para>
         /// </summary>
         RecoveryJournalManagement = 1 << 14,
+
+        /// <summary>
+        ///     <para xml:lang="en">Recovery journals are scoped by a validated stable owner identifier.</para>
+        ///     <para xml:lang="zh-CN">恢复日志按经过验证的稳定所有者标识进行隔离。</para>
+        /// </summary>
+        RecoveryJournalOwnership = 1 << 15,
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         A caller can explicitly accept a freshly captured destination and discard its matching retained journal.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">调用方可以显式接受新近捕获的目标，并放弃与之匹配的保留日志。</para>
+        /// </summary>
+        RecoveryJournalDisposition = 1 << 16,
+
+        /// <summary>
+        ///     <para xml:lang="en">Invalid recovery files are isolated under bounded provider-owned storage.</para>
+        ///     <para xml:lang="zh-CN">无效恢复文件会被隔离到提供方管理且有界的存储中。</para>
+        /// </summary>
+        InvalidRecoveryJournalQuarantine = 1 << 17,
     }
 
     /// <summary>
@@ -130,8 +150,13 @@
         public required int ProtocolVersion { get; init; }
 
         /// <summary>
-        ///     <para xml:lang="en">Gets the progress schemas accepted by this game-compatibility build.</para>
-        ///     <para xml:lang="zh-CN">获取此游戏兼容构建接受的进度 schema。</para>
+        ///     <para xml:lang="en">
+        ///         Gets the progress schemas currently accepted by the active game's migration manager. Callers should use
+        ///         the schema returned by the snapshot they intend to replace.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取当前游戏迁移管理器所接受的进度 schema。调用方应使用待替换快照所返回的 schema。
+        ///     </para>
         /// </summary>
         public required IReadOnlySet<int> SupportedSchemas { get; init; }
 
@@ -149,14 +174,20 @@
 
         /// <summary>
         ///     <para xml:lang="en">
-        ///         Gets the maximum number of recovery journals retained at once. New commits fail closed when this limit is
-        ///         reached until an existing recovery is resolved.
+        ///         Gets the maximum number of recovery journals retained at once across all owners. New commits fail closed
+        ///         when this limit is reached until an existing recovery is resolved.
         ///     </para>
         ///     <para xml:lang="zh-CN">
-        ///         获取同时保留的恢复日志数量上限。达到该上限后，新的提交会保守失败，直至已有恢复项得到处理。
+        ///         获取所有所有者合计同时保留的恢复日志数量上限。达到该上限后，新的提交会保守失败，直至已有恢复项得到处理。
         ///     </para>
         /// </summary>
         public required int MaxRetainedRecoveryJournals { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the largest accepted UTF-8 owner identifier size in bytes.</para>
+        ///     <para xml:lang="zh-CN">获取允许使用的 UTF-8 所有者标识最大字节数。</para>
+        /// </summary>
+        public required int MaxRecoveryOwnerIdUtf8Bytes { get; init; }
     }
 
     /// <summary>
@@ -349,8 +380,27 @@
         public required int SchemaVersion { get; init; }
 
         /// <summary>
-        ///     <para xml:lang="en">Gets the caller-generated transaction ID used for duplicate suppression and recovery.</para>
-        ///     <para xml:lang="zh-CN">获取调用方生成的事务 ID，用于抑制重复提交和恢复。</para>
+        ///     <para xml:lang="en">
+        ///         Gets the stable caller identifier used to isolate duplicate suppression and recovery journals. It must be
+        ///         non-blank, contain no leading or trailing whitespace, and fit the provider's advertised UTF-8 limit. Use a
+        ///         stable manifest mod ID. This is a cooperative namespace for avoiding accidental cross-mod operations, not
+        ///         an authorization boundary against code running in the same process.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取用于隔离重复提交抑制与恢复日志的稳定调用方标识。该值不得为空，不得包含首尾空白，且必须符合提供方声明的 UTF-8 大小上限。应使用稳定的 manifest 模组 ID。该值用于协作式命名以避免模组间误操作，并非针对同进程代码的授权边界。
+        ///     </para>
+        /// </summary>
+        public required string OwnerId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Gets the caller-generated transaction ID used for duplicate suppression and recovery. It must be unique
+        ///         within <see cref="OwnerId" />. Reuse the same owner and transaction only to replay the identical proposed
+        ///         payload; reusing it with different content is rejected.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取调用方生成的事务 ID，用于抑制重复提交和恢复。该值在 <see cref="OwnerId" /> 内必须唯一；仅可使用相同所有者与事务重试完全相同的拟提交内容，若内容不同则会被拒绝。
+        ///     </para>
         /// </summary>
         public required Guid TransactionId { get; init; }
 
@@ -501,6 +551,12 @@
         RecoveryJournalInvalid,
 
         /// <summary>
+        ///     <para xml:lang="en">The requested recovery journal changed after the caller enumerated it.</para>
+        ///     <para xml:lang="zh-CN">请求的恢复日志在调用方枚举后发生了变化。</para>
+        /// </summary>
+        RecoveryJournalChanged,
+
+        /// <summary>
         ///     <para xml:lang="en">Cancellation was observed before any destination mutation.</para>
         ///     <para xml:lang="zh-CN">在修改任何目标之前收到取消请求。</para>
         /// </summary>
@@ -618,6 +674,23 @@
     public sealed record RawProgressRecoveryRecord
     {
         /// <summary>
+        ///     <para xml:lang="en">Gets the stable owner identifier recorded by the original commit.</para>
+        ///     <para xml:lang="zh-CN">获取原始提交记录的稳定所有者标识。</para>
+        /// </summary>
+        public required string OwnerId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Gets the progress schema of the original document retained by this journal. A journal remains
+        ///         enumerable after the active game's schema changes, but restoration fails closed until its schema matches.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取此日志所保留原始文档的进度 schema。活动游戏的 schema 发生变化后，该日志仍可枚举，但在 schema 匹配前恢复操作会保守失败。
+        ///     </para>
+        /// </summary>
+        public required int SchemaVersion { get; init; }
+
+        /// <summary>
         ///     <para xml:lang="en">Gets the transaction that created the journal.</para>
         ///     <para xml:lang="zh-CN">获取创建该日志的事务。</para>
         /// </summary>
@@ -658,6 +731,15 @@
         ///     <para xml:lang="zh-CN">获取原始提交所提议内容的小写 SHA-256 哈希。</para>
         /// </summary>
         public required string ProposedSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Gets an opaque token for detecting journal changes before restoration or explicit discard. Callers must
+        ///         not parse or derive this value.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">获取用于在恢复或显式放弃前检测日志变化的不透明 token。调用方不得解析或推导该值。</para>
+        /// </summary>
+        public required string RecoveryToken { get; init; }
     }
 
     /// <summary>
@@ -692,6 +774,12 @@
     public sealed record RawProgressRecoveryReadResult
     {
         /// <summary>
+        ///     <para xml:lang="en">Gets the validated owner whose journals were requested.</para>
+        ///     <para xml:lang="zh-CN">获取本次请求恢复日志所对应的已验证所有者。</para>
+        /// </summary>
+        public required string OwnerId { get; init; }
+
+        /// <summary>
         ///     <para xml:lang="en">Gets the enumeration outcome.</para>
         ///     <para xml:lang="zh-CN">获取枚举结果。</para>
         /// </summary>
@@ -704,18 +792,27 @@
         public required IReadOnlyList<RawProgressRecoveryRecord> Records { get; init; }
 
         /// <summary>
-        ///     <para xml:lang="en">Gets the number of journal files ignored because validation failed.</para>
-        ///     <para xml:lang="zh-CN">获取因验证失败而被忽略的日志文件数量。</para>
+        ///     <para xml:lang="en">Gets the number of journal entries ignored because validation failed.</para>
+        ///     <para xml:lang="zh-CN">获取因验证失败而被忽略的日志条目数量。</para>
         /// </summary>
         public required int InvalidEntryCount { get; init; }
     }
 
     /// <summary>
-    ///     <para xml:lang="en">Requests conditional restoration of the original document retained by one journal.</para>
-    ///     <para xml:lang="zh-CN">请求有条件地恢复一个日志中保留的原始文档。</para>
+    ///     <para xml:lang="en">
+    ///         Selects one retained journal for conditional restoration or an explicit decision to accept the current
+    ///         destination and discard the journal.
+    ///     </para>
+    ///     <para xml:lang="zh-CN">选择一个保留日志，以有条件地恢复原始文档，或显式接受当前目标并放弃该日志。</para>
     /// </summary>
     public sealed record RawProgressRecoveryRequest
     {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the stable owner identifier used by the original commit.</para>
+        ///     <para xml:lang="zh-CN">获取原始提交使用的稳定所有者标识。</para>
+        /// </summary>
+        public required string OwnerId { get; init; }
+
         /// <summary>
         ///     <para xml:lang="en">Gets the transaction ID of the retained journal.</para>
         ///     <para xml:lang="zh-CN">获取保留日志的事务 ID。</para>
@@ -723,15 +820,108 @@
         public required Guid TransactionId { get; init; }
 
         /// <summary>
+        ///     <para xml:lang="en">Gets the opaque token returned by the latest recovery enumeration.</para>
+        ///     <para xml:lang="zh-CN">获取最近一次恢复枚举返回的不透明 token。</para>
+        /// </summary>
+        public required string RecoveryToken { get; init; }
+
+        /// <summary>
         ///     <para xml:lang="en">
-        ///         Gets the current destination generation that must still match before restoration. Capture a fresh
-        ///         snapshot after receiving a recovery-required result; do not reuse the generation from the original commit.
+        ///         Gets the current destination generation that must still match before restoration or discard. Capture a
+        ///         fresh snapshot after receiving a recovery-required result; do not reuse the generation from the original
+        ///         commit.
         ///     </para>
         ///     <para xml:lang="zh-CN">
-        ///         获取恢复前必须仍然匹配的当前目标代次。收到需要恢复的结果后应重新捕获快照，不要复用原始提交中的代次。
+        ///         获取恢复或放弃前必须仍然匹配的当前目标代次。收到需要恢复的结果后应重新捕获快照，不要复用原始提交中的代次。
         ///     </para>
         /// </summary>
         public required ProgressGeneration ExpectedGeneration { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Reports the result of explicitly discarding one retained recovery journal.</para>
+    ///     <para xml:lang="zh-CN">报告显式放弃一个保留恢复日志的结果。</para>
+    /// </summary>
+    public enum RawProgressRecoveryDiscardOutcome
+    {
+        /// <summary>
+        ///     <para xml:lang="en">The destination still matched and the journal was removed completely.</para>
+        ///     <para xml:lang="zh-CN">目标仍然匹配，且日志已被完整移除。</para>
+        /// </summary>
+        Discarded,
+
+        /// <summary>
+        ///     <para xml:lang="en">The request owner, transaction, token, or generation was malformed.</para>
+        ///     <para xml:lang="zh-CN">请求中的所有者、事务、token 或代次格式错误。</para>
+        /// </summary>
+        ValidationFailed,
+
+        /// <summary>
+        ///     <para xml:lang="en">No journal exists for the requested owner and transaction.</para>
+        ///     <para xml:lang="zh-CN">请求的所有者与事务不存在对应日志。</para>
+        /// </summary>
+        RecoveryJournalNotFound,
+
+        /// <summary>
+        ///     <para xml:lang="en">The journal is malformed or failed integrity validation.</para>
+        ///     <para xml:lang="zh-CN">日志格式错误或未通过完整性验证。</para>
+        /// </summary>
+        RecoveryJournalInvalid,
+
+        /// <summary>
+        ///     <para xml:lang="en">The journal changed after the caller enumerated it.</para>
+        ///     <para xml:lang="zh-CN">日志在调用方枚举后发生了变化。</para>
+        /// </summary>
+        RecoveryJournalChanged,
+
+        /// <summary>
+        ///     <para xml:lang="en">The active profile or modded save namespace changed.</para>
+        ///     <para xml:lang="zh-CN">活动档案或模组存档命名空间已改变。</para>
+        /// </summary>
+        ActiveProfileChanged,
+
+        /// <summary>
+        ///     <para xml:lang="en">The active destination no longer matches the freshly captured generation.</para>
+        ///     <para xml:lang="zh-CN">活动目标不再匹配新近捕获的代次。</para>
+        /// </summary>
+        GenerationConflict,
+
+        /// <summary>
+        ///     <para xml:lang="en">The destination could not be captured and validated for the discard decision.</para>
+        ///     <para xml:lang="zh-CN">无法为本次放弃决定捕获并验证目标。</para>
+        /// </summary>
+        DestinationUnavailable,
+
+        /// <summary>
+        ///     <para xml:lang="en">Cancellation was observed before the journal could be removed.</para>
+        ///     <para xml:lang="zh-CN">在日志开始移除前收到了取消请求。</para>
+        /// </summary>
+        Cancelled,
+
+        /// <summary>
+        ///     <para xml:lang="en">At least one journal file could not be removed.</para>
+        ///     <para xml:lang="zh-CN">至少有一个日志文件无法移除。</para>
+        /// </summary>
+        StorageFailure,
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Contains the outcome and retained-state evidence for an explicit recovery discard.</para>
+    ///     <para xml:lang="zh-CN">包含显式放弃恢复日志的结果及其保留状态证据。</para>
+    /// </summary>
+    public sealed record RawProgressRecoveryDiscardResult
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the discard outcome.</para>
+        ///     <para xml:lang="zh-CN">获取放弃结果。</para>
+        /// </summary>
+        public required RawProgressRecoveryDiscardOutcome Outcome { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether any recoverable copy of the requested journal remains.</para>
+        ///     <para xml:lang="zh-CN">获取请求日志是否仍保留任何可恢复副本。</para>
+        /// </summary>
+        public required bool RecoveryJournalRetained { get; init; }
     }
 
     /// <summary>
@@ -745,13 +935,18 @@
     {
         /// <summary>
         ///     <para xml:lang="en">
-        ///         Enumerates validated local recovery journals without exposing or changing their saved documents. Invalid
-        ///         entries are counted and ignored rather than returned as trusted recovery data.
+        ///         Enumerates validated local recovery journals belonging to one stable owner without exposing or changing
+        ///         their saved documents. Invalid entries in that owner scope are counted and ignored rather than returned as
+        ///         trusted recovery data.
         ///     </para>
         ///     <para xml:lang="zh-CN">
-        ///         枚举已验证的本地恢复日志，但不公开或改变其中保存的文档。无效条目会被计数并忽略，不会作为可信恢复数据返回。
+        ///         枚举属于一个稳定所有者的已验证本地恢复日志，但不公开或改变其中保存的文档。该所有者范围内的无效条目会被计数并忽略，不会作为可信恢复数据返回。
         ///     </para>
         /// </summary>
+        /// <param name="ownerId">
+        ///     <para xml:lang="en">The stable owner identifier used by commit requests.</para>
+        ///     <para xml:lang="zh-CN">提交请求所使用的稳定所有者标识。</para>
+        /// </param>
         /// <param name="cancellationToken">
         ///     <para xml:lang="en">Cancellation observed before enumeration completes.</para>
         ///     <para xml:lang="zh-CN">在枚举完成前接受的取消信号。</para>
@@ -764,7 +959,12 @@
         ///     <para xml:lang="en">The operation was cancelled before enumeration completed.</para>
         ///     <para xml:lang="zh-CN">操作在枚举完成前被取消。</para>
         /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <para xml:lang="en"><paramref name="ownerId" /> does not satisfy the advertised owner-ID limits.</para>
+        ///     <para xml:lang="zh-CN"><paramref name="ownerId" /> 不符合提供方声明的所有者标识限制。</para>
+        /// </exception>
         ValueTask<RawProgressRecoveryReadResult> GetPendingRecoveriesAsync(
+            string ownerId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -799,6 +999,36 @@
         ///     <para xml:lang="zh-CN"><paramref name="request" /> 为 <see langword="null" />。</para>
         /// </exception>
         ValueTask<RawProgressCommitResult> RestoreRecoveryAsync(
+            RawProgressRecoveryRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Explicitly accepts the current destination and removes a matching retained journal without changing
+        ///         progress data. The owner, opaque token, active profile, and freshly captured destination generation must
+        ///         still match inside the exclusive window. No journal is removed on a mismatch.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         显式接受当前目标，并在不改变进度数据的情况下移除匹配的保留日志。所有者、不透明 token、活动档案及新近捕获的目标代次必须在独占窗口内仍然匹配；任何不匹配都不会移除日志。
+        ///     </para>
+        /// </summary>
+        /// <param name="request">
+        ///     <para xml:lang="en">The latest enumerated journal identity and freshly captured destination generation.</para>
+        ///     <para xml:lang="zh-CN">最近枚举得到的日志身份及新近捕获的目标代次。</para>
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     <para xml:lang="en">Cancellation observed only before journal removal begins.</para>
+        ///     <para xml:lang="zh-CN">仅在日志开始移除前接受的取消信号。</para>
+        /// </param>
+        /// <returns>
+        ///     <para xml:lang="en">The discard outcome and whether a recoverable journal remains.</para>
+        ///     <para xml:lang="zh-CN">放弃结果及是否仍保留可恢复日志。</para>
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <para xml:lang="en"><paramref name="request" /> is <see langword="null" />.</para>
+        ///     <para xml:lang="zh-CN"><paramref name="request" /> 为 <see langword="null" />。</para>
+        /// </exception>
+        ValueTask<RawProgressRecoveryDiscardResult> DiscardRecoveryAsync(
             RawProgressRecoveryRequest request,
             CancellationToken cancellationToken = default);
 
@@ -876,6 +1106,6 @@
         ///     <para xml:lang="en">Gets the shared provider instance.</para>
         ///     <para xml:lang="zh-CN">获取共享的提供方实例。</para>
         /// </summary>
-        public static IRawProgressCommitBridge Instance { get; } = RawProgressCommitBridge.Instance;
+        public static IRawProgressCommitBridge Instance => RawProgressCommitBridge.Instance;
     }
 }

--- a/src/Saves/RawProgress/RawProgressBridgeContracts.cs
+++ b/src/Saves/RawProgress/RawProgressBridgeContracts.cs
@@ -80,8 +80,13 @@
         LiveProgressStateSynchronization = 1 << 11,
 
         /// <summary>
-        ///     <para xml:lang="en">Later ordinary saves retain unknown JSON properties when they can be matched safely.</para>
-        ///     <para xml:lang="zh-CN">后续普通保存会在能够安全匹配时保留未知 JSON 属性。</para>
+        ///     <para xml:lang="en">
+        ///         Later ordinary saves retain unknown JSON properties when they can be matched safely and abort the save if
+        ///         an installed preservation state cannot be applied without loss.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         后续普通保存会在能够安全匹配时保留未知 JSON 属性；若已安装的保留状态无法无损应用，则中止该次保存。
+        ///     </para>
         /// </summary>
         SubsequentSaveUnknownJsonPreservation = 1 << 12,
 
@@ -90,6 +95,14 @@
         ///     <para xml:lang="zh-CN">提供方可以捕获活动原始文档及其本地与云端代次。</para>
         /// </summary>
         ActiveProgressSnapshot = 1 << 13,
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Retained recovery journals can be enumerated and their original document can be restored conditionally.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">可以枚举保留的恢复日志，并有条件地恢复其中的原始文档。</para>
+        /// </summary>
+        RecoveryJournalManagement = 1 << 14,
     }
 
     /// <summary>
@@ -133,6 +146,17 @@
         ///     <para xml:lang="zh-CN">获取允许提交的 UTF-8 文档最大字节数。</para>
         /// </summary>
         public required long MaxDocumentUtf8Bytes { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Gets the maximum number of recovery journals retained at once. New commits fail closed when this limit is
+        ///         reached until an existing recovery is resolved.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取同时保留的恢复日志数量上限。达到该上限后，新的提交会保守失败，直至已有恢复项得到处理。
+        ///     </para>
+        /// </summary>
+        public required int MaxRetainedRecoveryJournals { get; init; }
     }
 
     /// <summary>
@@ -184,8 +208,13 @@
         public required bool CloudAvailable { get; init; }
 
         /// <summary>
-        ///     <para xml:lang="en">Gets whether the user enabled cloud synchronization.</para>
-        ///     <para xml:lang="zh-CN">获取用户是否启用了云同步。</para>
+        ///     <para xml:lang="en">
+        ///         Gets whether the user allows the cloud copy to be synchronized back to this machine. The game still
+        ///         writes local saves to an available cloud backend when this is false.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取用户是否允许将云端副本同步回本机。即使此值为 false，只要云端后端可用，游戏仍会将本地存档写入云端。
+        ///     </para>
         /// </summary>
         public required bool CloudSyncEnabled { get; init; }
 
@@ -460,6 +489,18 @@
         RecoveryRequired,
 
         /// <summary>
+        ///     <para xml:lang="en">The requested recovery journal no longer exists.</para>
+        ///     <para xml:lang="zh-CN">请求的恢复日志已不存在。</para>
+        /// </summary>
+        RecoveryJournalNotFound,
+
+        /// <summary>
+        ///     <para xml:lang="en">The requested recovery journal is malformed or failed integrity validation.</para>
+        ///     <para xml:lang="zh-CN">请求的恢复日志格式错误或未通过完整性验证。</para>
+        /// </summary>
+        RecoveryJournalInvalid,
+
+        /// <summary>
         ///     <para xml:lang="en">Cancellation was observed before any destination mutation.</para>
         ///     <para xml:lang="zh-CN">在修改任何目标之前收到取消请求。</para>
         /// </summary>
@@ -540,13 +581,227 @@
     }
 
     /// <summary>
+    ///     <para xml:lang="en">Identifies the last durable stage recorded for a retained recovery journal.</para>
+    ///     <para xml:lang="zh-CN">标识保留恢复日志中最后持久记录的阶段。</para>
+    /// </summary>
+    public enum RawProgressRecoveryStage
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Recovery data was prepared before the destination write began.</para>
+        ///     <para xml:lang="zh-CN">恢复数据已在目标写入开始前准备完成。</para>
+        /// </summary>
+        Prepared,
+
+        /// <summary>
+        ///     <para xml:lang="en">The destination may have changed, but its local content could not be verified.</para>
+        ///     <para xml:lang="zh-CN">目标可能已经改变，但无法验证其本地内容。</para>
+        /// </summary>
+        LocalUnverified,
+
+        /// <summary>
+        ///     <para xml:lang="en">The new local content was verified, but remaining verification was not finalized.</para>
+        ///     <para xml:lang="zh-CN">新的本地内容已经验证，但其余验证尚未完成。</para>
+        /// </summary>
+        LocalVerified,
+
+        /// <summary>
+        ///     <para xml:lang="en">At least one post-write verification step remained incomplete.</para>
+        ///     <para xml:lang="zh-CN">至少有一项写入后验证未完成。</para>
+        /// </summary>
+        VerificationIncomplete,
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Describes one validated local recovery journal without exposing its saved document.</para>
+    ///     <para xml:lang="zh-CN">描述一个已验证的本地恢复日志，但不公开其中保存的文档。</para>
+    /// </summary>
+    public sealed record RawProgressRecoveryRecord
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the transaction that created the journal.</para>
+        ///     <para xml:lang="zh-CN">获取创建该日志的事务。</para>
+        /// </summary>
+        public required Guid TransactionId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the profile ID recorded before the original commit.</para>
+        ///     <para xml:lang="zh-CN">获取原始提交前记录的档案 ID。</para>
+        /// </summary>
+        public required int ProfileId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether the journal belongs to the modded save namespace.</para>
+        ///     <para xml:lang="zh-CN">获取该日志是否属于模组存档命名空间。</para>
+        /// </summary>
+        public required bool IsModded { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the stable unique ID of the progress document.</para>
+        ///     <para xml:lang="zh-CN">获取进度文档的稳定唯一 ID。</para>
+        /// </summary>
+        public required string ProgressUniqueId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the journal's last durable stage.</para>
+        ///     <para xml:lang="zh-CN">获取日志最后持久记录的阶段。</para>
+        /// </summary>
+        public required RawProgressRecoveryStage Stage { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the lowercase SHA-256 hash of the recoverable original document.</para>
+        ///     <para xml:lang="zh-CN">获取可恢复原始文档的小写 SHA-256 哈希。</para>
+        /// </summary>
+        public required string OriginalSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the lowercase SHA-256 hash proposed by the original commit.</para>
+        ///     <para xml:lang="zh-CN">获取原始提交所提议内容的小写 SHA-256 哈希。</para>
+        /// </summary>
+        public required string ProposedSha256 { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Reports whether retained recovery journals were enumerated completely.</para>
+    ///     <para xml:lang="zh-CN">报告是否完整枚举了保留的恢复日志。</para>
+    /// </summary>
+    public enum RawProgressRecoveryReadOutcome
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Every retained journal was read and validated.</para>
+        ///     <para xml:lang="zh-CN">所有保留日志均已读取并验证。</para>
+        /// </summary>
+        Succeeded,
+
+        /// <summary>
+        ///     <para xml:lang="en">Valid journals are returned, but one or more malformed entries were ignored.</para>
+        ///     <para xml:lang="zh-CN">返回有效日志，但忽略了一个或多个格式错误的条目。</para>
+        /// </summary>
+        InvalidEntriesIgnored,
+
+        /// <summary>
+        ///     <para xml:lang="en">The local recovery directory could not be inspected.</para>
+        ///     <para xml:lang="zh-CN">无法检查本地恢复目录。</para>
+        /// </summary>
+        StorageUnavailable,
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Contains a snapshot of validated retained recovery journals.</para>
+    ///     <para xml:lang="zh-CN">包含已验证保留恢复日志的快照。</para>
+    /// </summary>
+    public sealed record RawProgressRecoveryReadResult
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the enumeration outcome.</para>
+        ///     <para xml:lang="zh-CN">获取枚举结果。</para>
+        /// </summary>
+        public required RawProgressRecoveryReadOutcome Outcome { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets validated journals ordered by transaction ID.</para>
+        ///     <para xml:lang="zh-CN">获取按事务 ID 排序的已验证日志。</para>
+        /// </summary>
+        public required IReadOnlyList<RawProgressRecoveryRecord> Records { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the number of journal files ignored because validation failed.</para>
+        ///     <para xml:lang="zh-CN">获取因验证失败而被忽略的日志文件数量。</para>
+        /// </summary>
+        public required int InvalidEntryCount { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Requests conditional restoration of the original document retained by one journal.</para>
+    ///     <para xml:lang="zh-CN">请求有条件地恢复一个日志中保留的原始文档。</para>
+    /// </summary>
+    public sealed record RawProgressRecoveryRequest
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the transaction ID of the retained journal.</para>
+        ///     <para xml:lang="zh-CN">获取保留日志的事务 ID。</para>
+        /// </summary>
+        public required Guid TransactionId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Gets the current destination generation that must still match before restoration. Capture a fresh
+        ///         snapshot after receiving a recovery-required result; do not reuse the generation from the original commit.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取恢复前必须仍然匹配的当前目标代次。收到需要恢复的结果后应重新捕获快照，不要复用原始提交中的代次。
+        ///     </para>
+        /// </summary>
+        public required ProgressGeneration ExpectedGeneration { get; init; }
+    }
+
+    /// <summary>
     ///     <para xml:lang="en">
-    ///         Provides fail-closed capture and conditional commit operations for the active progress document.
+    ///         Provides fail-closed capture, conditional commit, and bounded recovery operations for the active progress
+    ///         document.
     ///     </para>
-    ///     <para xml:lang="zh-CN">为活动进度文档提供保守失败的捕获与条件提交操作。</para>
+    ///     <para xml:lang="zh-CN">为活动进度文档提供保守失败的捕获、条件提交与有界恢复操作。</para>
     /// </summary>
     public interface IRawProgressCommitBridge
     {
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Enumerates validated local recovery journals without exposing or changing their saved documents. Invalid
+        ///         entries are counted and ignored rather than returned as trusted recovery data.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         枚举已验证的本地恢复日志，但不公开或改变其中保存的文档。无效条目会被计数并忽略，不会作为可信恢复数据返回。
+        ///     </para>
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     <para xml:lang="en">Cancellation observed before enumeration completes.</para>
+        ///     <para xml:lang="zh-CN">在枚举完成前接受的取消信号。</para>
+        /// </param>
+        /// <returns>
+        ///     <para xml:lang="en">The recovery-journal snapshot and its validation outcome.</para>
+        ///     <para xml:lang="zh-CN">恢复日志快照及其验证结果。</para>
+        /// </returns>
+        /// <exception cref="OperationCanceledException">
+        ///     <para xml:lang="en">The operation was cancelled before enumeration completed.</para>
+        ///     <para xml:lang="zh-CN">操作在枚举完成前被取消。</para>
+        /// </exception>
+        ValueTask<RawProgressRecoveryReadResult> GetPendingRecoveriesAsync(
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Restores a journal's validated original document only when the active profile and freshly captured
+        ///         destination generation still match. The same local, cloud, live-state, and preservation verification used
+        ///         by a normal raw commit applies. The journal is removed only after a fully verified restoration.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         仅当活动档案与新近捕获的目标代次仍然匹配时，恢复日志中已验证的原始文档。恢复会执行与普通原始提交相同的本地、云端、内存状态和保留机制验证，且仅在恢复得到完整验证后删除日志。
+        ///     </para>
+        /// </summary>
+        /// <param name="request">
+        ///     <para xml:lang="en">The journal identity and current destination generation.</para>
+        ///     <para xml:lang="zh-CN">日志身份与当前目标代次。</para>
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     <para xml:lang="en">Cancellation observed only before destination mutation begins.</para>
+        ///     <para xml:lang="zh-CN">仅在目标修改开始前接受的取消信号。</para>
+        /// </param>
+        /// <returns>
+        ///     <para xml:lang="en">
+        ///         Structured verification evidence. <see cref="RawProgressCommitOutcome.CommittedVerified" /> means the
+        ///         original document was restored and the journal was removed.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         结构化验证证据。<see cref="RawProgressCommitOutcome.CommittedVerified" /> 表示原始文档已恢复且日志已删除。
+        ///     </para>
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <para xml:lang="en"><paramref name="request" /> is <see langword="null" />.</para>
+        ///     <para xml:lang="zh-CN"><paramref name="request" /> 为 <see langword="null" />。</para>
+        /// </exception>
+        ValueTask<RawProgressCommitResult> RestoreRecoveryAsync(
+            RawProgressRecoveryRequest request,
+            CancellationToken cancellationToken = default);
+
         /// <summary>
         ///     <para xml:lang="en">Returns immutable provider capability metadata without reading or changing a profile.</para>
         ///     <para xml:lang="zh-CN">返回不可变的提供方能力元数据，不读取或改变任何档案。</para>

--- a/src/Saves/RawProgress/RawProgressBridgeContracts.cs
+++ b/src/Saves/RawProgress/RawProgressBridgeContracts.cs
@@ -1,0 +1,626 @@
+﻿namespace STS2RitsuLib.Saves.RawProgress
+{
+    /// <summary>
+    ///     <para xml:lang="en">Describes independently negotiable capabilities of the raw-progress bridge.</para>
+    ///     <para xml:lang="zh-CN">描述原始进度桥接器中可独立协商的能力。</para>
+    /// </summary>
+    [Flags]
+    public enum RawProgressBridgeFeature
+    {
+        /// <summary>
+        ///     <para xml:lang="en">The provider accepts complete progress documents using schema 21.</para>
+        ///     <para xml:lang="zh-CN">提供方接受使用 schema 21 的完整进度文档。</para>
+        /// </summary>
+        RawSchema21Document = 1 << 0,
+
+        /// <summary>
+        ///     <para xml:lang="en">A validated raw document is committed without a lossy typed reserialization.</para>
+        ///     <para xml:lang="zh-CN">提交已验证的原始文档时不会经过有损的强类型重新序列化。</para>
+        /// </summary>
+        UnknownJsonPassThrough = 1 << 1,
+
+        /// <summary>
+        ///     <para xml:lang="en">Commits use the save store owned by the running game.</para>
+        ///     <para xml:lang="zh-CN">提交使用当前游戏实例持有的存档存储。</para>
+        /// </summary>
+        LiveGameStoreCommit = 1 << 2,
+
+        /// <summary>
+        ///     <para xml:lang="en">Local replacement uses the game's backup, temporary-file, flush, and rename path.</para>
+        ///     <para xml:lang="zh-CN">本地替换使用游戏的备份、临时文件、刷新和重命名流程。</para>
+        /// </summary>
+        DurableLocalReplacement = 1 << 3,
+
+        /// <summary>
+        ///     <para xml:lang="en">Cloud-backed commits participate in the game's save-batch scope.</para>
+        ///     <para xml:lang="zh-CN">使用云存档的提交会加入游戏的存档批处理作用域。</para>
+        /// </summary>
+        CloudSaveBatch = 1 << 4,
+
+        /// <summary>
+        ///     <para xml:lang="en">The destination generation is compared again inside the exclusive window.</para>
+        ///     <para xml:lang="zh-CN">目标代次会在独占窗口内再次进行比较。</para>
+        /// </summary>
+        ConditionalGenerationCheck = 1 << 5,
+
+        /// <summary>
+        ///     <para xml:lang="en">Ordinary in-process progress saves share the commit's exclusive window.</para>
+        ///     <para xml:lang="zh-CN">进程内的普通进度保存与提交共享同一独占窗口。</para>
+        /// </summary>
+        ExclusiveSaveWindow = 1 << 6,
+
+        /// <summary>
+        ///     <para xml:lang="en">Recovery metadata is stored locally outside cloud-managed profile data.</para>
+        ///     <para xml:lang="zh-CN">恢复元数据仅保存在本地，并位于云端管理的档案数据之外。</para>
+        /// </summary>
+        LocalOnlyRecoveryJournal = 1 << 7,
+
+        /// <summary>
+        ///     <para xml:lang="en">Partial and indeterminate states are returned as structured outcomes.</para>
+        ///     <para xml:lang="zh-CN">部分成功和不确定状态会以结构化结果返回。</para>
+        /// </summary>
+        StructuredRecoveryOutcome = 1 << 8,
+
+        /// <summary>
+        ///     <para xml:lang="en">The capability is exposed through a documented public contract.</para>
+        ///     <para xml:lang="zh-CN">该能力通过有文档说明的公共契约公开。</para>
+        /// </summary>
+        StablePublicContract = 1 << 9,
+
+        /// <summary>
+        ///     <para xml:lang="en">Cloud writes are checked by reading the cloud backend directly.</para>
+        ///     <para xml:lang="zh-CN">云端写入会通过直接读取云端后端进行检查。</para>
+        /// </summary>
+        CloudReadBackVerification = 1 << 10,
+
+        /// <summary>
+        ///     <para xml:lang="en">The live progress state is replaced with the validated committed projection.</para>
+        ///     <para xml:lang="zh-CN">内存中的进度状态会替换为已经验证的提交投影。</para>
+        /// </summary>
+        LiveProgressStateSynchronization = 1 << 11,
+
+        /// <summary>
+        ///     <para xml:lang="en">Later ordinary saves retain unknown JSON properties when they can be matched safely.</para>
+        ///     <para xml:lang="zh-CN">后续普通保存会在能够安全匹配时保留未知 JSON 属性。</para>
+        /// </summary>
+        SubsequentSaveUnknownJsonPreservation = 1 << 12,
+
+        /// <summary>
+        ///     <para xml:lang="en">The provider can capture the active raw document and its local and cloud generation.</para>
+        ///     <para xml:lang="zh-CN">提供方可以捕获活动原始文档及其本地与云端代次。</para>
+        /// </summary>
+        ActiveProgressSnapshot = 1 << 13,
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Describes a raw-progress bridge provider and the contract it currently supports.</para>
+    ///     <para xml:lang="zh-CN">描述原始进度桥接提供方及其当前支持的契约。</para>
+    /// </summary>
+    public sealed record RawProgressBridgeDescriptor
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the stable provider identifier.</para>
+        ///     <para xml:lang="zh-CN">获取稳定的提供方标识符。</para>
+        /// </summary>
+        public required string ProviderId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the provider package version.</para>
+        ///     <para xml:lang="zh-CN">获取提供方包版本。</para>
+        /// </summary>
+        public required Version ProviderVersion { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the exact request and result protocol version.</para>
+        ///     <para xml:lang="zh-CN">获取请求和结果使用的精确协议版本。</para>
+        /// </summary>
+        public required int ProtocolVersion { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the progress schemas accepted by this game-compatibility build.</para>
+        ///     <para xml:lang="zh-CN">获取此游戏兼容构建接受的进度 schema。</para>
+        /// </summary>
+        public required IReadOnlySet<int> SupportedSchemas { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the advertised capabilities.</para>
+        ///     <para xml:lang="zh-CN">获取声明的能力集合。</para>
+        /// </summary>
+        public required RawProgressBridgeFeature Features { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the largest accepted UTF-8 document size in bytes.</para>
+        ///     <para xml:lang="zh-CN">获取允许提交的 UTF-8 文档最大字节数。</para>
+        /// </summary>
+        public required long MaxDocumentUtf8Bytes { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Identifies one observed version of the active progress destination.</para>
+    ///     <para xml:lang="zh-CN">标识活动进度目标的一次已观测版本。</para>
+    /// </summary>
+    public sealed record ProgressGeneration
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the active profile ID.</para>
+        ///     <para xml:lang="zh-CN">获取活动档案 ID。</para>
+        /// </summary>
+        public required int ProfileId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether the observed destination is the modded save namespace.</para>
+        ///     <para xml:lang="zh-CN">获取观测目标是否属于模组存档命名空间。</para>
+        /// </summary>
+        public required bool IsModded { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the progress document's stable unique ID.</para>
+        ///     <para xml:lang="zh-CN">获取进度文档的稳定唯一 ID。</para>
+        /// </summary>
+        public required string ProgressUniqueId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the lowercase SHA-256 hash of the local UTF-8 content.</para>
+        ///     <para xml:lang="zh-CN">获取本地 UTF-8 内容的小写 SHA-256 哈希。</para>
+        /// </summary>
+        public required string LocalSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the local UTF-8 content length.</para>
+        ///     <para xml:lang="zh-CN">获取本地 UTF-8 内容长度。</para>
+        /// </summary>
+        public required long LocalLength { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the observed local last-modified time in UTC ticks.</para>
+        ///     <para xml:lang="zh-CN">获取观测到的本地最后修改时间（UTC ticks）。</para>
+        /// </summary>
+        public required long LocalLastModifiedUtcTicks { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether the running game owns a cloud save backend.</para>
+        ///     <para xml:lang="zh-CN">获取当前游戏是否持有云存档后端。</para>
+        /// </summary>
+        public required bool CloudAvailable { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether the user enabled cloud synchronization.</para>
+        ///     <para xml:lang="zh-CN">获取用户是否启用了云同步。</para>
+        /// </summary>
+        public required bool CloudSyncEnabled { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether the progress file was persisted by the cloud backend.</para>
+        ///     <para xml:lang="zh-CN">获取进度文件是否已由云端后端持久化。</para>
+        /// </summary>
+        public required bool CloudPersisted { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the cloud content hash when a persisted remote file was read.</para>
+        ///     <para xml:lang="zh-CN">获取已持久化远端文件成功读回时的内容哈希。</para>
+        /// </summary>
+        public string? CloudSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the cloud UTF-8 content length when available.</para>
+        ///     <para xml:lang="zh-CN">获取可用时的云端 UTF-8 内容长度。</para>
+        /// </summary>
+        public long? CloudLength { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the observed cloud last-modified time in UTC ticks when available.</para>
+        ///     <para xml:lang="zh-CN">获取可用时观测到的云端最后修改时间（UTC ticks）。</para>
+        /// </summary>
+        public long? CloudLastModifiedUtcTicks { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Contains the active raw progress document and the generation captured with it.</para>
+    ///     <para xml:lang="zh-CN">包含活动原始进度文档及与其同时捕获的代次。</para>
+    /// </summary>
+    public sealed record RawProgressSnapshot
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the progress schema found in <see cref="RawJson" />.</para>
+        ///     <para xml:lang="zh-CN">获取 <see cref="RawJson" /> 中的进度 schema。</para>
+        /// </summary>
+        public required int SchemaVersion { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the complete raw progress JSON.</para>
+        ///     <para xml:lang="zh-CN">获取完整的原始进度 JSON。</para>
+        /// </summary>
+        public required string RawJson { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the destination generation captured in the same exclusive window.</para>
+        ///     <para xml:lang="zh-CN">获取在同一独占窗口内捕获的目标代次。</para>
+        /// </summary>
+        public required ProgressGeneration Generation { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Reports the outcome of capturing the active progress document.</para>
+    ///     <para xml:lang="zh-CN">报告捕获活动进度文档的结果。</para>
+    /// </summary>
+    public enum RawProgressReadOutcome
+    {
+        /// <summary>
+        ///     <para xml:lang="en">The snapshot was captured and validated.</para>
+        ///     <para xml:lang="zh-CN">快照已捕获并通过验证。</para>
+        /// </summary>
+        Succeeded,
+
+        /// <summary>
+        ///     <para xml:lang="en">The game has not initialized an active profile.</para>
+        ///     <para xml:lang="zh-CN">游戏尚未初始化活动档案。</para>
+        /// </summary>
+        ActiveProfileUnavailable,
+
+        /// <summary>
+        ///     <para xml:lang="en">The active local progress file does not exist or could not be read.</para>
+        ///     <para xml:lang="zh-CN">活动本地进度文件不存在或无法读取。</para>
+        /// </summary>
+        LocalReadUnavailable,
+
+        /// <summary>
+        ///     <para xml:lang="en">The active document is malformed, oversized, or lacks a stable identity.</para>
+        ///     <para xml:lang="zh-CN">活动文档格式错误、尺寸过大或缺少稳定身份。</para>
+        /// </summary>
+        ValidationFailed,
+
+        /// <summary>
+        ///     <para xml:lang="en">The active document uses a schema this provider build does not accept.</para>
+        ///     <para xml:lang="zh-CN">活动文档使用了此提供方构建不接受的 schema。</para>
+        /// </summary>
+        SchemaUnsupported,
+
+        /// <summary>
+        ///     <para xml:lang="en">A persisted cloud copy exists but could not be read completely.</para>
+        ///     <para xml:lang="zh-CN">已存在持久化云端副本，但无法完整读回。</para>
+        /// </summary>
+        CloudReadUnavailable,
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Returns either a validated snapshot or a fail-closed read outcome.</para>
+    ///     <para xml:lang="zh-CN">返回已验证快照，或一个保守失败的读取结果。</para>
+    /// </summary>
+    public sealed record RawProgressReadResult
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the read outcome.</para>
+        ///     <para xml:lang="zh-CN">获取读取结果。</para>
+        /// </summary>
+        public required RawProgressReadOutcome Outcome { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the snapshot only when <see cref="Outcome" /> is <see cref="RawProgressReadOutcome.Succeeded" />.</para>
+        ///     <para xml:lang="zh-CN">仅当 <see cref="Outcome" /> 为 <see cref="RawProgressReadOutcome.Succeeded" /> 时获取快照。</para>
+        /// </summary>
+        public RawProgressSnapshot? Snapshot { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Requests one conditional replacement of the active raw progress document.</para>
+    ///     <para xml:lang="zh-CN">请求对活动原始进度文档执行一次条件替换。</para>
+    /// </summary>
+    public sealed record RawProgressCommitRequest
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the exact protocol version expected by the caller.</para>
+        ///     <para xml:lang="zh-CN">获取调用方要求的精确协议版本。</para>
+        /// </summary>
+        public required int ProtocolVersion { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the schema declared by the proposed document.</para>
+        ///     <para xml:lang="zh-CN">获取拟提交文档声明的 schema。</para>
+        /// </summary>
+        public required int SchemaVersion { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the caller-generated transaction ID used for duplicate suppression and recovery.</para>
+        ///     <para xml:lang="zh-CN">获取调用方生成的事务 ID，用于抑制重复提交和恢复。</para>
+        /// </summary>
+        public required Guid TransactionId { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the destination generation that must still be current before mutation.</para>
+        ///     <para xml:lang="zh-CN">获取在修改前必须仍然有效的目标代次。</para>
+        /// </summary>
+        public required ProgressGeneration ExpectedGeneration { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the complete proposed progress JSON.</para>
+        ///     <para xml:lang="zh-CN">获取完整的拟提交进度 JSON。</para>
+        /// </summary>
+        public required string ProposedRawJson { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the caller-computed lowercase SHA-256 hash of the proposed UTF-8 content.</para>
+        ///     <para xml:lang="zh-CN">获取调用方计算的拟提交 UTF-8 内容小写 SHA-256 哈希。</para>
+        /// </summary>
+        public required string ProposedSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the caller-computed proposed UTF-8 content length.</para>
+        ///     <para xml:lang="zh-CN">获取调用方计算的拟提交 UTF-8 内容长度。</para>
+        /// </summary>
+        public required long ProposedUtf8Length { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Reports evidence obtained from the cloud backend after a commit attempt.</para>
+    ///     <para xml:lang="zh-CN">报告提交尝试后从云端后端获得的证据。</para>
+    /// </summary>
+    public enum CloudReadBackStatus
+    {
+        /// <summary>
+        ///     <para xml:lang="en">The running game has no cloud backend, so cloud verification was not required.</para>
+        ///     <para xml:lang="zh-CN">当前游戏没有云端后端，因此不需要云端验证。</para>
+        /// </summary>
+        NotRequired,
+
+        /// <summary>
+        ///     <para xml:lang="en">The cloud document was read and matched the proposed hash.</para>
+        ///     <para xml:lang="zh-CN">云端文档已读回，且与拟提交哈希一致。</para>
+        /// </summary>
+        Succeeded,
+
+        /// <summary>
+        ///     <para xml:lang="en">The cloud document could not be read or was not persisted.</para>
+        ///     <para xml:lang="zh-CN">云端文档无法读回或未被持久化。</para>
+        /// </summary>
+        Unavailable,
+
+        /// <summary>
+        ///     <para xml:lang="en">The cloud document was read but did not match the proposed hash.</para>
+        ///     <para xml:lang="zh-CN">云端文档已读回，但与拟提交哈希不一致。</para>
+        /// </summary>
+        Mismatch,
+
+        /// <summary>
+        ///     <para xml:lang="en">The cloud backend reported an operation failure.</para>
+        ///     <para xml:lang="zh-CN">云端后端报告了操作失败。</para>
+        /// </summary>
+        FailureObserved,
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Reports the final state of a conditional raw-progress commit.</para>
+    ///     <para xml:lang="zh-CN">报告条件原始进度提交的最终状态。</para>
+    /// </summary>
+    public enum RawProgressCommitOutcome
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Local, cloud when present, live memory, and preservation evidence all agree.</para>
+        ///     <para xml:lang="zh-CN">本地、存在时的云端、内存状态和保留机制证据全部一致。</para>
+        /// </summary>
+        CommittedVerified,
+
+        /// <summary>
+        ///     <para xml:lang="en">The active destination no longer matches the expected generation.</para>
+        ///     <para xml:lang="zh-CN">活动目标不再匹配预期代次。</para>
+        /// </summary>
+        GenerationConflict,
+
+        /// <summary>
+        ///     <para xml:lang="en">The active profile or modded save namespace changed.</para>
+        ///     <para xml:lang="zh-CN">活动档案或模组存档命名空间已改变。</para>
+        /// </summary>
+        ActiveProfileChanged,
+
+        /// <summary>
+        ///     <para xml:lang="en">The requested schema is not supported by this provider build.</para>
+        ///     <para xml:lang="zh-CN">请求的 schema 不受此提供方构建支持。</para>
+        /// </summary>
+        SchemaUnsupported,
+
+        /// <summary>
+        ///     <para xml:lang="en">The request, fingerprint, identity, or proposed document failed validation before mutation.</para>
+        ///     <para xml:lang="zh-CN">请求、指纹、身份或拟提交文档在修改前未通过验证。</para>
+        /// </summary>
+        ValidationFailed,
+
+        /// <summary>
+        ///     <para xml:lang="en">The local destination may have changed but could not be verified.</para>
+        ///     <para xml:lang="zh-CN">本地目标可能已经改变，但无法验证。</para>
+        /// </summary>
+        LocalReplacementUnverified,
+
+        /// <summary>
+        ///     <para xml:lang="en">The local document is verified, but the cloud document could not be verified.</para>
+        ///     <para xml:lang="zh-CN">本地文档已验证，但云端文档无法验证。</para>
+        /// </summary>
+        CloudReadBackUnverifiedLocalPreserved,
+
+        /// <summary>
+        ///     <para xml:lang="en">The local document is verified, but cloud read-back contains different content.</para>
+        ///     <para xml:lang="zh-CN">本地文档已验证，但云端读回内容不同。</para>
+        /// </summary>
+        CloudReadBackMismatchLocalPreserved,
+
+        /// <summary>
+        ///     <para xml:lang="en">The committed local document could not be proven equal to the live known projection.</para>
+        ///     <para xml:lang="zh-CN">无法证明已提交的本地文档与内存中的已知投影一致。</para>
+        /// </summary>
+        LiveProgressStateUnverified,
+
+        /// <summary>
+        ///     <para xml:lang="en">Unknown-property preservation could not be installed for later ordinary saves.</para>
+        ///     <para xml:lang="zh-CN">无法为后续普通保存安装未知属性保留机制。</para>
+        /// </summary>
+        UnknownJsonContinuationUnverified,
+
+        /// <summary>
+        ///     <para xml:lang="en">Recovery metadata could not be prepared or finalized safely.</para>
+        ///     <para xml:lang="zh-CN">恢复元数据无法被安全准备或结束。</para>
+        /// </summary>
+        RecoveryRequired,
+
+        /// <summary>
+        ///     <para xml:lang="en">Cancellation was observed before any destination mutation.</para>
+        ///     <para xml:lang="zh-CN">在修改任何目标之前收到取消请求。</para>
+        /// </summary>
+        CancelledBeforeCommit,
+
+        /// <summary>
+        ///     <para xml:lang="en">The caller requested a different protocol version.</para>
+        ///     <para xml:lang="zh-CN">调用方请求了不同的协议版本。</para>
+        /// </summary>
+        ProviderIncompatible,
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Contains verification and recovery evidence for a commit attempt.</para>
+    ///     <para xml:lang="zh-CN">包含一次提交尝试的验证与恢复证据。</para>
+    /// </summary>
+    public sealed record RawProgressCommitResult
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the final structured outcome.</para>
+        ///     <para xml:lang="zh-CN">获取最终结构化结果。</para>
+        /// </summary>
+        public required RawProgressCommitOutcome Outcome { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the verified local read-back hash, when available.</para>
+        ///     <para xml:lang="zh-CN">获取可用时已经验证的本地读回哈希。</para>
+        /// </summary>
+        public string? LocalReadBackSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the cloud read-back status.</para>
+        ///     <para xml:lang="zh-CN">获取云端读回状态。</para>
+        /// </summary>
+        public required CloudReadBackStatus CloudStatus { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the cloud read-back hash, when one was obtained.</para>
+        ///     <para xml:lang="zh-CN">获取成功取得时的云端读回哈希。</para>
+        /// </summary>
+        public string? CloudReadBackSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the hash of the live known projection, when synchronization was attempted.</para>
+        ///     <para xml:lang="zh-CN">获取尝试同步后内存中已知投影的哈希。</para>
+        /// </summary>
+        public string? LiveKnownProjectionSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether later ordinary saves received an unknown-property preservation state.</para>
+        ///     <para xml:lang="zh-CN">获取后续普通保存是否已获得未知属性保留状态。</para>
+        /// </summary>
+        public required bool UnknownJsonContinuationInstalled { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets the raw hash against which preservation was installed.</para>
+        ///     <para xml:lang="zh-CN">获取安装保留机制时对应的原始哈希。</para>
+        /// </summary>
+        public string? PreservedRawSha256 { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether any destination may have changed during the attempt.</para>
+        ///     <para xml:lang="zh-CN">获取尝试期间是否可能已经改变任何目标。</para>
+        /// </summary>
+        public required bool DestinationMayHaveChanged { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether the original local content is available from a verified backup or retained journal.</para>
+        ///     <para xml:lang="zh-CN">获取原始本地内容是否可从已验证备份或保留日志中恢复。</para>
+        /// </summary>
+        public required bool VerifiedBackupAvailable { get; init; }
+
+        /// <summary>
+        ///     <para xml:lang="en">Gets whether the local-only recovery journal was retained for inspection or recovery.</para>
+        ///     <para xml:lang="zh-CN">获取仅本地恢复日志是否为检查或恢复而被保留。</para>
+        /// </summary>
+        public required bool RecoveryJournalRetained { get; init; }
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">
+    ///         Provides fail-closed capture and conditional commit operations for the active progress document.
+    ///     </para>
+    ///     <para xml:lang="zh-CN">为活动进度文档提供保守失败的捕获与条件提交操作。</para>
+    /// </summary>
+    public interface IRawProgressCommitBridge
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Returns immutable provider capability metadata without reading or changing a profile.</para>
+        ///     <para xml:lang="zh-CN">返回不可变的提供方能力元数据，不读取或改变任何档案。</para>
+        /// </summary>
+        /// <returns>
+        ///     <para xml:lang="en">The provider descriptor.</para>
+        ///     <para xml:lang="zh-CN">提供方描述符。</para>
+        /// </returns>
+        RawProgressBridgeDescriptor Describe();
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Captures the complete active document and its generation inside the same in-process exclusive window.
+        ///         A persisted cloud copy must be readable or the operation fails closed.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         在同一进程内独占窗口中捕获完整活动文档及其代次。若存在已持久化云端副本但无法读回，操作会保守失败。
+        ///     </para>
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     <para xml:lang="en">Cancellation observed before the snapshot is captured.</para>
+        ///     <para xml:lang="zh-CN">在捕获快照前接受的取消信号。</para>
+        /// </param>
+        /// <returns>
+        ///     <para xml:lang="en">The snapshot result.</para>
+        ///     <para xml:lang="zh-CN">快照结果。</para>
+        /// </returns>
+        /// <exception cref="OperationCanceledException">
+        ///     <para xml:lang="en">The operation was cancelled before capture completed.</para>
+        ///     <para xml:lang="zh-CN">操作在捕获完成前被取消。</para>
+        /// </exception>
+        ValueTask<RawProgressReadResult> CaptureAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Conditionally commits a complete active progress document. Cancellation is honored only before recovery
+        ///         metadata or a destination can be changed; after that point the provider finishes verification and recovery
+        ///         bookkeeping before returning.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         有条件地提交完整活动进度文档。取消信号仅会在恢复元数据或目标可能改变之前生效；越过该点后，提供方会先完成验证和恢复记录再返回。
+        ///     </para>
+        /// </summary>
+        /// <param name="request">
+        ///     <para xml:lang="en">The validated-generation commit request.</para>
+        ///     <para xml:lang="zh-CN">带已验证代次的提交请求。</para>
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     <para xml:lang="en">Cancellation observed only before mutation begins.</para>
+        ///     <para xml:lang="zh-CN">仅在修改开始前接受的取消信号。</para>
+        /// </param>
+        /// <returns>
+        ///     <para xml:lang="en">Structured verification and recovery evidence.</para>
+        ///     <para xml:lang="zh-CN">结构化验证与恢复证据。</para>
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <para xml:lang="en"><paramref name="request" /> is <see langword="null" />.</para>
+        ///     <para xml:lang="zh-CN"><paramref name="request" /> 为 <see langword="null" />。</para>
+        /// </exception>
+        ValueTask<RawProgressCommitResult> CommitAsync(
+            RawProgressCommitRequest request,
+            CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Provides the process-wide RitsuLib raw-progress bridge service.</para>
+    ///     <para xml:lang="zh-CN">提供进程级的 RitsuLib 原始进度桥接服务。</para>
+    /// </summary>
+    public static class RawProgressBridge
+    {
+        /// <summary>
+        ///     <para xml:lang="en">Gets the shared provider instance.</para>
+        ///     <para xml:lang="zh-CN">获取共享的提供方实例。</para>
+        /// </summary>
+        public static IRawProgressCommitBridge Instance { get; } = RawProgressCommitBridge.Instance;
+    }
+}

--- a/src/Saves/RawProgress/RawProgressCommitBridge.cs
+++ b/src/Saves/RawProgress/RawProgressCommitBridge.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Godot;
 using MegaCrit.Sts2.Core.Debug;
 using MegaCrit.Sts2.Core.Logging;
@@ -40,6 +41,8 @@ namespace STS2RitsuLib.Saves.RawProgress
         private static readonly JsonSerializerOptions JournalJsonOptions = new()
         {
             WriteIndented = true,
+            MaxDepth = 32,
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
         };
 
         [ThreadStatic] private static bool _isPreparingCommitProjection;
@@ -60,7 +63,8 @@ namespace STS2RitsuLib.Saves.RawProgress
                            RawProgressBridgeFeature.CloudReadBackVerification |
                            RawProgressBridgeFeature.LiveProgressStateSynchronization |
                            RawProgressBridgeFeature.SubsequentSaveUnknownJsonPreservation |
-                           RawProgressBridgeFeature.ActiveProgressSnapshot;
+                           RawProgressBridgeFeature.ActiveProgressSnapshot |
+                           RawProgressBridgeFeature.RecoveryJournalManagement;
 
 #if !STS2_AT_LEAST_0_108_0
             features |= RawProgressBridgeFeature.RawSchema21Document;
@@ -74,6 +78,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 SupportedSchemas = SupportedSchemas,
                 Features = features,
                 MaxDocumentUtf8Bytes = MaxDocumentUtf8Bytes,
+                MaxRetainedRecoveryJournals = MaxRetainedRecoveryJournals,
             };
         }
 
@@ -106,6 +111,29 @@ namespace STS2RitsuLib.Saves.RawProgress
             ArgumentNullException.ThrowIfNull(request);
 
             return new(RitsuMainThread.InvokeAsync(() => CommitOnMainThread(request, cancellationToken)));
+        }
+
+        public ValueTask<RawProgressRecoveryReadResult> GetPendingRecoveriesAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return new(RitsuMainThread.InvokeAsync(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                lock (SaveWindow)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return RecoveryJournal.ReadAll();
+                }
+            }, cancellationToken));
+        }
+
+        public ValueTask<RawProgressCommitResult> RestoreRecoveryAsync(
+            RawProgressRecoveryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            return new(RitsuMainThread.InvokeAsync(() => RestoreRecoveryOnMainThread(request, cancellationToken)));
         }
 
         internal static void SaveOrdinaryProgress(ProgressSaveManager manager)
@@ -248,12 +276,103 @@ namespace STS2RitsuLib.Saves.RawProgress
                         recoveryJournalRetained: !removed));
                 }
 
-                return Remember(request, CommitPrepared(request, proposed, current, journal));
+                return Remember(request, CommitPrepared(
+                    request.ProposedRawJson,
+                    request.ProposedSha256,
+                    proposed,
+                    current,
+                    journal));
+            }
+        }
+
+        private static RawProgressCommitResult RestoreRecoveryOnMainThread(
+            RawProgressRecoveryRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (request.TransactionId == Guid.Empty || request.ExpectedGeneration == null)
+                return CreateResult(RawProgressCommitOutcome.ValidationFailed);
+            if (cancellationToken.IsCancellationRequested)
+                return CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit);
+
+            lock (SaveWindow)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit);
+
+                var loadOutcome = RecoveryJournal.TryLoad(request.TransactionId, out var journal);
+                if (loadOutcome == RecoveryJournalLoadOutcome.NotFound)
+                    return CreateResult(RawProgressCommitOutcome.RecoveryJournalNotFound);
+                if (loadOutcome != RecoveryJournalLoadOutcome.Succeeded || journal == null)
+                    return CreateResult(RawProgressCommitOutcome.RecoveryJournalInvalid);
+
+                var data = journal.Data;
+                var expected = request.ExpectedGeneration;
+                if (data.ProfileId != expected.ProfileId || data.IsModded != expected.IsModded ||
+                    !string.Equals(data.ProgressUniqueId, expected.ProgressUniqueId, StringComparison.Ordinal))
+                    return CreateResult(
+                        RawProgressCommitOutcome.ActiveProfileChanged,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+
+                var current = CaptureCore();
+                if (current.Result.Outcome != RawProgressReadOutcome.Succeeded || current.Result.Snapshot == null)
+                    return CreateResult(
+                        MapCaptureFailure(current.Result.Outcome).Outcome,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+
+                var currentGeneration = current.Result.Snapshot.Generation;
+                if (currentGeneration.ProfileId != data.ProfileId || currentGeneration.IsModded != data.IsModded ||
+                    !string.Equals(currentGeneration.ProgressUniqueId, data.ProgressUniqueId, StringComparison.Ordinal))
+                    return CreateResult(
+                        RawProgressCommitOutcome.ActiveProfileChanged,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+                if (!GenerationMatches(currentGeneration, expected))
+                    return CreateResult(
+                        RawProgressCommitOutcome.GenerationConflict,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+                if (cancellationToken.IsCancellationRequested)
+                    return CreateResult(
+                        RawProgressCommitOutcome.CancelledBeforeCommit,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+
+                if (!TryGetUtf8Bytes(data.OriginalRawJson, out var originalBytes))
+                    return CreateResult(
+                        RawProgressCommitOutcome.RecoveryJournalInvalid,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+
+                var validationRequest = new RawProgressCommitRequest
+                {
+                    ProtocolVersion = ProtocolVersion,
+                    SchemaVersion = SupportedSchema,
+                    TransactionId = data.TransactionId,
+                    ExpectedGeneration = expected,
+                    ProposedRawJson = data.OriginalRawJson,
+                    ProposedSha256 = data.OriginalSha256,
+                    ProposedUtf8Length = originalBytes.LongLength,
+                };
+                if (!TryValidateProposedDocument(validationRequest, out var original))
+                    return CreateResult(
+                        RawProgressCommitOutcome.RecoveryJournalInvalid,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+
+                return CommitPrepared(
+                    data.OriginalRawJson,
+                    data.OriginalSha256,
+                    original,
+                    current,
+                    journal);
             }
         }
 
         private static RawProgressCommitResult CommitPrepared(
-            RawProgressCommitRequest request,
+            string proposedRawJson,
+            string proposedSha256,
             ValidatedDocument proposed,
             CapturedProgress current,
             RecoveryJournal journal)
@@ -273,12 +392,12 @@ namespace STS2RitsuLib.Saves.RawProgress
             {
                 batch = saveManager.BeginSaveBatch();
                 destinationMayHaveChanged = true;
-                saveStore.WriteFile(path, request.ProposedRawJson);
+                saveStore.WriteFile(path, proposedRawJson);
                 var localReadBack = localStore.ReadFile(path);
                 if (localReadBack != null)
                 {
                     localReadBackHash = ComputeSha256(localReadBack);
-                    localVerified = HashEquals(localReadBackHash, request.ProposedSha256);
+                    localVerified = HashEquals(localReadBackHash, proposedSha256);
                 }
             }
             catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
@@ -313,7 +432,7 @@ namespace STS2RitsuLib.Saves.RawProgress
             }
 
             journal.TryUpdate("local_verified", localReadBackHash, null, null);
-            var cloudReadBack = VerifyCloudReadBack(saveStore, path, request.ProposedSha256, batchFailure);
+            var cloudReadBack = VerifyCloudReadBack(saveStore, path, proposedSha256, batchFailure);
             cloudStatus = cloudReadBack.Status;
             var cloudReadBackHash = cloudReadBack.Hash;
 
@@ -324,7 +443,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 saveManager.Progress = proposed.Progress;
                 continuationInstalled = RawProgressJsonPreservation.TryAttach(
                     proposed.Progress,
-                    request.ProposedRawJson,
+                    proposedRawJson,
                     proposed.KnownProjectionJson);
 
                 var liveSerializable = saveManager.Progress.ToSerializable();
@@ -367,7 +486,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 cloudReadBackHash,
                 liveProjectionHash,
                 continuationInstalled,
-                continuationInstalled ? request.ProposedSha256 : null,
+                continuationInstalled ? proposedSha256 : null,
                 destinationMayHaveChanged,
                 gameBackupVerified || journal.Exists,
                 journal.Exists);
@@ -839,6 +958,13 @@ namespace STS2RitsuLib.Saves.RawProgress
 
         private sealed record CompletedTransaction(string ProposedSha256, RawProgressCommitResult Result);
 
+        private enum RecoveryJournalLoadOutcome
+        {
+            Succeeded,
+            NotFound,
+            Invalid,
+        }
+
         private sealed record RecoveryJournalData
         {
             public required int JournalProtocolVersion { get; init; }
@@ -857,20 +983,31 @@ namespace STS2RitsuLib.Saves.RawProgress
 
         private sealed class RecoveryJournal
         {
-            private RecoveryJournal(string path, RecoveryJournalData data)
+            private RecoveryJournal(
+                string basePath,
+                string writePath,
+                RecoveryJournalData data,
+                bool canUpdate = true)
             {
-                Path = path;
+                BasePath = basePath;
+                WritePath = writePath;
                 Data = data;
+                CanUpdate = canUpdate;
             }
 
-            private string Path { get; }
-            private RecoveryJournalData Data { get; set; }
-            internal bool Exists => FileOperations.FileExists(Path) || FileOperations.FileExists(Path + ".backup");
+            private string BasePath { get; }
+            private string WritePath { get; }
+            private bool CanUpdate { get; }
+            internal RecoveryJournalData Data { get; private set; }
+
+            internal bool Exists => FileOperations.FileExists(BasePath) ||
+                                    FileOperations.FileExists(BasePath + ".backup") ||
+                                    FileOperations.FileExists(BasePath + ".backup.backup");
 
             internal static RecoveryJournal Create(RawProgressCommitRequest request, string originalRawJson)
             {
                 var path = $"{GetRecoveryDirectory()}/{request.TransactionId:N}.json";
-                return new(path, new()
+                return new(path, path, new()
                 {
                     JournalProtocolVersion = ProtocolVersion,
                     TransactionId = request.TransactionId,
@@ -882,6 +1019,78 @@ namespace STS2RitsuLib.Saves.RawProgress
                     OriginalSha256 = ComputeSha256(originalRawJson),
                     ProposedSha256 = request.ProposedSha256,
                 });
+            }
+
+            internal static RawProgressRecoveryReadResult ReadAll()
+            {
+                if (!TryEnumerateTransactionIds(out var transactionIds, out var invalidEntryCount))
+                    return new()
+                    {
+                        Outcome = RawProgressRecoveryReadOutcome.StorageUnavailable,
+                        Records = [],
+                        InvalidEntryCount = invalidEntryCount,
+                    };
+
+                var records = new List<RawProgressRecoveryRecord>(transactionIds.Count);
+                foreach (var transactionId in transactionIds)
+                {
+                    var outcome = TryLoad(transactionId, out var journal);
+                    if (outcome != RecoveryJournalLoadOutcome.Succeeded || journal == null)
+                    {
+                        invalidEntryCount++;
+                        continue;
+                    }
+
+                    records.Add(journal.ToRecord());
+                }
+
+                records.Sort(static (left, right) => left.TransactionId.CompareTo(right.TransactionId));
+                return new()
+                {
+                    Outcome = invalidEntryCount == 0
+                        ? RawProgressRecoveryReadOutcome.Succeeded
+                        : RawProgressRecoveryReadOutcome.InvalidEntriesIgnored,
+                    Records = records.AsReadOnly(),
+                    InvalidEntryCount = invalidEntryCount,
+                };
+            }
+
+            internal static RecoveryJournalLoadOutcome TryLoad(
+                Guid transactionId,
+                out RecoveryJournal? journal)
+            {
+                journal = null;
+                if (transactionId == Guid.Empty)
+                    return RecoveryJournalLoadOutcome.Invalid;
+
+                var basePath = $"{GetRecoveryDirectory()}/{transactionId:N}.json";
+                var primaryExists = FileOperations.FileExists(basePath);
+                var backupPath = basePath + ".backup";
+                var backupExists = FileOperations.FileExists(backupPath);
+                var secondBackupPath = backupPath + ".backup";
+                var secondBackupExists = FileOperations.FileExists(secondBackupPath);
+                if (!primaryExists && !backupExists && !secondBackupExists)
+                    return RecoveryJournalLoadOutcome.NotFound;
+
+                if (primaryExists && TryReadData(basePath, transactionId, out var primaryData))
+                {
+                    journal = new(basePath, basePath, primaryData);
+                    return RecoveryJournalLoadOutcome.Succeeded;
+                }
+
+                if (backupExists && TryReadData(backupPath, transactionId, out var backupData))
+                {
+                    journal = new(basePath, backupPath, backupData);
+                    return RecoveryJournalLoadOutcome.Succeeded;
+                }
+
+                if (secondBackupExists && TryReadData(secondBackupPath, transactionId, out var secondBackupData))
+                {
+                    journal = new(basePath, secondBackupPath, secondBackupData, false);
+                    return RecoveryJournalLoadOutcome.Succeeded;
+                }
+
+                return RecoveryJournalLoadOutcome.Invalid;
             }
 
             internal bool TryPrepare()
@@ -898,6 +1107,9 @@ namespace STS2RitsuLib.Saves.RawProgress
                 string? cloudReadBackSha256,
                 string? liveKnownProjectionSha256)
             {
+                if (!CanUpdate)
+                    return;
+
                 Data = Data with
                 {
                     Stage = stage,
@@ -910,10 +1122,20 @@ namespace STS2RitsuLib.Saves.RawProgress
 
             internal bool TryDelete()
             {
-                var primary = FileOperations.DeleteFile(Path, RecoveryLogContext);
-                var backup = FileOperations.DeleteFile(Path + ".backup", RecoveryLogContext);
-                var temporary = FileOperations.DeleteFile(Path + ".tmp", RecoveryLogContext);
-                return primary.Success && backup.Success && temporary.Success && !Exists;
+                var paths = new[]
+                {
+                    BasePath,
+                    BasePath + ".backup",
+                    BasePath + ".tmp",
+                    BasePath + ".backup.backup",
+                    BasePath + ".backup.tmp",
+                    BasePath + ".backup.backup.backup",
+                    BasePath + ".backup.backup.tmp",
+                };
+                var success = true;
+                foreach (var path in paths)
+                    success &= FileOperations.DeleteFile(path, RecoveryLogContext).Success;
+                return success && !Exists;
             }
 
             private bool TryWrite()
@@ -921,7 +1143,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 try
                 {
                     var json = JsonSerializer.Serialize(Data, JournalJsonOptions);
-                    return FileOperations.WriteText(Path, json, RecoveryLogContext).Success;
+                    return FileOperations.WriteText(WritePath, json, RecoveryLogContext).Success;
                 }
                 catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
                 {
@@ -933,17 +1155,141 @@ namespace STS2RitsuLib.Saves.RawProgress
 
             private static int CountRetainedJournals()
             {
+                return TryEnumerateTransactionIds(out var transactionIds, out var invalidEntryCount)
+                    ? transactionIds.Count + invalidEntryCount
+                    : MaxRetainedRecoveryJournals;
+            }
+
+            private RawProgressRecoveryRecord ToRecord()
+            {
+                _ = TryParseStage(Data.Stage, out var stage);
+                return new()
+                {
+                    TransactionId = Data.TransactionId,
+                    ProfileId = Data.ProfileId,
+                    IsModded = Data.IsModded,
+                    ProgressUniqueId = Data.ProgressUniqueId,
+                    Stage = stage,
+                    OriginalSha256 = Data.OriginalSha256,
+                    ProposedSha256 = Data.ProposedSha256,
+                };
+            }
+
+            private static bool TryReadData(
+                string path,
+                Guid expectedTransactionId,
+                out RecoveryJournalData data)
+            {
+                data = null!;
+                var read = FileOperations.ReadText(path, RecoveryLogContext);
+                if (!read.Success || read.Content == null)
+                    return false;
+
                 try
                 {
-                    using var directory = DirAccess.Open(GetRecoveryDirectory());
-                    return directory?.GetFiles().Count(static file =>
-                        file.EndsWith(".json", StringComparison.OrdinalIgnoreCase)) ?? 0;
+                    var candidate = JsonSerializer.Deserialize<RecoveryJournalData>(read.Content, JournalJsonOptions);
+                    if (!IsValid(candidate, expectedTransactionId))
+                        return false;
+
+                    data = candidate!;
+                    return true;
                 }
                 catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
                 {
                     RitsuLibFramework.Logger.Warn(
-                        $"[RawProgress] Failed to count retained recovery journals: {ex.Message}");
-                    return MaxRetainedRecoveryJournals;
+                        $"[RawProgress] Failed to read recovery metadata at '{path}': {ex.Message}");
+                    return false;
+                }
+            }
+
+            private static bool IsValid(RecoveryJournalData? data, Guid expectedTransactionId)
+            {
+                if (data == null ||
+                    data.JournalProtocolVersion != ProtocolVersion ||
+                    data.TransactionId != expectedTransactionId ||
+                    data.ProfileId is < 1 or > 3 ||
+                    string.IsNullOrWhiteSpace(data.ProgressUniqueId) ||
+                    data.ProgressUniqueId.Length > 256 ||
+                    !TryParseStage(data.Stage, out _) ||
+                    string.IsNullOrWhiteSpace(data.OriginalRawJson) ||
+                    data.OriginalRawJson.Length > MaxDocumentUtf8Bytes ||
+                    !IsSha256(data.OriginalSha256) ||
+                    !IsSha256(data.ProposedSha256) ||
+                    data.LocalReadBackSha256 != null && !IsSha256(data.LocalReadBackSha256) ||
+                    data.CloudReadBackSha256 != null && !IsSha256(data.CloudReadBackSha256) ||
+                    data.LiveKnownProjectionSha256 != null && !IsSha256(data.LiveKnownProjectionSha256) ||
+                    !TryInspectExistingDocument(
+                        data.OriginalRawJson,
+                        out var schema,
+                        out var uniqueId,
+                        out var originalBytes) ||
+                    schema != SupportedSchema ||
+                    originalBytes.LongLength > MaxDocumentUtf8Bytes ||
+                    !HashEquals(ComputeSha256(originalBytes), data.OriginalSha256) ||
+                    !string.Equals(uniqueId, data.ProgressUniqueId, StringComparison.Ordinal))
+                    return false;
+
+                return true;
+            }
+
+            private static bool TryParseStage(string? value, out RawProgressRecoveryStage stage)
+            {
+                stage = value switch
+                {
+                    "prepared" => RawProgressRecoveryStage.Prepared,
+                    "local_unverified" => RawProgressRecoveryStage.LocalUnverified,
+                    "local_verified" => RawProgressRecoveryStage.LocalVerified,
+                    "verification_incomplete" => RawProgressRecoveryStage.VerificationIncomplete,
+                    _ => default,
+                };
+                return value is "prepared" or "local_unverified" or "local_verified" or
+                    "verification_incomplete";
+            }
+
+            private static bool TryEnumerateTransactionIds(
+                out HashSet<Guid> transactionIds,
+                out int invalidEntryCount)
+            {
+                transactionIds = [];
+                invalidEntryCount = 0;
+                var invalidNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var recoveryDirectory = GetRecoveryDirectory();
+                try
+                {
+                    if (!DirAccess.DirExistsAbsolute(recoveryDirectory))
+                        return true;
+
+                    using var directory = DirAccess.Open(recoveryDirectory);
+                    if (directory == null)
+                        return false;
+
+                    foreach (var file in directory.GetFiles())
+                    {
+                        string? transactionText = null;
+                        if (file.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                            transactionText = file[..^".json".Length];
+                        else if (file.EndsWith(".json.backup", StringComparison.OrdinalIgnoreCase))
+                            transactionText = file[..^".json.backup".Length];
+                        else if (file.EndsWith(".json.backup.backup", StringComparison.OrdinalIgnoreCase))
+                            transactionText = file[..^".json.backup.backup".Length];
+
+                        if (transactionText == null)
+                            continue;
+                        if (Guid.TryParseExact(transactionText, "N", out var transactionId))
+                            transactionIds.Add(transactionId);
+                        else
+                            invalidNames.Add(transactionText);
+                    }
+
+                    invalidEntryCount = invalidNames.Count;
+                    return true;
+                }
+                catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+                {
+                    RitsuLibFramework.Logger.Warn(
+                        $"[RawProgress] Failed to enumerate retained recovery journals: {ex.Message}");
+                    invalidEntryCount = invalidNames.Count;
+                    return false;
                 }
             }
         }

--- a/src/Saves/RawProgress/RawProgressCommitBridge.cs
+++ b/src/Saves/RawProgress/RawProgressCommitBridge.cs
@@ -1,0 +1,951 @@
+﻿using System.Collections.Frozen;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Godot;
+using MegaCrit.Sts2.Core.Debug;
+using MegaCrit.Sts2.Core.Logging;
+using MegaCrit.Sts2.Core.Saves;
+using MegaCrit.Sts2.Core.Saves.Managers;
+using MegaCrit.Sts2.Core.Saves.Migrations;
+using MegaCrit.Sts2.Core.Saves.Validation;
+using STS2RitsuLib.Utils;
+using STS2RitsuLib.Utils.Persistence;
+
+namespace STS2RitsuLib.Saves.RawProgress
+{
+    internal sealed class RawProgressCommitBridge : IRawProgressCommitBridge
+    {
+        internal const int ProtocolVersion = 1;
+        internal const long MaxDocumentUtf8Bytes = 16 * 1024 * 1024;
+        private const int MaxRetainedRecoveryJournals = 8;
+        private const string RecoveryLogContext = "RawProgressRecovery";
+        private const string RecoveryDirectoryName = "recovery/raw-progress";
+
+#if STS2_AT_LEAST_0_110_0
+        internal const int SupportedSchema = 24;
+#elif STS2_AT_LEAST_0_108_0
+        internal const int SupportedSchema = 22;
+#else
+        internal const int SupportedSchema = 21;
+#endif
+
+        private static readonly object SaveWindow = new();
+        private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+        private static readonly FrozenSet<int> SupportedSchemas = new[] { SupportedSchema }.ToFrozenSet();
+        private static readonly Dictionary<Guid, CompletedTransaction> CompletedTransactions = [];
+        private static readonly Queue<Guid> CompletedTransactionOrder = [];
+
+        private static readonly JsonSerializerOptions JournalJsonOptions = new()
+        {
+            WriteIndented = true,
+        };
+
+        [ThreadStatic] private static bool _isPreparingCommitProjection;
+
+        private readonly RawProgressBridgeDescriptor _descriptor;
+
+        private RawProgressCommitBridge()
+        {
+            var features = RawProgressBridgeFeature.UnknownJsonPassThrough |
+                           RawProgressBridgeFeature.LiveGameStoreCommit |
+                           RawProgressBridgeFeature.DurableLocalReplacement |
+                           RawProgressBridgeFeature.CloudSaveBatch |
+                           RawProgressBridgeFeature.ConditionalGenerationCheck |
+                           RawProgressBridgeFeature.ExclusiveSaveWindow |
+                           RawProgressBridgeFeature.LocalOnlyRecoveryJournal |
+                           RawProgressBridgeFeature.StructuredRecoveryOutcome |
+                           RawProgressBridgeFeature.StablePublicContract |
+                           RawProgressBridgeFeature.CloudReadBackVerification |
+                           RawProgressBridgeFeature.LiveProgressStateSynchronization |
+                           RawProgressBridgeFeature.SubsequentSaveUnknownJsonPreservation |
+                           RawProgressBridgeFeature.ActiveProgressSnapshot;
+
+#if !STS2_AT_LEAST_0_108_0
+            features |= RawProgressBridgeFeature.RawSchema21Document;
+#endif
+
+            _descriptor = new()
+            {
+                ProviderId = Const.ModId,
+                ProviderVersion = Version.Parse(Const.Version),
+                ProtocolVersion = ProtocolVersion,
+                SupportedSchemas = SupportedSchemas,
+                Features = features,
+                MaxDocumentUtf8Bytes = MaxDocumentUtf8Bytes,
+            };
+        }
+
+        internal static RawProgressCommitBridge Instance { get; } = new();
+
+        internal static bool IsPreparingCommitProjection => _isPreparingCommitProjection;
+
+        public RawProgressBridgeDescriptor Describe()
+        {
+            return _descriptor;
+        }
+
+        public ValueTask<RawProgressReadResult> CaptureAsync(CancellationToken cancellationToken = default)
+        {
+            return new(RitsuMainThread.InvokeAsync(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                lock (SaveWindow)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return CaptureCore().Result;
+                }
+            }, cancellationToken));
+        }
+
+        public ValueTask<RawProgressCommitResult> CommitAsync(
+            RawProgressCommitRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            return new(RitsuMainThread.InvokeAsync(() => CommitOnMainThread(request, cancellationToken)));
+        }
+
+        internal static void SaveOrdinaryProgress(ProgressSaveManager manager)
+        {
+            ArgumentNullException.ThrowIfNull(manager);
+
+            lock (SaveWindow)
+            {
+                try
+                {
+                    var progress = manager.Progress;
+                    var serializable = progress.ToSerializable();
+                    serializable.SchemaVersion = MigrationManager(manager).GetLatestVersion<SerializableProgress>();
+                    var knownJson = JsonSerializationUtility.ToJson(serializable);
+                    var content = RawProgressJsonPreservation.PreserveAndAdvance(progress, knownJson);
+                    SaveStore(manager).WriteFile(
+                        ProgressSaveManager.GetProgressPathForProfile(ProfileIdProvider(manager).CurrentProfileId),
+                        content);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"Failed to save progress: {ex}");
+                    SentryService.CaptureException(ex);
+                }
+            }
+        }
+
+        internal static LoadCapture? BeginProgressLoad(ProgressSaveManager manager)
+        {
+            Monitor.Enter(SaveWindow);
+            try
+            {
+                var profileId = ProfileIdProvider(manager).CurrentProfileId;
+                var path = ProgressSaveManager.GetProgressPathForProfile(profileId);
+                var rawJson = SaveStore(manager).ReadFile(path);
+                return string.IsNullOrWhiteSpace(rawJson) ? null : new(rawJson);
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[RawProgress] Could not capture the raw document before load: {ex.Message}");
+                return null;
+            }
+        }
+
+        internal static void CompleteProgressLoad(
+            ProgressSaveManager manager,
+            ReadSaveResult<SerializableProgress> result,
+            LoadCapture? capture)
+        {
+            try
+            {
+                if (capture == null || result is not { Success: true, SaveData: not null })
+                    return;
+
+                if (!TryReadSchema(capture.RawJson, out var rawSchema) || rawSchema != SupportedSchema)
+                    return;
+
+                var rawReadResult = JsonSerializationUtility.FromJson<SerializableProgress>(capture.RawJson);
+                if (rawReadResult is not { Success: true, SaveData: not null })
+                    return;
+
+                rawReadResult.SaveData.SchemaVersion = SupportedSchema;
+                var knownJson = JsonSerializationUtility.ToJson(rawReadResult.SaveData);
+                if (!RawProgressJsonPreservation.TryAttach(manager.Progress, capture.RawJson, knownJson))
+                    RitsuLibFramework.Logger.Warn(
+                        "[RawProgress] The loaded document contains unknown properties that could not be matched safely; " +
+                        "ordinary saves will use the known game projection.");
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[RawProgress] Failed to install preservation state after progress load: {ex.Message}");
+            }
+        }
+
+        internal static void EndProgressLoad()
+        {
+            Monitor.Exit(SaveWindow);
+        }
+
+        internal static void EnterProfileMutation()
+        {
+            Monitor.Enter(SaveWindow);
+        }
+
+        internal static void ExitProfileMutation()
+        {
+            Monitor.Exit(SaveWindow);
+        }
+
+        private static RawProgressCommitResult CommitOnMainThread(
+            RawProgressCommitRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (request.ProtocolVersion != ProtocolVersion)
+                return CreateResult(RawProgressCommitOutcome.ProviderIncompatible);
+            if (request.SchemaVersion != SupportedSchema)
+                return CreateResult(RawProgressCommitOutcome.SchemaUnsupported);
+            if (cancellationToken.IsCancellationRequested)
+                return CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit);
+
+            if (!TryValidateProposedDocument(request, out var proposed))
+                return CreateResult(RawProgressCommitOutcome.ValidationFailed);
+            if (cancellationToken.IsCancellationRequested)
+                return CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit);
+
+            lock (SaveWindow)
+            {
+                if (TryGetCompletedTransaction(request, out var completed))
+                    return completed;
+                if (cancellationToken.IsCancellationRequested)
+                    return Remember(request, CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit));
+
+                var current = CaptureCore();
+                if (current.Result.Outcome != RawProgressReadOutcome.Succeeded || current.Result.Snapshot == null)
+                    return Remember(request, MapCaptureFailure(current.Result.Outcome));
+
+                var snapshot = current.Result.Snapshot;
+                if (snapshot.Generation.ProfileId != request.ExpectedGeneration.ProfileId ||
+                    snapshot.Generation.IsModded != request.ExpectedGeneration.IsModded)
+                    return Remember(request, CreateResult(RawProgressCommitOutcome.ActiveProfileChanged));
+                if (!GenerationMatches(snapshot.Generation, request.ExpectedGeneration))
+                    return Remember(request, CreateResult(RawProgressCommitOutcome.GenerationConflict));
+                if (!string.Equals(proposed.ProgressUniqueId, snapshot.Generation.ProgressUniqueId,
+                        StringComparison.Ordinal))
+                    return Remember(request, CreateResult(RawProgressCommitOutcome.ValidationFailed));
+
+                var journal = RecoveryJournal.Create(request, snapshot.RawJson);
+                if (!journal.TryPrepare())
+                    return Remember(request, CreateResult(
+                        RawProgressCommitOutcome.RecoveryRequired,
+                        recoveryJournalRetained: journal.Exists));
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    var removed = journal.TryDelete();
+                    return Remember(request, CreateResult(
+                        RawProgressCommitOutcome.CancelledBeforeCommit,
+                        verifiedBackupAvailable: !removed,
+                        recoveryJournalRetained: !removed));
+                }
+
+                return Remember(request, CommitPrepared(request, proposed, current, journal));
+            }
+        }
+
+        private static RawProgressCommitResult CommitPrepared(
+            RawProgressCommitRequest request,
+            ValidatedDocument proposed,
+            CapturedProgress current,
+            RecoveryJournal journal)
+        {
+            var destinationMayHaveChanged = false;
+            var localVerified = false;
+            var batchFailure = false;
+            var localReadBackHash = (string?)null;
+            var cloudStatus = CloudReadBackStatus.NotRequired;
+            var saveManager = current.SaveManager!;
+            var saveStore = current.Store!;
+            var localStore = GetLocalStore(saveStore);
+            var path = current.Path!;
+            SaveBatchScope? batch = null;
+
+            try
+            {
+                batch = saveManager.BeginSaveBatch();
+                destinationMayHaveChanged = true;
+                saveStore.WriteFile(path, request.ProposedRawJson);
+                var localReadBack = localStore.ReadFile(path);
+                if (localReadBack != null)
+                {
+                    localReadBackHash = ComputeSha256(localReadBack);
+                    localVerified = HashEquals(localReadBackHash, request.ProposedSha256);
+                }
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.ErrorNoTrace($"[RawProgress] Commit write failed: {ex.Message}");
+            }
+            finally
+            {
+                try
+                {
+                    batch?.Dispose();
+                }
+                catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+                {
+                    batchFailure = true;
+                    RitsuLibFramework.Logger.ErrorNoTrace(
+                        $"[RawProgress] Failed to end cloud save batch: {ex.Message}");
+                }
+            }
+
+            var gameBackupVerified = VerifyGameBackup(localStore, path, current.Result.Snapshot!.RawJson);
+            if (!localVerified)
+            {
+                journal.TryUpdate("local_unverified", localReadBackHash, null, null);
+                return CreateResult(
+                    RawProgressCommitOutcome.LocalReplacementUnverified,
+                    localReadBackSha256: localReadBackHash,
+                    cloudStatus: batchFailure ? CloudReadBackStatus.FailureObserved : cloudStatus,
+                    destinationMayHaveChanged: destinationMayHaveChanged,
+                    verifiedBackupAvailable: gameBackupVerified || journal.Exists,
+                    recoveryJournalRetained: journal.Exists);
+            }
+
+            journal.TryUpdate("local_verified", localReadBackHash, null, null);
+            var cloudReadBack = VerifyCloudReadBack(saveStore, path, request.ProposedSha256, batchFailure);
+            cloudStatus = cloudReadBack.Status;
+            var cloudReadBackHash = cloudReadBack.Hash;
+
+            var liveProjectionHash = (string?)null;
+            var continuationInstalled = false;
+            try
+            {
+                saveManager.Progress = proposed.Progress;
+                continuationInstalled = RawProgressJsonPreservation.TryAttach(
+                    proposed.Progress,
+                    request.ProposedRawJson,
+                    proposed.KnownProjectionJson);
+
+                var liveSerializable = saveManager.Progress.ToSerializable();
+                liveSerializable.SchemaVersion = SupportedSchema;
+                liveProjectionHash = ComputeSha256(JsonSerializationUtility.ToJson(liveSerializable));
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.ErrorNoTrace(
+                    $"[RawProgress] Failed to synchronize the live progress projection: {ex.Message}");
+            }
+
+            RawProgressCommitOutcome outcome;
+            if (!HashEquals(liveProjectionHash, proposed.KnownProjectionSha256))
+                outcome = RawProgressCommitOutcome.LiveProgressStateUnverified;
+            else if (!continuationInstalled)
+                outcome = RawProgressCommitOutcome.UnknownJsonContinuationUnverified;
+            else if (cloudStatus is CloudReadBackStatus.Unavailable or CloudReadBackStatus.FailureObserved)
+                outcome = RawProgressCommitOutcome.CloudReadBackUnverifiedLocalPreserved;
+            else if (cloudStatus == CloudReadBackStatus.Mismatch)
+                outcome = RawProgressCommitOutcome.CloudReadBackMismatchLocalPreserved;
+            else
+                outcome = RawProgressCommitOutcome.CommittedVerified;
+
+            if (outcome == RawProgressCommitOutcome.CommittedVerified)
+            {
+                if (!journal.TryDelete())
+                    outcome = RawProgressCommitOutcome.RecoveryRequired;
+            }
+            else
+            {
+                journal.TryUpdate("verification_incomplete", localReadBackHash, cloudReadBackHash,
+                    liveProjectionHash);
+            }
+
+            return CreateResult(
+                outcome,
+                localReadBackHash,
+                cloudStatus,
+                cloudReadBackHash,
+                liveProjectionHash,
+                continuationInstalled,
+                continuationInstalled ? request.ProposedSha256 : null,
+                destinationMayHaveChanged,
+                gameBackupVerified || journal.Exists,
+                journal.Exists);
+        }
+
+        private static CapturedProgress CaptureCore()
+        {
+            SaveManager saveManager;
+            int profileId;
+            try
+            {
+                saveManager = SaveManager.Instance;
+                profileId = saveManager.CurrentProfileId;
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Debug($"[RawProgress] Active profile is unavailable: {ex.Message}");
+                return new(new() { Outcome = RawProgressReadOutcome.ActiveProfileUnavailable });
+            }
+
+            var saveStore = SaveStore(saveManager);
+            var localStore = GetLocalStore(saveStore);
+            var isModded = UserDataPathProvider.IsRunningModded;
+            var path = GetProgressPath(profileId, isModded);
+            string? rawJson;
+            long localModified;
+            int localStoredLength;
+            try
+            {
+                if (!localStore.FileExists(path))
+                    return new(new() { Outcome = RawProgressReadOutcome.LocalReadUnavailable });
+                var modifiedBeforeRead = localStore.GetLastModifiedTime(path).UtcTicks;
+                rawJson = localStore.ReadFile(path);
+                localStoredLength = localStore.GetFileSize(path);
+                localModified = localStore.GetLastModifiedTime(path).UtcTicks;
+                if (modifiedBeforeRead != localModified)
+                    return new(new() { Outcome = RawProgressReadOutcome.LocalReadUnavailable });
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn($"[RawProgress] Failed to read active local progress: {ex.Message}");
+                return new(new() { Outcome = RawProgressReadOutcome.LocalReadUnavailable });
+            }
+
+            if (!TryInspectExistingDocument(rawJson, out var schema, out var uniqueId, out var localBytes))
+                return new(new() { Outcome = RawProgressReadOutcome.ValidationFailed });
+            if (schema != SupportedSchema)
+                return new(new() { Outcome = RawProgressReadOutcome.SchemaUnsupported });
+
+            try
+            {
+                var localHash = ComputeSha256(localBytes);
+                if (localStoredLength != localBytes.Length)
+                    return new(new() { Outcome = RawProgressReadOutcome.LocalReadUnavailable });
+                var cloudAvailable = saveStore is CloudSaveStore;
+                var cloudSyncEnabled = false;
+                var cloudPersisted = false;
+                string? cloudHash = null;
+                long? cloudLength = null;
+                long? cloudModified = null;
+
+                if (saveStore is CloudSaveStore cloudSaveStore)
+                {
+                    var cloudStore = cloudSaveStore.CloudStore;
+                    cloudSyncEnabled = cloudSaveStore.HasUserEnabledCloudSync();
+                    cloudPersisted = cloudStore.IsFilePersisted(path);
+                    if (cloudPersisted)
+                    {
+                        var cloudModifiedBeforeRead = cloudStore.GetLastModifiedTime(path).UtcTicks;
+                        var cloudJson = cloudStore.ReadFile(path);
+                        if (cloudJson == null || !TryGetUtf8Bytes(cloudJson, out var cloudBytes))
+                            return new(new() { Outcome = RawProgressReadOutcome.CloudReadUnavailable });
+
+                        var cloudStoredLength = cloudStore.GetFileSize(path);
+                        var cloudModifiedAfterRead = cloudStore.GetLastModifiedTime(path).UtcTicks;
+                        if (cloudModifiedBeforeRead != cloudModifiedAfterRead || cloudStoredLength != cloudBytes.Length)
+                            return new(new() { Outcome = RawProgressReadOutcome.CloudReadUnavailable });
+
+                        cloudHash = ComputeSha256(cloudBytes);
+                        cloudLength = cloudBytes.LongLength;
+                        cloudModified = cloudModifiedAfterRead;
+                    }
+                }
+
+                var generation = new ProgressGeneration
+                {
+                    ProfileId = profileId,
+                    IsModded = isModded,
+                    ProgressUniqueId = uniqueId,
+                    LocalSha256 = localHash,
+                    LocalLength = localBytes.LongLength,
+                    LocalLastModifiedUtcTicks = localModified,
+                    CloudAvailable = cloudAvailable,
+                    CloudSyncEnabled = cloudSyncEnabled,
+                    CloudPersisted = cloudPersisted,
+                    CloudSha256 = cloudHash,
+                    CloudLength = cloudLength,
+                    CloudLastModifiedUtcTicks = cloudModified,
+                };
+                var snapshot = new RawProgressSnapshot
+                {
+                    SchemaVersion = schema,
+                    RawJson = rawJson!,
+                    Generation = generation,
+                };
+                return new(
+                    new() { Outcome = RawProgressReadOutcome.Succeeded, Snapshot = snapshot },
+                    saveManager,
+                    saveStore,
+                    path);
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn($"[RawProgress] Failed to capture destination generation: {ex.Message}");
+                return new(new() { Outcome = RawProgressReadOutcome.CloudReadUnavailable });
+            }
+        }
+
+        private static bool TryValidateProposedDocument(
+            RawProgressCommitRequest request,
+            out ValidatedDocument proposed)
+        {
+            proposed = null!;
+            if (request.TransactionId == Guid.Empty ||
+                request.ExpectedGeneration == null ||
+                request.ProposedRawJson == null ||
+                request.ProposedSha256 == null ||
+                request.ExpectedGeneration.ProfileId is < 1 or > 3 ||
+                string.IsNullOrWhiteSpace(request.ExpectedGeneration.ProgressUniqueId) ||
+                !IsSha256(request.ProposedSha256) ||
+                !IsSha256(request.ExpectedGeneration.LocalSha256) ||
+                request.ProposedRawJson.Length > MaxDocumentUtf8Bytes ||
+                !TryGetUtf8Bytes(request.ProposedRawJson, out var proposedBytes) ||
+                proposedBytes.LongLength == 0 ||
+                proposedBytes.LongLength > MaxDocumentUtf8Bytes ||
+                proposedBytes.LongLength != request.ProposedUtf8Length ||
+                !HashEquals(ComputeSha256(proposedBytes), request.ProposedSha256) ||
+                !TryValidateJsonShape(request.ProposedRawJson, out var schema) ||
+                schema != request.SchemaVersion)
+                return false;
+
+            var readResult = JsonSerializationUtility.FromJson<SerializableProgress>(request.ProposedRawJson);
+            if (readResult is not { Success: true, SaveData: not null } ||
+                readResult.SaveData.SchemaVersion != request.SchemaVersion ||
+                string.IsNullOrWhiteSpace(readResult.SaveData.UniqueId) ||
+                !string.Equals(readResult.SaveData.UniqueId, request.ExpectedGeneration.ProgressUniqueId,
+                    StringComparison.Ordinal))
+                return false;
+
+            try
+            {
+                _isPreparingCommitProjection = true;
+                var context = new DeserializationContext();
+                var progress = ProgressState.FromSerializable(readResult.SaveData, context);
+                if (context.Errors.Any(static error => error.IsFatal))
+                    return false;
+
+                var knownProjection = progress.ToSerializable();
+                knownProjection.SchemaVersion = request.SchemaVersion;
+                var knownProjectionJson = JsonSerializationUtility.ToJson(knownProjection);
+                proposed = new(
+                    readResult.SaveData.UniqueId,
+                    progress,
+                    knownProjectionJson,
+                    ComputeSha256(knownProjectionJson));
+                return true;
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn($"[RawProgress] Proposed document validation failed: {ex.Message}");
+                return false;
+            }
+            finally
+            {
+                _isPreparingCommitProjection = false;
+            }
+        }
+
+        private static bool TryInspectExistingDocument(
+            string? rawJson,
+            out int schema,
+            out string uniqueId,
+            out byte[] utf8Bytes)
+        {
+            schema = 0;
+            uniqueId = string.Empty;
+            utf8Bytes = [];
+            if (string.IsNullOrWhiteSpace(rawJson) ||
+                rawJson.Length > MaxDocumentUtf8Bytes ||
+                !TryGetUtf8Bytes(rawJson, out utf8Bytes) ||
+                utf8Bytes.LongLength > MaxDocumentUtf8Bytes ||
+                !TryValidateJsonShape(rawJson, out schema))
+                return false;
+
+            var readResult = JsonSerializationUtility.FromJson<SerializableProgress>(rawJson);
+            if (readResult is not { Success: true, SaveData: not null } ||
+                readResult.SaveData.SchemaVersion != schema ||
+                string.IsNullOrWhiteSpace(readResult.SaveData.UniqueId))
+                return false;
+
+            uniqueId = readResult.SaveData.UniqueId;
+            return true;
+        }
+
+        private static bool TryValidateJsonShape(string json, out int schema)
+        {
+            schema = 0;
+            try
+            {
+                using var document = JsonDocument.Parse(json, new()
+                {
+                    AllowTrailingCommas = false,
+                    CommentHandling = JsonCommentHandling.Disallow,
+                    MaxDepth = 128,
+                });
+                if (document.RootElement.ValueKind != JsonValueKind.Object ||
+                    !document.RootElement.TryGetProperty("schema_version", out var schemaElement) ||
+                    !schemaElement.TryGetInt32(out schema) ||
+                    schema < 1)
+                    return false;
+
+                return HasUniquePropertyNames(document.RootElement);
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static bool HasUniquePropertyNames(JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                {
+                    var propertyNames = new HashSet<string>(StringComparer.Ordinal);
+                    foreach (var property in element.EnumerateObject())
+                        if (!propertyNames.Add(property.Name) || !HasUniquePropertyNames(property.Value))
+                            return false;
+                    break;
+                }
+                case JsonValueKind.Array:
+                    foreach (var item in element.EnumerateArray())
+                        if (!HasUniquePropertyNames(item))
+                            return false;
+                    break;
+            }
+
+            return true;
+        }
+
+        private static bool TryReadSchema(string json, out int schema)
+        {
+            return TryValidateJsonShape(json, out schema);
+        }
+
+        private static bool GenerationMatches(ProgressGeneration actual, ProgressGeneration expected)
+        {
+            return actual.ProfileId == expected.ProfileId &&
+                   actual.IsModded == expected.IsModded &&
+                   string.Equals(actual.ProgressUniqueId, expected.ProgressUniqueId, StringComparison.Ordinal) &&
+                   HashEquals(actual.LocalSha256, expected.LocalSha256) &&
+                   actual.LocalLength == expected.LocalLength &&
+                   actual.LocalLastModifiedUtcTicks == expected.LocalLastModifiedUtcTicks &&
+                   actual.CloudAvailable == expected.CloudAvailable &&
+                   actual.CloudSyncEnabled == expected.CloudSyncEnabled &&
+                   actual.CloudPersisted == expected.CloudPersisted &&
+                   HashEquals(actual.CloudSha256, expected.CloudSha256) &&
+                   actual.CloudLength == expected.CloudLength &&
+                   actual.CloudLastModifiedUtcTicks == expected.CloudLastModifiedUtcTicks;
+        }
+
+        private static (CloudReadBackStatus Status, string? Hash) VerifyCloudReadBack(
+            ISaveStore saveStore,
+            string path,
+            string expectedHash,
+            bool batchFailure)
+        {
+            if (saveStore is not CloudSaveStore cloudSaveStore)
+                return (CloudReadBackStatus.NotRequired, null);
+            if (batchFailure)
+                return (CloudReadBackStatus.FailureObserved, null);
+
+            try
+            {
+                var cloudStore = cloudSaveStore.CloudStore;
+                if (!cloudStore.IsFilePersisted(path))
+                    return (CloudReadBackStatus.Unavailable, null);
+
+                var cloudJson = cloudStore.ReadFile(path);
+                if (cloudJson == null || !TryGetUtf8Bytes(cloudJson, out var cloudBytes))
+                    return (CloudReadBackStatus.Unavailable, null);
+
+                var cloudHash = ComputeSha256(cloudBytes);
+                return HashEquals(cloudHash, expectedHash)
+                    ? (CloudReadBackStatus.Succeeded, cloudHash)
+                    : (CloudReadBackStatus.Mismatch, cloudHash);
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn($"[RawProgress] Cloud read-back failed: {ex.Message}");
+                return (CloudReadBackStatus.FailureObserved, null);
+            }
+        }
+
+        private static bool VerifyGameBackup(ISaveStore localStore, string path, string originalRawJson)
+        {
+            try
+            {
+                var backup = localStore.ReadFile(path + ".backup");
+                return backup != null && HashEquals(ComputeSha256(backup), ComputeSha256(originalRawJson));
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn($"[RawProgress] Could not verify the game backup: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static RawProgressCommitResult MapCaptureFailure(RawProgressReadOutcome outcome)
+        {
+            return outcome switch
+            {
+                RawProgressReadOutcome.ActiveProfileUnavailable =>
+                    CreateResult(RawProgressCommitOutcome.ActiveProfileChanged),
+                RawProgressReadOutcome.SchemaUnsupported =>
+                    CreateResult(RawProgressCommitOutcome.SchemaUnsupported),
+                _ => CreateResult(RawProgressCommitOutcome.GenerationConflict),
+            };
+        }
+
+        private static RawProgressCommitResult CreateResult(
+            RawProgressCommitOutcome outcome,
+            string? localReadBackSha256 = null,
+            CloudReadBackStatus cloudStatus = CloudReadBackStatus.NotRequired,
+            string? cloudReadBackSha256 = null,
+            string? liveKnownProjectionSha256 = null,
+            bool unknownJsonContinuationInstalled = false,
+            string? preservedRawSha256 = null,
+            bool destinationMayHaveChanged = false,
+            bool verifiedBackupAvailable = false,
+            bool recoveryJournalRetained = false)
+        {
+            return new()
+            {
+                Outcome = outcome,
+                LocalReadBackSha256 = localReadBackSha256,
+                CloudStatus = cloudStatus,
+                CloudReadBackSha256 = cloudReadBackSha256,
+                LiveKnownProjectionSha256 = liveKnownProjectionSha256,
+                UnknownJsonContinuationInstalled = unknownJsonContinuationInstalled,
+                PreservedRawSha256 = preservedRawSha256,
+                DestinationMayHaveChanged = destinationMayHaveChanged,
+                VerifiedBackupAvailable = verifiedBackupAvailable,
+                RecoveryJournalRetained = recoveryJournalRetained,
+            };
+        }
+
+        private static bool TryGetCompletedTransaction(
+            RawProgressCommitRequest request,
+            out RawProgressCommitResult result)
+        {
+            if (!CompletedTransactions.TryGetValue(request.TransactionId, out var completed))
+            {
+                result = null!;
+                return false;
+            }
+
+            result = HashEquals(completed.ProposedSha256, request.ProposedSha256)
+                ? completed.Result
+                : CreateResult(RawProgressCommitOutcome.ValidationFailed);
+            return true;
+        }
+
+        private static RawProgressCommitResult Remember(
+            RawProgressCommitRequest request,
+            RawProgressCommitResult result)
+        {
+            if (!CompletedTransactions.ContainsKey(request.TransactionId))
+            {
+                CompletedTransactions.Add(request.TransactionId, new(request.ProposedSha256, result));
+                CompletedTransactionOrder.Enqueue(request.TransactionId);
+                while (CompletedTransactionOrder.Count > 256)
+                    CompletedTransactions.Remove(CompletedTransactionOrder.Dequeue());
+            }
+
+            return result;
+        }
+
+        private static ISaveStore GetLocalStore(ISaveStore saveStore)
+        {
+            return saveStore is CloudSaveStore cloudSaveStore ? cloudSaveStore.LocalStore : saveStore;
+        }
+
+        private static string GetProgressPath(int profileId, bool isModded)
+        {
+#if STS2_AT_LEAST_0_110_0
+            return ProgressSaveManager.GetProgressPathForProfile(profileId, isModded);
+#else
+            return ProgressSaveManager.GetProgressPathForProfile(profileId);
+#endif
+        }
+
+        private static bool TryGetUtf8Bytes(string value, out byte[] bytes)
+        {
+            try
+            {
+                bytes = StrictUtf8.GetBytes(value);
+                return true;
+            }
+            catch (EncoderFallbackException)
+            {
+                bytes = [];
+                return false;
+            }
+        }
+
+        private static string ComputeSha256(string value)
+        {
+            return ComputeSha256(StrictUtf8.GetBytes(value));
+        }
+
+        private static string ComputeSha256(byte[] bytes)
+        {
+            return Convert.ToHexStringLower(SHA256.HashData(bytes));
+        }
+
+        private static bool IsSha256(string value)
+        {
+            return value.Length == 64 && value.All(static character =>
+                character is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F');
+        }
+
+        private static bool HashEquals(string? left, string? right)
+        {
+            return string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetRecoveryDirectory()
+        {
+            return $"{ProfileManager.GetAccountBasePath()}/{RecoveryDirectoryName}";
+        }
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_saveStore")]
+        private static extern ref readonly ISaveStore SaveStore(SaveManager manager);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_saveStore")]
+        private static extern ref readonly ISaveStore SaveStore(ProgressSaveManager manager);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_migrationManager")]
+        private static extern ref readonly MigrationManager MigrationManager(ProgressSaveManager manager);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_profileIdProvider")]
+        private static extern ref readonly IProfileIdProvider ProfileIdProvider(ProgressSaveManager manager);
+
+        internal sealed record LoadCapture(string RawJson);
+
+        private sealed record CapturedProgress(
+            RawProgressReadResult Result,
+            SaveManager? SaveManager = null,
+            ISaveStore? Store = null,
+            string? Path = null);
+
+        private sealed record ValidatedDocument(
+            string ProgressUniqueId,
+            ProgressState Progress,
+            string KnownProjectionJson,
+            string KnownProjectionSha256);
+
+        private sealed record CompletedTransaction(string ProposedSha256, RawProgressCommitResult Result);
+
+        private sealed record RecoveryJournalData
+        {
+            public required int JournalProtocolVersion { get; init; }
+            public required Guid TransactionId { get; init; }
+            public required int ProfileId { get; init; }
+            public required bool IsModded { get; init; }
+            public required string ProgressUniqueId { get; init; }
+            public required string Stage { get; init; }
+            public required string OriginalRawJson { get; init; }
+            public required string OriginalSha256 { get; init; }
+            public required string ProposedSha256 { get; init; }
+            public string? LocalReadBackSha256 { get; init; }
+            public string? CloudReadBackSha256 { get; init; }
+            public string? LiveKnownProjectionSha256 { get; init; }
+        }
+
+        private sealed class RecoveryJournal
+        {
+            private RecoveryJournal(string path, RecoveryJournalData data)
+            {
+                Path = path;
+                Data = data;
+            }
+
+            private string Path { get; }
+            private RecoveryJournalData Data { get; set; }
+            internal bool Exists => FileOperations.FileExists(Path) || FileOperations.FileExists(Path + ".backup");
+
+            internal static RecoveryJournal Create(RawProgressCommitRequest request, string originalRawJson)
+            {
+                var path = $"{GetRecoveryDirectory()}/{request.TransactionId:N}.json";
+                return new(path, new()
+                {
+                    JournalProtocolVersion = ProtocolVersion,
+                    TransactionId = request.TransactionId,
+                    ProfileId = request.ExpectedGeneration.ProfileId,
+                    IsModded = request.ExpectedGeneration.IsModded,
+                    ProgressUniqueId = request.ExpectedGeneration.ProgressUniqueId,
+                    Stage = "prepared",
+                    OriginalRawJson = originalRawJson,
+                    OriginalSha256 = ComputeSha256(originalRawJson),
+                    ProposedSha256 = request.ProposedSha256,
+                });
+            }
+
+            internal bool TryPrepare()
+            {
+                if (Exists || CountRetainedJournals() >= MaxRetainedRecoveryJournals)
+                    return false;
+
+                return TryWrite();
+            }
+
+            internal void TryUpdate(
+                string stage,
+                string? localReadBackSha256,
+                string? cloudReadBackSha256,
+                string? liveKnownProjectionSha256)
+            {
+                Data = Data with
+                {
+                    Stage = stage,
+                    LocalReadBackSha256 = localReadBackSha256,
+                    CloudReadBackSha256 = cloudReadBackSha256,
+                    LiveKnownProjectionSha256 = liveKnownProjectionSha256,
+                };
+                TryWrite();
+            }
+
+            internal bool TryDelete()
+            {
+                var primary = FileOperations.DeleteFile(Path, RecoveryLogContext);
+                var backup = FileOperations.DeleteFile(Path + ".backup", RecoveryLogContext);
+                var temporary = FileOperations.DeleteFile(Path + ".tmp", RecoveryLogContext);
+                return primary.Success && backup.Success && temporary.Success && !Exists;
+            }
+
+            private bool TryWrite()
+            {
+                try
+                {
+                    var json = JsonSerializer.Serialize(Data, JournalJsonOptions);
+                    return FileOperations.WriteText(Path, json, RecoveryLogContext).Success;
+                }
+                catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+                {
+                    RitsuLibFramework.Logger.ErrorNoTrace(
+                        $"[RawProgress] Failed to serialize recovery metadata: {ex.Message}");
+                    return false;
+                }
+            }
+
+            private static int CountRetainedJournals()
+            {
+                try
+                {
+                    using var directory = DirAccess.Open(GetRecoveryDirectory());
+                    return directory?.GetFiles().Count(static file =>
+                        file.EndsWith(".json", StringComparison.OrdinalIgnoreCase)) ?? 0;
+                }
+                catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+                {
+                    RitsuLibFramework.Logger.Warn(
+                        $"[RawProgress] Failed to count retained recovery journals: {ex.Message}");
+                    return MaxRetainedRecoveryJournals;
+                }
+            }
+        }
+    }
+}

--- a/src/Saves/RawProgress/RawProgressCommitBridge.cs
+++ b/src/Saves/RawProgress/RawProgressCommitBridge.cs
@@ -20,23 +20,19 @@ namespace STS2RitsuLib.Saves.RawProgress
     {
         internal const int ProtocolVersion = 1;
         internal const long MaxDocumentUtf8Bytes = 16 * 1024 * 1024;
+        internal const int MaxRecoveryOwnerIdUtf8Bytes = 256;
         private const int MaxRetainedRecoveryJournals = 8;
+        private const int MaxRecoveryDirectoryFiles = 128;
+        private const int MaxQuarantinedRecoveryFiles = 64;
+        private const long MaxQuarantinedRecoveryBytes = 64 * 1024 * 1024;
         private const string RecoveryLogContext = "RawProgressRecovery";
         private const string RecoveryDirectoryName = "recovery/raw-progress";
-
-#if STS2_AT_LEAST_0_110_0
-        internal const int SupportedSchema = 24;
-#elif STS2_AT_LEAST_0_108_0
-        internal const int SupportedSchema = 22;
-#else
-        internal const int SupportedSchema = 21;
-#endif
+        private const string RecoveryQuarantineDirectoryName = "recovery/raw-progress-quarantine";
 
         private static readonly object SaveWindow = new();
         private static readonly UTF8Encoding StrictUtf8 = new(false, true);
-        private static readonly FrozenSet<int> SupportedSchemas = new[] { SupportedSchema }.ToFrozenSet();
-        private static readonly Dictionary<Guid, CompletedTransaction> CompletedTransactions = [];
-        private static readonly Queue<Guid> CompletedTransactionOrder = [];
+        private static readonly Dictionary<RecoveryTransactionKey, CompletedTransaction> CompletedTransactions = [];
+        private static readonly Queue<RecoveryTransactionKey> CompletedTransactionOrder = [];
 
         private static readonly JsonSerializerOptions JournalJsonOptions = new()
         {
@@ -45,50 +41,55 @@ namespace STS2RitsuLib.Saves.RawProgress
             UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
         };
 
-        [ThreadStatic] private static bool _isPreparingCommitProjection;
+        [field: ThreadStatic] internal static bool IsPreparingCommitProjection { get; private set; }
 
-        private readonly RawProgressBridgeDescriptor _descriptor;
+        private readonly RawProgressBridgeFeature _features;
 
         private RawProgressCommitBridge()
         {
-            var features = RawProgressBridgeFeature.UnknownJsonPassThrough |
-                           RawProgressBridgeFeature.LiveGameStoreCommit |
-                           RawProgressBridgeFeature.DurableLocalReplacement |
-                           RawProgressBridgeFeature.CloudSaveBatch |
-                           RawProgressBridgeFeature.ConditionalGenerationCheck |
-                           RawProgressBridgeFeature.ExclusiveSaveWindow |
-                           RawProgressBridgeFeature.LocalOnlyRecoveryJournal |
-                           RawProgressBridgeFeature.StructuredRecoveryOutcome |
-                           RawProgressBridgeFeature.StablePublicContract |
-                           RawProgressBridgeFeature.CloudReadBackVerification |
-                           RawProgressBridgeFeature.LiveProgressStateSynchronization |
-                           RawProgressBridgeFeature.SubsequentSaveUnknownJsonPreservation |
-                           RawProgressBridgeFeature.ActiveProgressSnapshot |
-                           RawProgressBridgeFeature.RecoveryJournalManagement;
-
 #if !STS2_AT_LEAST_0_108_0
-            features |= RawProgressBridgeFeature.RawSchema21Document;
+            const RawProgressBridgeFeature schemaFeatures = RawProgressBridgeFeature.RawSchema21Document;
+#else
+            const RawProgressBridgeFeature schemaFeatures = 0;
 #endif
+            const RawProgressBridgeFeature features = RawProgressBridgeFeature.UnknownJsonPassThrough |
+                                                      RawProgressBridgeFeature.LiveGameStoreCommit |
+                                                      RawProgressBridgeFeature.DurableLocalReplacement |
+                                                      RawProgressBridgeFeature.CloudSaveBatch |
+                                                      RawProgressBridgeFeature.ConditionalGenerationCheck |
+                                                      RawProgressBridgeFeature.ExclusiveSaveWindow |
+                                                      RawProgressBridgeFeature.LocalOnlyRecoveryJournal |
+                                                      RawProgressBridgeFeature.StructuredRecoveryOutcome |
+                                                      RawProgressBridgeFeature.StablePublicContract |
+                                                      RawProgressBridgeFeature.CloudReadBackVerification |
+                                                      RawProgressBridgeFeature.LiveProgressStateSynchronization |
+                                                      RawProgressBridgeFeature.SubsequentSaveUnknownJsonPreservation |
+                                                      RawProgressBridgeFeature.ActiveProgressSnapshot |
+                                                      RawProgressBridgeFeature.RecoveryJournalManagement |
+                                                      RawProgressBridgeFeature.RecoveryJournalOwnership |
+                                                      RawProgressBridgeFeature.RecoveryJournalDisposition |
+                                                      RawProgressBridgeFeature.InvalidRecoveryJournalQuarantine |
+                                                      schemaFeatures;
 
-            _descriptor = new()
-            {
-                ProviderId = Const.ModId,
-                ProviderVersion = Version.Parse(Const.Version),
-                ProtocolVersion = ProtocolVersion,
-                SupportedSchemas = SupportedSchemas,
-                Features = features,
-                MaxDocumentUtf8Bytes = MaxDocumentUtf8Bytes,
-                MaxRetainedRecoveryJournals = MaxRetainedRecoveryJournals,
-            };
+            _features = features;
         }
 
         internal static RawProgressCommitBridge Instance { get; } = new();
 
-        internal static bool IsPreparingCommitProjection => _isPreparingCommitProjection;
-
         public RawProgressBridgeDescriptor Describe()
         {
-            return _descriptor;
+            var supportedSchema = GetSupportedSchema(SaveManager.Instance);
+            return new()
+            {
+                ProviderId = Const.ModId,
+                ProviderVersion = Version.Parse(Const.Version),
+                ProtocolVersion = ProtocolVersion,
+                SupportedSchemas = new[] { supportedSchema }.ToFrozenSet(),
+                Features = _features,
+                MaxDocumentUtf8Bytes = MaxDocumentUtf8Bytes,
+                MaxRetainedRecoveryJournals = MaxRetainedRecoveryJournals,
+                MaxRecoveryOwnerIdUtf8Bytes = MaxRecoveryOwnerIdUtf8Bytes,
+            };
         }
 
         public ValueTask<RawProgressReadResult> CaptureAsync(CancellationToken cancellationToken = default)
@@ -110,19 +111,25 @@ namespace STS2RitsuLib.Saves.RawProgress
         {
             ArgumentNullException.ThrowIfNull(request);
 
-            return new(RitsuMainThread.InvokeAsync(() => CommitOnMainThread(request, cancellationToken)));
+            return new(RitsuMainThread.InvokeAsync(
+                () => CommitOnMainThread(request, cancellationToken),
+                cancellationToken));
         }
 
         public ValueTask<RawProgressRecoveryReadResult> GetPendingRecoveriesAsync(
+            string ownerId,
             CancellationToken cancellationToken = default)
         {
+            if (!IsValidOwnerId(ownerId))
+                throw new ArgumentException("The recovery owner identifier is invalid.", nameof(ownerId));
+
             return new(RitsuMainThread.InvokeAsync(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 lock (SaveWindow)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    return RecoveryJournal.ReadAll();
+                    return RecoveryJournal.ReadAll(ownerId);
                 }
             }, cancellationToken));
         }
@@ -133,7 +140,20 @@ namespace STS2RitsuLib.Saves.RawProgress
         {
             ArgumentNullException.ThrowIfNull(request);
 
-            return new(RitsuMainThread.InvokeAsync(() => RestoreRecoveryOnMainThread(request, cancellationToken)));
+            return new(RitsuMainThread.InvokeAsync(
+                () => RestoreRecoveryOnMainThread(request, cancellationToken),
+                cancellationToken));
+        }
+
+        public ValueTask<RawProgressRecoveryDiscardResult> DiscardRecoveryAsync(
+            RawProgressRecoveryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            return new(RitsuMainThread.InvokeAsync(
+                () => DiscardRecoveryOnMainThread(request, cancellationToken),
+                cancellationToken));
         }
 
         internal static void SaveOrdinaryProgress(ProgressSaveManager manager)
@@ -189,14 +209,15 @@ namespace STS2RitsuLib.Saves.RawProgress
                 if (capture == null || result is not { Success: true, SaveData: not null })
                     return;
 
-                if (!TryReadSchema(capture.RawJson, out var rawSchema) || rawSchema != SupportedSchema)
+                var supportedSchema = MigrationManager(manager).GetLatestVersion<SerializableProgress>();
+                if (!TryReadSchema(capture.RawJson, out var rawSchema) || rawSchema != supportedSchema)
                     return;
 
                 var rawReadResult = JsonSerializationUtility.FromJson<SerializableProgress>(capture.RawJson);
                 if (rawReadResult is not { Success: true, SaveData: not null })
                     return;
 
-                rawReadResult.SaveData.SchemaVersion = SupportedSchema;
+                rawReadResult.SaveData.SchemaVersion = supportedSchema;
                 var knownJson = JsonSerializationUtility.ToJson(rawReadResult.SaveData);
                 if (!RawProgressJsonPreservation.TryAttach(manager.Progress, capture.RawJson, knownJson))
                     RitsuLibFramework.Logger.Warn(
@@ -229,9 +250,9 @@ namespace STS2RitsuLib.Saves.RawProgress
             RawProgressCommitRequest request,
             CancellationToken cancellationToken)
         {
-            if (request.ProtocolVersion != ProtocolVersion)
+            if (request.ProtocolVersion != ProtocolVersion || !TryGetSupportedSchema(out var supportedSchema))
                 return CreateResult(RawProgressCommitOutcome.ProviderIncompatible);
-            if (request.SchemaVersion != SupportedSchema)
+            if (request.SchemaVersion != supportedSchema)
                 return CreateResult(RawProgressCommitOutcome.SchemaUnsupported);
             if (cancellationToken.IsCancellationRequested)
                 return CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit);
@@ -289,7 +310,7 @@ namespace STS2RitsuLib.Saves.RawProgress
             RawProgressRecoveryRequest request,
             CancellationToken cancellationToken)
         {
-            if (request.TransactionId == Guid.Empty || request.ExpectedGeneration == null)
+            if (!IsValidRecoveryRequest(request))
                 return CreateResult(RawProgressCommitOutcome.ValidationFailed);
             if (cancellationToken.IsCancellationRequested)
                 return CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit);
@@ -299,13 +320,29 @@ namespace STS2RitsuLib.Saves.RawProgress
                 if (cancellationToken.IsCancellationRequested)
                     return CreateResult(RawProgressCommitOutcome.CancelledBeforeCommit);
 
-                var loadOutcome = RecoveryJournal.TryLoad(request.TransactionId, out var journal);
+                var loadOutcome = RecoveryJournal.TryLoad(request.OwnerId, request.TransactionId, out var journal);
                 if (loadOutcome == RecoveryJournalLoadOutcome.NotFound)
                     return CreateResult(RawProgressCommitOutcome.RecoveryJournalNotFound);
                 if (loadOutcome != RecoveryJournalLoadOutcome.Succeeded || journal == null)
                     return CreateResult(RawProgressCommitOutcome.RecoveryJournalInvalid);
+                if (!HashEquals(journal.RecoveryToken, request.RecoveryToken))
+                    return CreateResult(
+                        RawProgressCommitOutcome.RecoveryJournalChanged,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
 
                 var data = journal.Data;
+                if (!TryGetSupportedSchema(out var supportedSchema))
+                    return CreateResult(
+                        RawProgressCommitOutcome.ProviderIncompatible,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+                if (data.SchemaVersion != supportedSchema)
+                    return CreateResult(
+                        RawProgressCommitOutcome.SchemaUnsupported,
+                        verifiedBackupAvailable: true,
+                        recoveryJournalRetained: journal.Exists);
+
                 var expected = request.ExpectedGeneration;
                 if (data.ProfileId != expected.ProfileId || data.IsModded != expected.IsModded ||
                     !string.Equals(data.ProgressUniqueId, expected.ProgressUniqueId, StringComparison.Ordinal))
@@ -348,7 +385,8 @@ namespace STS2RitsuLib.Saves.RawProgress
                 var validationRequest = new RawProgressCommitRequest
                 {
                     ProtocolVersion = ProtocolVersion,
-                    SchemaVersion = SupportedSchema,
+                    SchemaVersion = data.SchemaVersion,
+                    OwnerId = data.OwnerId,
                     TransactionId = data.TransactionId,
                     ExpectedGeneration = expected,
                     ProposedRawJson = data.OriginalRawJson,
@@ -370,6 +408,70 @@ namespace STS2RitsuLib.Saves.RawProgress
             }
         }
 
+        private static RawProgressRecoveryDiscardResult DiscardRecoveryOnMainThread(
+            RawProgressRecoveryRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!IsValidRecoveryRequest(request))
+                return CreateDiscardResult(RawProgressRecoveryDiscardOutcome.ValidationFailed);
+            if (cancellationToken.IsCancellationRequested)
+                return CreateDiscardResult(RawProgressRecoveryDiscardOutcome.Cancelled);
+
+            lock (SaveWindow)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return CreateDiscardResult(RawProgressRecoveryDiscardOutcome.Cancelled);
+
+                var loadOutcome = RecoveryJournal.TryLoad(request.OwnerId, request.TransactionId, out var journal);
+                if (loadOutcome == RecoveryJournalLoadOutcome.NotFound)
+                    return CreateDiscardResult(RawProgressRecoveryDiscardOutcome.RecoveryJournalNotFound);
+                if (loadOutcome != RecoveryJournalLoadOutcome.Succeeded || journal == null)
+                    return CreateDiscardResult(RawProgressRecoveryDiscardOutcome.RecoveryJournalInvalid);
+                if (!HashEquals(journal.RecoveryToken, request.RecoveryToken))
+                    return CreateDiscardResult(
+                        RawProgressRecoveryDiscardOutcome.RecoveryJournalChanged,
+                        journal.Exists);
+
+                var data = journal.Data;
+                var expected = request.ExpectedGeneration;
+                if (data.ProfileId != expected.ProfileId || data.IsModded != expected.IsModded ||
+                    !string.Equals(data.ProgressUniqueId, expected.ProgressUniqueId, StringComparison.Ordinal))
+                    return CreateDiscardResult(
+                        RawProgressRecoveryDiscardOutcome.ActiveProfileChanged,
+                        journal.Exists);
+
+                var current = CaptureCore();
+                if (current.Result.Outcome != RawProgressReadOutcome.Succeeded || current.Result.Snapshot == null)
+                    return CreateDiscardResult(
+                        current.Result.Outcome == RawProgressReadOutcome.ActiveProfileUnavailable
+                            ? RawProgressRecoveryDiscardOutcome.ActiveProfileChanged
+                            : RawProgressRecoveryDiscardOutcome.DestinationUnavailable,
+                        journal.Exists);
+
+                var currentGeneration = current.Result.Snapshot.Generation;
+                if (currentGeneration.ProfileId != data.ProfileId || currentGeneration.IsModded != data.IsModded ||
+                    !string.Equals(currentGeneration.ProgressUniqueId, data.ProgressUniqueId, StringComparison.Ordinal))
+                    return CreateDiscardResult(
+                        RawProgressRecoveryDiscardOutcome.ActiveProfileChanged,
+                        journal.Exists);
+                if (!GenerationMatches(currentGeneration, expected))
+                    return CreateDiscardResult(
+                        RawProgressRecoveryDiscardOutcome.GenerationConflict,
+                        journal.Exists);
+                if (cancellationToken.IsCancellationRequested)
+                    return CreateDiscardResult(
+                        RawProgressRecoveryDiscardOutcome.Cancelled,
+                        journal.Exists);
+
+                var discarded = journal.TryDelete();
+                return CreateDiscardResult(
+                    discarded
+                        ? RawProgressRecoveryDiscardOutcome.Discarded
+                        : RawProgressRecoveryDiscardOutcome.StorageFailure,
+                    journal.Exists);
+            }
+        }
+
         private static RawProgressCommitResult CommitPrepared(
             string proposedRawJson,
             string proposedSha256,
@@ -380,7 +482,7 @@ namespace STS2RitsuLib.Saves.RawProgress
             var destinationMayHaveChanged = false;
             var localVerified = false;
             var batchFailure = false;
-            var localReadBackHash = (string?)null;
+            string? localReadBackHash = null;
             var cloudStatus = CloudReadBackStatus.NotRequired;
             var saveManager = current.SaveManager!;
             var saveStore = current.Store!;
@@ -432,11 +534,13 @@ namespace STS2RitsuLib.Saves.RawProgress
             }
 
             journal.TryUpdate("local_verified", localReadBackHash, null, null);
-            var cloudReadBack = VerifyCloudReadBack(saveStore, path, proposedSha256, batchFailure);
-            cloudStatus = cloudReadBack.Status;
-            var cloudReadBackHash = cloudReadBack.Hash;
+            (cloudStatus, var cloudReadBackHash) = VerifyCloudReadBack(
+                saveStore,
+                path,
+                proposedSha256,
+                batchFailure);
 
-            var liveProjectionHash = (string?)null;
+            string? liveProjectionHash = null;
             var continuationInstalled = false;
             try
             {
@@ -447,7 +551,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                     proposed.KnownProjectionJson);
 
                 var liveSerializable = saveManager.Progress.ToSerializable();
-                liveSerializable.SchemaVersion = SupportedSchema;
+                liveSerializable.SchemaVersion = current.Result.Snapshot!.SchemaVersion;
                 liveProjectionHash = ComputeSha256(JsonSerializationUtility.ToJson(liveSerializable));
             }
             catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
@@ -456,17 +560,19 @@ namespace STS2RitsuLib.Saves.RawProgress
                     $"[RawProgress] Failed to synchronize the live progress projection: {ex.Message}");
             }
 
-            RawProgressCommitOutcome outcome;
-            if (!HashEquals(liveProjectionHash, proposed.KnownProjectionSha256))
-                outcome = RawProgressCommitOutcome.LiveProgressStateUnverified;
-            else if (!continuationInstalled)
-                outcome = RawProgressCommitOutcome.UnknownJsonContinuationUnverified;
-            else if (cloudStatus is CloudReadBackStatus.Unavailable or CloudReadBackStatus.FailureObserved)
-                outcome = RawProgressCommitOutcome.CloudReadBackUnverifiedLocalPreserved;
-            else if (cloudStatus == CloudReadBackStatus.Mismatch)
-                outcome = RawProgressCommitOutcome.CloudReadBackMismatchLocalPreserved;
-            else
-                outcome = RawProgressCommitOutcome.CommittedVerified;
+            var outcome = (
+                    LiveProjectionMatches: HashEquals(liveProjectionHash, proposed.KnownProjectionSha256),
+                    ContinuationInstalled: continuationInstalled,
+                    CloudStatus: cloudStatus) switch
+                {
+                    { LiveProjectionMatches: false } => RawProgressCommitOutcome.LiveProgressStateUnverified,
+                    { ContinuationInstalled: false } => RawProgressCommitOutcome.UnknownJsonContinuationUnverified,
+                    { CloudStatus: CloudReadBackStatus.Unavailable or CloudReadBackStatus.FailureObserved } =>
+                        RawProgressCommitOutcome.CloudReadBackUnverifiedLocalPreserved,
+                    { CloudStatus: CloudReadBackStatus.Mismatch } =>
+                        RawProgressCommitOutcome.CloudReadBackMismatchLocalPreserved,
+                    _ => RawProgressCommitOutcome.CommittedVerified,
+                };
 
             if (outcome == RawProgressCommitOutcome.CommittedVerified)
             {
@@ -496,10 +602,12 @@ namespace STS2RitsuLib.Saves.RawProgress
         {
             SaveManager saveManager;
             int profileId;
+            int supportedSchema;
             try
             {
                 saveManager = SaveManager.Instance;
                 profileId = saveManager.CurrentProfileId;
+                supportedSchema = GetSupportedSchema(saveManager);
             }
             catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
             {
@@ -533,7 +641,7 @@ namespace STS2RitsuLib.Saves.RawProgress
 
             if (!TryInspectExistingDocument(rawJson, out var schema, out var uniqueId, out var localBytes))
                 return new(new() { Outcome = RawProgressReadOutcome.ValidationFailed });
-            if (schema != SupportedSchema)
+            if (schema != supportedSchema)
                 return new(new() { Outcome = RawProgressReadOutcome.SchemaUnsupported });
 
             try
@@ -610,7 +718,8 @@ namespace STS2RitsuLib.Saves.RawProgress
             out ValidatedDocument proposed)
         {
             proposed = null!;
-            if (request.TransactionId == Guid.Empty ||
+            if (!IsValidOwnerId(request.OwnerId) ||
+                request.TransactionId == Guid.Empty ||
                 request.ExpectedGeneration == null ||
                 request.ProposedRawJson == null ||
                 request.ProposedSha256 == null ||
@@ -638,7 +747,7 @@ namespace STS2RitsuLib.Saves.RawProgress
 
             try
             {
-                _isPreparingCommitProjection = true;
+                IsPreparingCommitProjection = true;
                 var context = new DeserializationContext();
                 var progress = ProgressState.FromSerializable(readResult.SaveData, context);
                 if (context.Errors.Any(static error => error.IsFatal))
@@ -661,7 +770,7 @@ namespace STS2RitsuLib.Saves.RawProgress
             }
             finally
             {
-                _isPreparingCommitProjection = false;
+                IsPreparingCommitProjection = false;
             }
         }
 
@@ -723,12 +832,14 @@ namespace STS2RitsuLib.Saves.RawProgress
                 case JsonValueKind.Object:
                 {
                     var propertyNames = new HashSet<string>(StringComparer.Ordinal);
+                    // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
                     foreach (var property in element.EnumerateObject())
                         if (!propertyNames.Add(property.Name) || !HasUniquePropertyNames(property.Value))
                             return false;
                     break;
                 }
                 case JsonValueKind.Array:
+                    // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
                     foreach (var item in element.EnumerateArray())
                         if (!HasUniquePropertyNames(item))
                             return false;
@@ -845,11 +956,23 @@ namespace STS2RitsuLib.Saves.RawProgress
             };
         }
 
+        private static RawProgressRecoveryDiscardResult CreateDiscardResult(
+            RawProgressRecoveryDiscardOutcome outcome,
+            bool recoveryJournalRetained = false)
+        {
+            return new()
+            {
+                Outcome = outcome,
+                RecoveryJournalRetained = recoveryJournalRetained,
+            };
+        }
+
         private static bool TryGetCompletedTransaction(
             RawProgressCommitRequest request,
             out RawProgressCommitResult result)
         {
-            if (!CompletedTransactions.TryGetValue(request.TransactionId, out var completed))
+            var key = new RecoveryTransactionKey(request.OwnerId, request.TransactionId);
+            if (!CompletedTransactions.TryGetValue(key, out var completed))
             {
                 result = null!;
                 return false;
@@ -865,10 +988,11 @@ namespace STS2RitsuLib.Saves.RawProgress
             RawProgressCommitRequest request,
             RawProgressCommitResult result)
         {
-            if (!CompletedTransactions.ContainsKey(request.TransactionId))
+            var key = new RecoveryTransactionKey(request.OwnerId, request.TransactionId);
+            if (!CompletedTransactions.ContainsKey(key))
             {
-                CompletedTransactions.Add(request.TransactionId, new(request.ProposedSha256, result));
-                CompletedTransactionOrder.Enqueue(request.TransactionId);
+                CompletedTransactions.Add(key, new(request.ProposedSha256, result));
+                CompletedTransactionOrder.Enqueue(key);
                 while (CompletedTransactionOrder.Count > 256)
                     CompletedTransactions.Remove(CompletedTransactionOrder.Dequeue());
             }
@@ -879,6 +1003,27 @@ namespace STS2RitsuLib.Saves.RawProgress
         private static ISaveStore GetLocalStore(ISaveStore saveStore)
         {
             return saveStore is CloudSaveStore cloudSaveStore ? cloudSaveStore.LocalStore : saveStore;
+        }
+
+        private static int GetSupportedSchema(SaveManager saveManager)
+        {
+            return saveManager.GetLatestSchemaVersion<SerializableProgress>();
+        }
+
+        private static bool TryGetSupportedSchema(out int supportedSchema)
+        {
+            try
+            {
+                supportedSchema = GetSupportedSchema(SaveManager.Instance);
+                return supportedSchema > 0;
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[RawProgress] Could not resolve the active progress schema: {ex.Message}");
+                supportedSchema = 0;
+                return false;
+            }
         }
 
         private static string GetProgressPath(int profileId, bool isModded)
@@ -902,6 +1047,30 @@ namespace STS2RitsuLib.Saves.RawProgress
                 bytes = [];
                 return false;
             }
+        }
+
+        private static bool IsValidOwnerId(string? ownerId)
+        {
+            return !string.IsNullOrWhiteSpace(ownerId) &&
+                   ownerId.Length <= MaxRecoveryOwnerIdUtf8Bytes &&
+                   string.Equals(ownerId, ownerId.Trim(), StringComparison.Ordinal) &&
+                   TryGetUtf8Bytes(ownerId, out var bytes) &&
+                   bytes.Length is > 0 and <= MaxRecoveryOwnerIdUtf8Bytes;
+        }
+
+        private static bool IsValidRecoveryRequest(RawProgressRecoveryRequest request)
+        {
+            return IsValidOwnerId(request.OwnerId) &&
+                   request.TransactionId != Guid.Empty &&
+                   request.RecoveryToken != null &&
+                   IsSha256(request.RecoveryToken) &&
+                   request.ExpectedGeneration is
+                   {
+                       ProfileId: >= 1 and <= 3,
+                   } expected &&
+                   !string.IsNullOrWhiteSpace(expected.ProgressUniqueId) &&
+                   expected.ProgressUniqueId.Length <= 256 &&
+                   IsSha256(expected.LocalSha256);
         }
 
         private static string ComputeSha256(string value)
@@ -928,6 +1097,26 @@ namespace STS2RitsuLib.Saves.RawProgress
         private static string GetRecoveryDirectory()
         {
             return $"{ProfileManager.GetAccountBasePath()}/{RecoveryDirectoryName}";
+        }
+
+        private static string ComputeOwnerStorageId(string ownerId)
+        {
+            return ComputeSha256(ownerId);
+        }
+
+        private static string GetRecoveryPath(string ownerId, Guid transactionId)
+        {
+            return GetRecoveryPath(new(ComputeOwnerStorageId(ownerId), transactionId));
+        }
+
+        private static string GetRecoveryPath(RecoveryJournalKey key)
+        {
+            return $"{GetRecoveryDirectory()}/{key.OwnerStorageId}-{key.TransactionId:N}.json";
+        }
+
+        private static string GetRecoveryQuarantineDirectory()
+        {
+            return $"{ProfileManager.GetAccountBasePath()}/{RecoveryQuarantineDirectoryName}";
         }
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_saveStore")]
@@ -958,6 +1147,10 @@ namespace STS2RitsuLib.Saves.RawProgress
 
         private sealed record CompletedTransaction(string ProposedSha256, RawProgressCommitResult Result);
 
+        private readonly record struct RecoveryTransactionKey(string OwnerId, Guid TransactionId);
+
+        private readonly record struct RecoveryJournalKey(string OwnerStorageId, Guid TransactionId);
+
         private enum RecoveryJournalLoadOutcome
         {
             Succeeded,
@@ -968,6 +1161,8 @@ namespace STS2RitsuLib.Saves.RawProgress
         private sealed record RecoveryJournalData
         {
             public required int JournalProtocolVersion { get; init; }
+            public required string OwnerId { get; init; }
+            public required int SchemaVersion { get; init; }
             public required Guid TransactionId { get; init; }
             public required int ProfileId { get; init; }
             public required bool IsModded { get; init; }
@@ -1000,16 +1195,20 @@ namespace STS2RitsuLib.Saves.RawProgress
             private bool CanUpdate { get; }
             internal RecoveryJournalData Data { get; private set; }
 
+            internal string RecoveryToken => ComputeSha256(JsonSerializer.Serialize(Data, JournalJsonOptions));
+
             internal bool Exists => FileOperations.FileExists(BasePath) ||
                                     FileOperations.FileExists(BasePath + ".backup") ||
                                     FileOperations.FileExists(BasePath + ".backup.backup");
 
             internal static RecoveryJournal Create(RawProgressCommitRequest request, string originalRawJson)
             {
-                var path = $"{GetRecoveryDirectory()}/{request.TransactionId:N}.json";
+                var path = GetRecoveryPath(request.OwnerId, request.TransactionId);
                 return new(path, path, new()
                 {
                     JournalProtocolVersion = ProtocolVersion,
+                    OwnerId = request.OwnerId,
+                    SchemaVersion = request.SchemaVersion,
                     TransactionId = request.TransactionId,
                     ProfileId = request.ExpectedGeneration.ProfileId,
                     IsModded = request.ExpectedGeneration.IsModded,
@@ -1021,20 +1220,26 @@ namespace STS2RitsuLib.Saves.RawProgress
                 });
             }
 
-            internal static RawProgressRecoveryReadResult ReadAll()
+            internal static RawProgressRecoveryReadResult ReadAll(string ownerId)
             {
-                if (!TryEnumerateTransactionIds(out var transactionIds, out var invalidEntryCount))
+                var ownerStorageId = ComputeOwnerStorageId(ownerId);
+                if (!TryEnumerateJournalKeys(out var journalKeys, out var invalidFiles))
                     return new()
                     {
+                        OwnerId = ownerId,
                         Outcome = RawProgressRecoveryReadOutcome.StorageUnavailable,
                         Records = [],
-                        InvalidEntryCount = invalidEntryCount,
+                        InvalidEntryCount = CountInvalidOwnerFiles(invalidFiles, ownerStorageId),
                     };
 
-                var records = new List<RawProgressRecoveryRecord>(transactionIds.Count);
-                foreach (var transactionId in transactionIds)
+                var ownerKeys = journalKeys
+                    .Where(key => string.Equals(key.OwnerStorageId, ownerStorageId, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+                var invalidEntryCount = CountInvalidOwnerFiles(invalidFiles, ownerStorageId);
+                var records = new List<RawProgressRecoveryRecord>(ownerKeys.Length);
+                foreach (var key in ownerKeys)
                 {
-                    var outcome = TryLoad(transactionId, out var journal);
+                    var outcome = TryLoadKey(key, ownerId, out var journal);
                     if (outcome != RecoveryJournalLoadOutcome.Succeeded || journal == null)
                     {
                         invalidEntryCount++;
@@ -1047,6 +1252,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 records.Sort(static (left, right) => left.TransactionId.CompareTo(right.TransactionId));
                 return new()
                 {
+                    OwnerId = ownerId,
                     Outcome = invalidEntryCount == 0
                         ? RawProgressRecoveryReadOutcome.Succeeded
                         : RawProgressRecoveryReadOutcome.InvalidEntriesIgnored,
@@ -1056,35 +1262,50 @@ namespace STS2RitsuLib.Saves.RawProgress
             }
 
             internal static RecoveryJournalLoadOutcome TryLoad(
+                string ownerId,
                 Guid transactionId,
                 out RecoveryJournal? journal)
             {
-                journal = null;
-                if (transactionId == Guid.Empty)
+                if (!IsValidOwnerId(ownerId) || transactionId == Guid.Empty)
+                {
+                    journal = null;
                     return RecoveryJournalLoadOutcome.Invalid;
+                }
 
-                var basePath = $"{GetRecoveryDirectory()}/{transactionId:N}.json";
+                var key = new RecoveryJournalKey(ComputeOwnerStorageId(ownerId), transactionId);
+                return TryLoadKey(key, ownerId, out journal);
+            }
+
+            private static RecoveryJournalLoadOutcome TryLoadKey(
+                RecoveryJournalKey key,
+                string? expectedOwnerId,
+                out RecoveryJournal? journal)
+            {
+                journal = null;
+                var basePath = GetRecoveryPath(key);
                 var primaryExists = FileOperations.FileExists(basePath);
                 var backupPath = basePath + ".backup";
                 var backupExists = FileOperations.FileExists(backupPath);
                 var secondBackupPath = backupPath + ".backup";
                 var secondBackupExists = FileOperations.FileExists(secondBackupPath);
+                // ReSharper disable once ConvertIfStatementToSwitchStatement
                 if (!primaryExists && !backupExists && !secondBackupExists)
                     return RecoveryJournalLoadOutcome.NotFound;
 
-                if (primaryExists && TryReadData(basePath, transactionId, out var primaryData))
+                if (primaryExists && TryReadData(basePath, key, expectedOwnerId, out var primaryData))
                 {
                     journal = new(basePath, basePath, primaryData);
                     return RecoveryJournalLoadOutcome.Succeeded;
                 }
 
-                if (backupExists && TryReadData(backupPath, transactionId, out var backupData))
+                if (backupExists && TryReadData(backupPath, key, expectedOwnerId, out var backupData))
                 {
                     journal = new(basePath, backupPath, backupData);
                     return RecoveryJournalLoadOutcome.Succeeded;
                 }
 
-                if (secondBackupExists && TryReadData(secondBackupPath, transactionId, out var secondBackupData))
+                if (secondBackupExists && TryReadData(secondBackupPath, key, expectedOwnerId,
+                        out var secondBackupData))
                 {
                     journal = new(basePath, secondBackupPath, secondBackupData, false);
                     return RecoveryJournalLoadOutcome.Succeeded;
@@ -1095,7 +1316,9 @@ namespace STS2RitsuLib.Saves.RawProgress
 
             internal bool TryPrepare()
             {
-                if (Exists || CountRetainedJournals() >= MaxRetainedRecoveryJournals)
+                if (!TryMaintainAndCountRetainedJournals(out var retainedJournalCount) ||
+                    Exists ||
+                    retainedJournalCount >= MaxRetainedRecoveryJournals)
                     return false;
 
                 return TryWrite();
@@ -1153,18 +1376,13 @@ namespace STS2RitsuLib.Saves.RawProgress
                 }
             }
 
-            private static int CountRetainedJournals()
-            {
-                return TryEnumerateTransactionIds(out var transactionIds, out var invalidEntryCount)
-                    ? transactionIds.Count + invalidEntryCount
-                    : MaxRetainedRecoveryJournals;
-            }
-
             private RawProgressRecoveryRecord ToRecord()
             {
                 _ = TryParseStage(Data.Stage, out var stage);
                 return new()
                 {
+                    OwnerId = Data.OwnerId,
+                    SchemaVersion = Data.SchemaVersion,
                     TransactionId = Data.TransactionId,
                     ProfileId = Data.ProfileId,
                     IsModded = Data.IsModded,
@@ -1172,12 +1390,167 @@ namespace STS2RitsuLib.Saves.RawProgress
                     Stage = stage,
                     OriginalSha256 = Data.OriginalSha256,
                     ProposedSha256 = Data.ProposedSha256,
+                    RecoveryToken = RecoveryToken,
                 };
+            }
+
+            private static bool TryMaintainAndCountRetainedJournals(out int retainedJournalCount)
+            {
+                retainedJournalCount = 0;
+                if (!TryEnumerateJournalKeys(out var journalKeys, out var invalidFiles))
+                    return false;
+
+                var recoveryDirectory = GetRecoveryDirectory();
+                foreach (var invalidFile in invalidFiles)
+                    _ = TryQuarantineFile($"{recoveryDirectory}/{invalidFile}");
+
+                foreach (var key in journalKeys)
+                {
+                    var outcome = TryLoadKey(key, null, out _);
+                    switch (outcome)
+                    {
+                        case RecoveryJournalLoadOutcome.Succeeded:
+                            retainedJournalCount++;
+                            break;
+                        case RecoveryJournalLoadOutcome.Invalid:
+                            TryQuarantineJournal(key);
+                            break;
+                    }
+                }
+
+                return true;
+            }
+
+            private static void TryQuarantineJournal(RecoveryJournalKey key)
+            {
+                var basePath = GetRecoveryPath(key);
+                var paths = new[]
+                {
+                    basePath,
+                    basePath + ".backup",
+                    basePath + ".tmp",
+                    basePath + ".backup.backup",
+                    basePath + ".backup.tmp",
+                    basePath + ".backup.backup.backup",
+                    basePath + ".backup.backup.tmp",
+                };
+                foreach (var path in paths)
+                    _ = TryQuarantineFile(path);
+            }
+
+            private static bool TryQuarantineFile(string sourcePath)
+            {
+                if (!FileOperations.FileExists(sourcePath))
+                    return true;
+                if (!TryGetFileLength(sourcePath, out var sourceLength) ||
+                    !TryGetQuarantineUsage(out var quarantineFileCount, out var quarantineBytes) ||
+                    quarantineFileCount >= MaxQuarantinedRecoveryFiles ||
+                    sourceLength > MaxQuarantinedRecoveryBytes - quarantineBytes)
+                {
+                    RitsuLibFramework.Logger.Warn(
+                        $"[RawProgress] Could not quarantine invalid recovery data at '{sourcePath}' within limits.");
+                    return false;
+                }
+
+                var quarantineDirectory = GetRecoveryQuarantineDirectory();
+                if (!DirAccess.DirExistsAbsolute(quarantineDirectory))
+                {
+                    var createError = DirAccess.MakeDirRecursiveAbsolute(quarantineDirectory);
+                    if (createError != Error.Ok)
+                    {
+                        RitsuLibFramework.Logger.Warn(
+                            $"[RawProgress] Could not create the recovery quarantine (Error: {createError}).");
+                        return false;
+                    }
+                }
+
+                var destinationPath =
+                    $"{quarantineDirectory}/{DateTime.UtcNow.Ticks}-{Guid.NewGuid():N}.invalid";
+                var renameError = DirAccess.RenameAbsolute(sourcePath, destinationPath);
+                if (renameError != Error.Ok)
+                {
+                    RitsuLibFramework.Logger.Warn(
+                        $"[RawProgress] Could not quarantine invalid recovery data at '{sourcePath}' " +
+                        $"(Error: {renameError}).");
+                    return false;
+                }
+
+                RitsuLibFramework.Logger.Warn(
+                    $"[RawProgress] Quarantined invalid recovery data from '{sourcePath}'.");
+                return true;
+            }
+
+            private static bool TryGetQuarantineUsage(out int fileCount, out long totalBytes)
+            {
+                fileCount = 0;
+                totalBytes = 0;
+                var quarantineDirectory = GetRecoveryQuarantineDirectory();
+                if (!DirAccess.DirExistsAbsolute(quarantineDirectory))
+                    return true;
+
+                try
+                {
+                    using var directory = DirAccess.Open(quarantineDirectory);
+                    if (directory == null)
+                        return false;
+
+                    foreach (var file in directory.GetFiles())
+                    {
+                        fileCount++;
+                        if (fileCount > MaxQuarantinedRecoveryFiles ||
+                            !TryGetFileLength($"{quarantineDirectory}/{file}", out var length) ||
+                            length > MaxQuarantinedRecoveryBytes - totalBytes)
+                            return false;
+
+                        totalBytes += length;
+                    }
+
+                    return true;
+                }
+                catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+                {
+                    RitsuLibFramework.Logger.Warn(
+                        $"[RawProgress] Could not inspect the recovery quarantine: {ex.Message}");
+                    return false;
+                }
+            }
+
+            private static bool TryGetFileLength(string path, out long length)
+            {
+                length = 0;
+                try
+                {
+                    using var file = Godot.FileAccess.Open(path, Godot.FileAccess.ModeFlags.Read);
+                    if (file == null)
+                        return false;
+
+                    var rawLength = file.GetLength();
+                    if (rawLength > long.MaxValue)
+                        return false;
+
+                    length = (long)rawLength;
+                    return true;
+                }
+                catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+                {
+                    RitsuLibFramework.Logger.Warn(
+                        $"[RawProgress] Could not inspect recovery data at '{path}': {ex.Message}");
+                    return false;
+                }
+            }
+
+            private static int CountInvalidOwnerFiles(IEnumerable<string> invalidFiles, string ownerStorageId)
+            {
+                var ownerPrefix = ownerStorageId + "-";
+                return invalidFiles.Count(file =>
+                    TryStripRecoverySuffix(file, out var stem) &&
+                    stem.StartsWith(ownerPrefix, StringComparison.OrdinalIgnoreCase));
             }
 
             private static bool TryReadData(
                 string path,
-                Guid expectedTransactionId,
+                RecoveryJournalKey key,
+                string? expectedOwnerId,
                 out RecoveryJournalData data)
             {
                 data = null!;
@@ -1188,7 +1561,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 try
                 {
                     var candidate = JsonSerializer.Deserialize<RecoveryJournalData>(read.Content, JournalJsonOptions);
-                    if (!IsValid(candidate, expectedTransactionId))
+                    if (!IsValid(candidate, key, expectedOwnerId))
                         return false;
 
                     data = candidate!;
@@ -1202,11 +1575,19 @@ namespace STS2RitsuLib.Saves.RawProgress
                 }
             }
 
-            private static bool IsValid(RecoveryJournalData? data, Guid expectedTransactionId)
+            private static bool IsValid(
+                RecoveryJournalData? data,
+                RecoveryJournalKey key,
+                string? expectedOwnerId)
             {
-                if (data == null ||
-                    data.JournalProtocolVersion != ProtocolVersion ||
-                    data.TransactionId != expectedTransactionId ||
+                if (data is not { JournalProtocolVersion: ProtocolVersion } ||
+                    !IsValidOwnerId(data.OwnerId) ||
+                    !string.Equals(ComputeOwnerStorageId(data.OwnerId), key.OwnerStorageId,
+                        StringComparison.OrdinalIgnoreCase) ||
+                    expectedOwnerId != null &&
+                    !string.Equals(data.OwnerId, expectedOwnerId, StringComparison.Ordinal) ||
+                    data.SchemaVersion < 1 ||
+                    data.TransactionId != key.TransactionId ||
                     data.ProfileId is < 1 or > 3 ||
                     string.IsNullOrWhiteSpace(data.ProgressUniqueId) ||
                     data.ProgressUniqueId.Length > 256 ||
@@ -1223,7 +1604,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                         out var schema,
                         out var uniqueId,
                         out var originalBytes) ||
-                    schema != SupportedSchema ||
+                    schema != data.SchemaVersion ||
                     originalBytes.LongLength > MaxDocumentUtf8Bytes ||
                     !HashEquals(ComputeSha256(originalBytes), data.OriginalSha256) ||
                     !string.Equals(uniqueId, data.ProgressUniqueId, StringComparison.Ordinal))
@@ -1246,13 +1627,51 @@ namespace STS2RitsuLib.Saves.RawProgress
                     "verification_incomplete";
             }
 
-            private static bool TryEnumerateTransactionIds(
-                out HashSet<Guid> transactionIds,
-                out int invalidEntryCount)
+            private static bool TryStripRecoverySuffix(string fileName, out string stem)
             {
-                transactionIds = [];
-                invalidEntryCount = 0;
-                var invalidNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var suffix in new[]
+                         {
+                             ".json.backup.backup.backup",
+                             ".json.backup.backup.tmp",
+                             ".json.backup.backup",
+                             ".json.backup.tmp",
+                             ".json.backup",
+                             ".json.tmp",
+                             ".json",
+                         })
+                {
+                    if (!fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    stem = fileName[..^suffix.Length];
+                    return true;
+                }
+
+                stem = string.Empty;
+                return false;
+            }
+
+            private static bool TryParseJournalKey(string stem, out RecoveryJournalKey key)
+            {
+                key = default;
+                if (stem.Length != 97 || stem[64] != '-')
+                    return false;
+
+                var ownerStorageId = stem[..64];
+                if (!IsSha256(ownerStorageId) ||
+                    !Guid.TryParseExact(stem[65..], "N", out var transactionId))
+                    return false;
+
+                key = new(ownerStorageId.ToLowerInvariant(), transactionId);
+                return true;
+            }
+
+            private static bool TryEnumerateJournalKeys(
+                out HashSet<RecoveryJournalKey> journalKeys,
+                out HashSet<string> invalidFiles)
+            {
+                journalKeys = [];
+                invalidFiles = new(StringComparer.OrdinalIgnoreCase);
                 var recoveryDirectory = GetRecoveryDirectory();
                 try
                 {
@@ -1263,32 +1682,31 @@ namespace STS2RitsuLib.Saves.RawProgress
                     if (directory == null)
                         return false;
 
+                    var fileCount = 0;
                     foreach (var file in directory.GetFiles())
                     {
-                        string? transactionText = null;
-                        if (file.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                            transactionText = file[..^".json".Length];
-                        else if (file.EndsWith(".json.backup", StringComparison.OrdinalIgnoreCase))
-                            transactionText = file[..^".json.backup".Length];
-                        else if (file.EndsWith(".json.backup.backup", StringComparison.OrdinalIgnoreCase))
-                            transactionText = file[..^".json.backup.backup".Length];
+                        fileCount++;
+                        if (fileCount > MaxRecoveryDirectoryFiles)
+                            return false;
 
-                        if (transactionText == null)
+                        if (!TryStripRecoverySuffix(file, out var stem))
+                        {
+                            invalidFiles.Add(file);
                             continue;
-                        if (Guid.TryParseExact(transactionText, "N", out var transactionId))
-                            transactionIds.Add(transactionId);
+                        }
+
+                        if (TryParseJournalKey(stem, out var key))
+                            journalKeys.Add(key);
                         else
-                            invalidNames.Add(transactionText);
+                            invalidFiles.Add(file);
                     }
 
-                    invalidEntryCount = invalidNames.Count;
                     return true;
                 }
                 catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
                 {
                     RitsuLibFramework.Logger.Warn(
                         $"[RawProgress] Failed to enumerate retained recovery journals: {ex.Message}");
-                    invalidEntryCount = invalidNames.Count;
                     return false;
                 }
             }

--- a/src/Saves/RawProgress/RawProgressCommitBridge.cs
+++ b/src/Saves/RawProgress/RawProgressCommitBridge.cs
@@ -33,6 +33,7 @@ namespace STS2RitsuLib.Saves.RawProgress
         private static readonly UTF8Encoding StrictUtf8 = new(false, true);
         private static readonly Dictionary<RecoveryTransactionKey, CompletedTransaction> CompletedTransactions = [];
         private static readonly Queue<RecoveryTransactionKey> CompletedTransactionOrder = [];
+        private static int _observedRuntimeSchema;
 
         private static readonly JsonSerializerOptions JournalJsonOptions = new()
         {
@@ -78,13 +79,15 @@ namespace STS2RitsuLib.Saves.RawProgress
 
         public RawProgressBridgeDescriptor Describe()
         {
-            var supportedSchema = GetSupportedSchema(SaveManager.Instance);
+            var supportedSchema = Volatile.Read(ref _observedRuntimeSchema);
             return new()
             {
                 ProviderId = Const.ModId,
                 ProviderVersion = Version.Parse(Const.Version),
                 ProtocolVersion = ProtocolVersion,
-                SupportedSchemas = new[] { supportedSchema }.ToFrozenSet(),
+                SupportedSchemas = supportedSchema > 0
+                    ? new[] { supportedSchema }.ToFrozenSet()
+                    : FrozenSet<int>.Empty,
                 Features = _features,
                 MaxDocumentUtf8Bytes = MaxDocumentUtf8Bytes,
                 MaxRetainedRecoveryJournals = MaxRetainedRecoveryJournals,
@@ -166,7 +169,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 {
                     var progress = manager.Progress;
                     var serializable = progress.ToSerializable();
-                    serializable.SchemaVersion = MigrationManager(manager).GetLatestVersion<SerializableProgress>();
+                    serializable.SchemaVersion = GetSupportedSchema(manager);
                     var knownJson = JsonSerializationUtility.ToJson(serializable);
                     var content = RawProgressJsonPreservation.PreserveAndAdvance(progress, knownJson);
                     SaveStore(manager).WriteFile(
@@ -209,7 +212,7 @@ namespace STS2RitsuLib.Saves.RawProgress
                 if (capture == null || result is not { Success: true, SaveData: not null })
                     return;
 
-                var supportedSchema = MigrationManager(manager).GetLatestVersion<SerializableProgress>();
+                var supportedSchema = GetSupportedSchema(manager);
                 if (!TryReadSchema(capture.RawJson, out var rawSchema) || rawSchema != supportedSchema)
                     return;
 
@@ -1007,7 +1010,20 @@ namespace STS2RitsuLib.Saves.RawProgress
 
         private static int GetSupportedSchema(SaveManager saveManager)
         {
-            return saveManager.GetLatestSchemaVersion<SerializableProgress>();
+            return ObserveSupportedSchema(saveManager.GetLatestSchemaVersion<SerializableProgress>());
+        }
+
+        private static int GetSupportedSchema(ProgressSaveManager saveManager)
+        {
+            return ObserveSupportedSchema(MigrationManager(saveManager).GetLatestVersion<SerializableProgress>());
+        }
+
+        private static int ObserveSupportedSchema(int supportedSchema)
+        {
+            if (supportedSchema > 0)
+                Volatile.Write(ref _observedRuntimeSchema, supportedSchema);
+
+            return supportedSchema;
         }
 
         private static bool TryGetSupportedSchema(out int supportedSchema)

--- a/src/Saves/RawProgress/RawProgressJsonPreservation.cs
+++ b/src/Saves/RawProgress/RawProgressJsonPreservation.cs
@@ -1,0 +1,314 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MegaCrit.Sts2.Core.Saves;
+
+namespace STS2RitsuLib.Saves.RawProgress
+{
+    internal static class RawProgressJsonPreservation
+    {
+        private static readonly ConditionalWeakTable<ProgressState, PreservationState> States = [];
+
+        private static readonly JsonSerializerOptions WriteOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            WriteIndented = false,
+        };
+
+        private static readonly string[] IdentityPropertyNames =
+        [
+            "id",
+            "character",
+            "achievement",
+            "key",
+            "name",
+            "player_id",
+            "slot",
+        ];
+
+        internal static bool TryAttach(ProgressState progress, string rawJson, string knownJson)
+        {
+            ArgumentNullException.ThrowIfNull(progress);
+
+            try
+            {
+                var state = PreservationState.Create(rawJson, knownJson);
+                if (!state.CanReconstructRawDocument())
+                    return false;
+
+                States.Remove(progress);
+                States.Add(progress, state);
+                return true;
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[RawProgress] Failed to install unknown-property preservation: {ex.Message}");
+                return false;
+            }
+        }
+
+        internal static string PreserveAndAdvance(ProgressState progress, string knownJson)
+        {
+            ArgumentNullException.ThrowIfNull(progress);
+            ArgumentNullException.ThrowIfNull(knownJson);
+
+            if (!States.TryGetValue(progress, out var state))
+                return knownJson;
+
+            try
+            {
+                return state.PreserveAndAdvance(knownJson);
+            }
+            catch (Exception ex) when (RitsuLibExceptionPolicy.IsRecoverable(ex))
+            {
+                RitsuLibFramework.Logger.Warn(
+                    $"[RawProgress] Failed to preserve unknown properties during an ordinary save: {ex.Message}");
+                States.Remove(progress);
+                return knownJson;
+            }
+        }
+
+        private static void MergeUnknown(JsonNode? raw, JsonNode? baseline, JsonNode? current)
+        {
+            if (raw is JsonObject rawObject && baseline is JsonObject baselineObject &&
+                current is JsonObject currentObject)
+            {
+                MergeUnknownObject(rawObject, baselineObject, currentObject);
+                return;
+            }
+
+            if (raw is JsonArray rawArray && baseline is JsonArray baselineArray && current is JsonArray currentArray)
+                MergeUnknownArray(rawArray, baselineArray, currentArray);
+        }
+
+        private static void MergeUnknownObject(
+            JsonObject raw,
+            JsonObject baseline,
+            JsonObject current)
+        {
+            foreach (var (propertyName, rawValue) in raw)
+            {
+                if (!baseline.TryGetPropertyValue(propertyName, out var baselineValue))
+                {
+                    if (!current.ContainsKey(propertyName))
+                        current[propertyName] = rawValue?.DeepClone();
+                    continue;
+                }
+
+                if (current.TryGetPropertyValue(propertyName, out var currentValue))
+                    MergeUnknown(rawValue, baselineValue, currentValue);
+            }
+        }
+
+        private static void MergeUnknownArray(JsonArray raw, JsonArray baseline, JsonArray current)
+        {
+            foreach (var currentItem in current)
+            {
+                if (!TryGetIdentity(currentItem, out var identityProperty, out var identityValue))
+                    continue;
+
+                var baselineItem = FindByIdentity(baseline, identityProperty, identityValue);
+                var rawItem = FindByIdentity(raw, identityProperty, identityValue);
+                if (baselineItem != null && rawItem != null)
+                    MergeUnknown(rawItem, baselineItem, currentItem);
+            }
+        }
+
+        private static bool AreUnknownPropertiesPreserved(JsonNode? raw, JsonNode? baseline, JsonNode? current)
+        {
+            if (raw is JsonObject rawObject && baseline is JsonObject baselineObject)
+            {
+                if (current is not JsonObject currentObject)
+                    return !ContainsUnknownProperties(rawObject, baselineObject);
+
+                foreach (var (propertyName, rawValue) in rawObject)
+                {
+                    if (!baselineObject.TryGetPropertyValue(propertyName, out var baselineValue))
+                    {
+                        if (!currentObject.TryGetPropertyValue(propertyName, out var currentValue) ||
+                            !JsonNode.DeepEquals(rawValue, currentValue))
+                            return false;
+                        continue;
+                    }
+
+                    currentObject.TryGetPropertyValue(propertyName, out var currentKnownValue);
+                    if (!AreUnknownPropertiesPreserved(rawValue, baselineValue, currentKnownValue))
+                        return false;
+                }
+
+                return true;
+            }
+
+            if (raw is not JsonArray rawArray || baseline is not JsonArray baselineArray)
+                return true;
+            if (current is not JsonArray currentArray)
+                return !ContainsUnknownProperties(rawArray, baselineArray);
+
+            for (var index = 0; index < rawArray.Count; index++)
+            {
+                var rawItem = rawArray[index];
+                if (!TryGetIdentity(rawItem, out var identityProperty, out var identityValue))
+                {
+                    var baselineItemAtIndex = index < baselineArray.Count ? baselineArray[index] : null;
+                    if (ContainsUnknownProperties(rawItem, baselineItemAtIndex))
+                        return false;
+                    continue;
+                }
+
+                var baselineItem = FindByIdentity(baselineArray, identityProperty, identityValue);
+                if (baselineItem == null)
+                    return false;
+
+                var currentItem = FindByIdentity(currentArray, identityProperty, identityValue);
+                if (!AreUnknownPropertiesPreserved(rawItem, baselineItem, currentItem))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool ContainsUnknownProperties(JsonNode? raw, JsonNode? baseline)
+        {
+            if (raw is JsonObject rawObject)
+            {
+                if (baseline is not JsonObject baselineObject)
+                    return rawObject.Count > 0;
+
+                foreach (var (propertyName, rawValue) in rawObject)
+                {
+                    if (!baselineObject.TryGetPropertyValue(propertyName, out var baselineValue) ||
+                        ContainsUnknownProperties(rawValue, baselineValue))
+                        return true;
+                }
+
+                return false;
+            }
+
+            if (raw is not JsonArray rawArray)
+                return false;
+            if (baseline is not JsonArray baselineArray)
+                return rawArray.Count > 0;
+
+            for (var index = 0; index < rawArray.Count; index++)
+            {
+                var rawItem = rawArray[index];
+                if (!TryGetIdentity(rawItem, out var identityProperty, out var identityValue))
+                {
+                    var baselineItemAtIndex = index < baselineArray.Count ? baselineArray[index] : null;
+                    if (ContainsUnknownProperties(rawItem, baselineItemAtIndex))
+                        return true;
+                    continue;
+                }
+
+                var baselineItem = FindByIdentity(baselineArray, identityProperty, identityValue);
+                if (baselineItem == null || ContainsUnknownProperties(rawItem, baselineItem))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static JsonNode? FindByIdentity(JsonArray array, string propertyName, string identityValue)
+        {
+            JsonNode? match = null;
+            foreach (var item in array)
+            {
+                if (!TryReadIdentity(item, propertyName, out var candidate) || candidate != identityValue)
+                    continue;
+
+                if (match != null)
+                    return null;
+
+                match = item;
+            }
+
+            return match;
+        }
+
+        private static bool TryGetIdentity(JsonNode? node, out string propertyName, out string identityValue)
+        {
+            foreach (var candidate in IdentityPropertyNames)
+                if (TryReadIdentity(node, candidate, out identityValue))
+                {
+                    propertyName = candidate;
+                    return true;
+                }
+
+            propertyName = string.Empty;
+            identityValue = string.Empty;
+            return false;
+        }
+
+        private static bool TryReadIdentity(JsonNode? node, string propertyName, out string identityValue)
+        {
+            identityValue = string.Empty;
+            if (node is not JsonObject obj ||
+                !obj.TryGetPropertyValue(propertyName, out var value) ||
+                value is not JsonValue jsonValue)
+                return false;
+
+            if (jsonValue.TryGetValue<string>(out var stringValue) && !string.IsNullOrWhiteSpace(stringValue))
+            {
+                identityValue = $"s:{stringValue}";
+                return true;
+            }
+
+            if (jsonValue.TryGetValue<long>(out var longValue))
+            {
+                identityValue = $"n:{longValue}";
+                return true;
+            }
+
+            return false;
+        }
+
+        private sealed class PreservationState
+        {
+            private readonly object _syncRoot = new();
+            private JsonNode _knownBaseline;
+            private JsonNode _rawDocument;
+
+            private PreservationState(JsonNode rawDocument, JsonNode knownBaseline)
+            {
+                _rawDocument = rawDocument;
+                _knownBaseline = knownBaseline;
+            }
+
+            internal static PreservationState Create(string rawJson, string knownJson)
+            {
+                var rawDocument = JsonNode.Parse(rawJson) ??
+                                  throw new JsonException("The raw progress document parsed as null.");
+                var knownBaseline = JsonNode.Parse(knownJson) ??
+                                    throw new JsonException("The known progress projection parsed as null.");
+                return new(rawDocument, knownBaseline);
+            }
+
+            internal bool CanReconstructRawDocument()
+            {
+                lock (_syncRoot)
+                {
+                    var reconstructed = _knownBaseline.DeepClone();
+                    MergeUnknown(_rawDocument, _knownBaseline, reconstructed);
+                    return AreUnknownPropertiesPreserved(_rawDocument, _knownBaseline, reconstructed);
+                }
+            }
+
+            internal string PreserveAndAdvance(string knownJson)
+            {
+                var currentKnown = JsonNode.Parse(knownJson) ??
+                                   throw new JsonException("The current known progress projection parsed as null.");
+
+                lock (_syncRoot)
+                {
+                    var merged = currentKnown.DeepClone();
+                    MergeUnknown(_rawDocument, _knownBaseline, merged);
+                    _rawDocument = merged.DeepClone();
+                    _knownBaseline = currentKnown;
+                    return merged.ToJsonString(WriteOptions);
+                }
+            }
+        }
+    }
+}

--- a/src/Saves/RawProgress/RawProgressJsonPreservation.cs
+++ b/src/Saves/RawProgress/RawProgressJsonPreservation.cs
@@ -65,8 +65,7 @@ namespace STS2RitsuLib.Saves.RawProgress
             {
                 RitsuLibFramework.Logger.Warn(
                     $"[RawProgress] Failed to preserve unknown properties during an ordinary save: {ex.Message}");
-                States.Remove(progress);
-                return knownJson;
+                throw;
             }
         }
 
@@ -116,7 +115,11 @@ namespace STS2RitsuLib.Saves.RawProgress
             }
         }
 
-        private static bool AreUnknownPropertiesPreserved(JsonNode? raw, JsonNode? baseline, JsonNode? current)
+        private static bool AreUnknownPropertiesPreserved(
+            JsonNode? raw,
+            JsonNode? baseline,
+            JsonNode? current,
+            bool allowDeletedArrayRecords = false)
         {
             if (raw is JsonObject rawObject && baseline is JsonObject baselineObject)
             {
@@ -134,7 +137,11 @@ namespace STS2RitsuLib.Saves.RawProgress
                     }
 
                     currentObject.TryGetPropertyValue(propertyName, out var currentKnownValue);
-                    if (!AreUnknownPropertiesPreserved(rawValue, baselineValue, currentKnownValue))
+                    if (!AreUnknownPropertiesPreserved(
+                            rawValue,
+                            baselineValue,
+                            currentKnownValue,
+                            allowDeletedArrayRecords))
                         return false;
                 }
 
@@ -161,8 +168,15 @@ namespace STS2RitsuLib.Saves.RawProgress
                 if (baselineItem == null)
                     return false;
 
-                var currentItem = FindByIdentity(currentArray, identityProperty, identityValue);
-                if (!AreUnknownPropertiesPreserved(rawItem, baselineItem, currentItem))
+                if (!TryFindUniqueByIdentity(currentArray, identityProperty, identityValue, out var currentItem))
+                    return false;
+                if (currentItem == null && allowDeletedArrayRecords)
+                    continue;
+                if (!AreUnknownPropertiesPreserved(
+                        rawItem,
+                        baselineItem,
+                        currentItem,
+                        allowDeletedArrayRecords))
                     return false;
             }
 
@@ -225,6 +239,26 @@ namespace STS2RitsuLib.Saves.RawProgress
             }
 
             return match;
+        }
+
+        private static bool TryFindUniqueByIdentity(
+            JsonArray array,
+            string propertyName,
+            string identityValue,
+            out JsonNode? match)
+        {
+            match = null;
+            foreach (var item in array)
+            {
+                if (!TryReadIdentity(item, propertyName, out var candidate) || candidate != identityValue)
+                    continue;
+                if (match != null)
+                    return false;
+
+                match = item;
+            }
+
+            return true;
         }
 
         private static bool TryGetIdentity(JsonNode? node, out string propertyName, out string identityValue)
@@ -304,9 +338,15 @@ namespace STS2RitsuLib.Saves.RawProgress
                 {
                     var merged = currentKnown.DeepClone();
                     MergeUnknown(_rawDocument, _knownBaseline, merged);
-                    _rawDocument = merged.DeepClone();
+                    if (!AreUnknownPropertiesPreserved(_rawDocument, _knownBaseline, merged, true))
+                        throw new JsonException(
+                            "Unknown progress properties could not be matched uniquely to the current projection.");
+
+                    var nextRawDocument = merged.DeepClone();
+                    var result = merged.ToJsonString(WriteOptions);
+                    _rawDocument = nextRawDocument;
                     _knownBaseline = currentKnown;
-                    return merged.ToJsonString(WriteOptions);
+                    return result;
                 }
             }
         }

--- a/src/Saves/RawProgress/RawProgressJsonPreservation.cs
+++ b/src/Saves/RawProgress/RawProgressJsonPreservation.cs
@@ -71,15 +71,15 @@ namespace STS2RitsuLib.Saves.RawProgress
 
         private static void MergeUnknown(JsonNode? raw, JsonNode? baseline, JsonNode? current)
         {
-            if (raw is JsonObject rawObject && baseline is JsonObject baselineObject &&
-                current is JsonObject currentObject)
+            switch (raw, baseline, current)
             {
-                MergeUnknownObject(rawObject, baselineObject, currentObject);
-                return;
+                case (JsonObject rawObject, JsonObject baselineObject, JsonObject currentObject):
+                    MergeUnknownObject(rawObject, baselineObject, currentObject);
+                    break;
+                case (JsonArray rawArray, JsonArray baselineArray, JsonArray currentArray):
+                    MergeUnknownArray(rawArray, baselineArray, currentArray);
+                    break;
             }
-
-            if (raw is JsonArray rawArray && baseline is JsonArray baselineArray && current is JsonArray currentArray)
-                MergeUnknownArray(rawArray, baselineArray, currentArray);
         }
 
         private static void MergeUnknownObject(
@@ -300,7 +300,7 @@ namespace STS2RitsuLib.Saves.RawProgress
 
         private sealed class PreservationState
         {
-            private readonly object _syncRoot = new();
+            private readonly Lock _syncRoot = new();
             private JsonNode _knownBaseline;
             private JsonNode _rawDocument;
 


### PR DESCRIPTION
## Summary / 概要

- Add a versioned public bridge for conditionally capturing and committing active-profile raw progress while preserving unknown JSON properties.
- 新增版本化公共接口，用于按条件捕获和提交当前档案的原始进度数据，并保留未知 JSON 属性。
- Add an owner-scoped, bounded recovery lifecycle for interrupted or partially verified commits.
- 为中断或未完整验证的提交新增按所有者隔离且资源有界的恢复生命周期。

## Why / 背景与动机

- Mods need a supported persistence boundary that uses the live game-owned save store without exposing save-store internals or bypassing save coordination.
- Mod 需要一个受支持的持久化边界，在不暴露存档内部实现、也不绕过存档协调机制的前提下使用游戏当前持有的存档服务。
- Retained recovery data must remain actionable without allowing one mod, stale state, or malformed files to interfere accidentally with another caller.
- 保留的恢复数据必须可被安全处理，同时避免不同 Mod、过期状态或异常文件相互干扰。

## What changed / 变更点

- Add validated capture and conditional commit contracts for the progress schema, profile identity, destination generation, transaction identity, payload size, and fingerprints.
- 为进度 schema、档案身份、目标代次、事务标识、数据大小和指纹新增严格校验的捕获与条件提交接口。
- Resolve the accepted progress schema from the active game's migration manager. Recovery records remain tied to the schema in which they were created and fail closed on a schema mismatch.
- 从当前游戏的迁移管理器获取可接受的进度 schema。恢复记录始终绑定到创建时的 schema，发生 schema 不匹配时会保守失败。
- Coordinate ordinary progress saves with raw commits, then verify local, Cloud, and live in-memory results before reporting full success.
- 协调普通进度保存与原始提交，并在确认本地、Cloud 和运行时内存状态后才报告完整成功。
- Preserve safely matchable unknown properties across later ordinary saves and fail closed when preservation cannot be proven safe.
- 在后续普通保存中保留可安全匹配的未知属性；无法证明安全时终止保存，避免数据丢失。
- Scope recovery records and duplicate suppression by a stable caller identifier, detect stale recovery selections with opaque tokens, and support generation-guarded restoration or explicit discard.
- 使用稳定的调用方标识隔离恢复记录与重复提交抑制，通过不透明 token 检测过期恢复选择，并支持带目标代次保护的恢复或显式放弃。
- Keep valid recovery capacity bounded across callers while isolating malformed recovery files so they do not consume the active allowance.
- 对所有调用方合计设置有效恢复记录上限，并隔离异常恢复文件，避免其占用有效恢复名额。

## Validation / 验证

- [x] Rider MCP warning/error inspection passes for all six C# files changed by this branch.
- [x] JetBrains InspectCode 2026.2.0.2 passes at `INFO` severity with exact include filters for the same six files and zero diagnostics at every reported severity.
- [x] Builds pass sequentially for every declared compatibility target: `0.107.1`, `0.108.0`, `0.109.0`, and `0.110.0`; the latest build completed its normal copy to the game Mods directory.
- [x] The requesting consumer reported 106 passing Release contract tests against the earlier `6e45b101` revision, including 14 tests compiled against that prototype.
- [ ] Re-run the requesting consumer contract suite against the current `1a41746d` revision.
- [ ] Complete disposable-profile runtime acceptance for local/Cloud read-back, interrupted recovery, conditional restoration and discard, and a subsequent ordinary save.

Closes #94
