### PR TITLE
perf: 缓存 BaseLib 目标类型的重复程序集查询

### DIFF
--- a/src/Combat/CardTargeting/BaseLibTargetTypeBridge.cs
+++ b/src/Combat/CardTargeting/BaseLibTargetTypeBridge.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Entities.Players;
@@ -15,6 +16,7 @@ namespace STS2RitsuLib.Combat.CardTargeting
         private const string BaseLibCustomTargetTypeName = "BaseLib.Patches.Features.CustomTargetType";
 
         private static readonly Lock Gate = new();
+        private static readonly ConditionalWeakTable<Assembly, TypeResolution> TypeCache = new();
 
         private static ITargetPredicateMap? _singleTargeting;
         private static ITargetPredicateMap? _multiTargeting;
@@ -135,13 +137,13 @@ namespace STS2RitsuLib.Combat.CardTargeting
             foreach (var mod in Sts2ModManagerCompat.EnumerateLoadedModsWithAssembly())
             foreach (var assembly in Sts2ModManagerCompat.GetAssemblies(mod))
             {
-                var type = assembly.GetType(BaseLibCustomTargetTypeName, false);
+                var type = ResolveAssemblyType(assembly);
                 if (type != null)
                     return type;
             }
 
             var fallback = AppDomain.CurrentDomain.GetAssemblies()
-                .Select(assembly => assembly.GetType(BaseLibCustomTargetTypeName, false))
+                .Select(assembly => ResolveAssemblyType(assembly))
                 .OfType<Type>()
                 .FirstOrDefault();
             if (fallback != null)
@@ -153,6 +155,19 @@ namespace STS2RitsuLib.Combat.CardTargeting
             RitsuLibFramework.Logger.Info("[CardTargeting] BaseLib custom TargetType type not found.");
             return null;
         }
+
+        private static Type? ResolveAssemblyType(Assembly assembly)
+        {
+            // Cache per static assembly; the outer scan still discovers later assemblies in order.
+            // Dynamic assemblies can create types later, so do not cache their missing results.
+            if (assembly.IsDynamic)
+                return assembly.GetType(BaseLibCustomTargetTypeName, false);
+
+            return TypeCache.GetValue(assembly, static candidate =>
+                new TypeResolution(candidate.GetType(BaseLibCustomTargetTypeName, false))).Type;
+        }
+
+        private sealed record TypeResolution(Type? Type);
 
         private static ITargetPredicateMap? ReadPredicateMap(
             Type type,


### PR DESCRIPTION
## Summary / 概要

你好，感谢维护 RitsuLib。我在排查 CombatSolver 的搜索分配时，发现 `BaseLibTargetTypeBridge` 在未找到 BaseLib 目标类型时会重复查询程序集。这份改动尝试缓存单个静态程序集的查询结果，减少高频目标检查中的重复分配，供你审阅。

## Why / 背景与动机

当目标类型尚未找到时，后续目标检查仍会进入 `ResolveBaseLibCustomTargetType()`。当前 `_loggedMissingType` 避免了重复日志，但 Mod 程序集与 AppDomain 回退路径仍可能反复调用 `Assembly.GetType()`。

CombatSolver 的模拟搜索会频繁调用目标检查，因此容易放大这部分成本。我们先在下游做了范围较窄的适配，见 [CombatSolver PR #49](https://github.com/Torch1230/CombatSolver/pull/49)。如果这里适合直接处理，下游就可以减少对 RitsuLib 私有实现的适配。普通游戏流程能获得多少收益，目前还没有测量。

## What changed / 变更点

- 用 `ConditionalWeakTable<Assembly, TypeResolution>` 按程序集实例缓存目标类型查询，包括未找到的结果；新增缓存自身不阻止可回收程序集卸载。
- Mod 程序集与 AppDomain 回退查询复用同一个方法，保留原来的发现顺序。没有缓存“BaseLib 整体不存在”，后续加载的程序集仍会被发现。
- 动态程序集继续实时查询，以支持同一程序集内晚创建的类型。查询抛出的异常仍向上传播，不写入缺失缓存。
- 保留注册字段的重试和目标谓词调用；方法内注释使用英文。

## Test plan / 测试计划

- [x] 用同一套工具复现旧实现：连续解析 20 次，同一个缺失目标类型的测试程序集被查询 20 次；修改后为 1 次。
- [x] 基于 dev 整理提交后，本地 19 项直接检查重新通过，覆盖来源优先级、晚加载、动态类型、程序集实例区分、异常传播、并发结果、缓存的可回收性、字段晚初始化和两种目标谓词。
- [x] 预热后，对同一个静态程序集执行 100,000 次缺失查询，当前线程分配由 18,400,000 B 降为 0 B。这仅衡量查询方法，不能推导整个桥或游戏搜索零分配。
- [x] 使用 .NET SDK 9.0.304、当前游戏 0.111.0 引用，Release DLL 与分析器构建通过，0 警告、0 错误；构建时关闭游戏复制和 Viewer，并使用项目已有开关跳过清单生成。
- [ ] 完整构建：本机清单生成任务遇到 `System.Text.Json` 加载版本冲突，因此尚未通过包含该步骤的完整构建。
- [ ] 其他声明支持的游戏 API 版本、真实 BaseLib 组合及游戏内行为和性能回归。
- [ ] ReSharper 格式化与检查：当前环境未配置相应工具，本轮仅完成编译和差异空白检查。

测试工具直接链接生产桥源码，外部框架注册表、Mod 枚举与日志使用测试替身，因此这些检查不代替真实 Mod 集成测试。按审查建议，测试项目已从提交中移除；测试源码及原始日志保留在本地，本 PR 仅记录验证结论。

## Notes / 备注

提交历史已整理为基于 dev 的单个提交，仅修改一个桥接文件，没有调整搜索策略、GC 政策、版本或发布配置。程序集枚举仍然存在，首次查询也仍有成本；上述微基准不代表普通游戏中的整体性能收益，也不承诺既有全局缓存支持完整热卸载。

我尽量把改动限制在重复查询这一处。如果这种缓存与项目预期的加载生命周期有冲突，或你更倾向于在已有框架发现机制中统一处理，欢迎指出，我愿意据此调整。感谢审阅。



