### PR TITLE
Add interface for replacing card frames in Crystal Sphere event

### DIFF
--- a/src/RitsuLibFramework.PatcherSetup.cs
+++ b/src/RitsuLibFramework.PatcherSetup.cs
@@ -711,6 +711,7 @@ namespace STS2RitsuLib
             patcher.RegisterPatch<CharacterCastSfxPatch>();
             patcher.RegisterPatch<CharacterDeathSfxPatch>();
             patcher.RegisterPatch<ColorfulPhilosophersCardPoolColorOrderPatch>();
+            patcher.RegisterPatch<CrystalSphereCardPoolCardBackPatch>();
             patcher.RegisterPatch<CharacterArmPointingTexturePathPatch>();
             patcher.RegisterPatch<CharacterArmRockTexturePathPatch>();
             patcher.RegisterPatch<CharacterArmPaperTexturePathPatch>();

--- a/src/Scaffolding/Characters/ICrystalSphereCardPool.cs
+++ b/src/Scaffolding/Characters/ICrystalSphereCardPool.cs
@@ -1,0 +1,34 @@
+using Godot;
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2RitsuLib.Scaffolding.Characters
+{
+    /// <summary>
+    ///     <para xml:lang="en">
+    ///         Allows a card pool to replace the crystal-sphere card-reward back texture and material.
+    ///     </para>
+    ///     <para xml:lang="zh-CN">允许卡池替换水晶球事件中卡奖励格的底图和材质。</para>
+    /// </summary>
+    public interface ICrystalSphereCardPool
+    {
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Gets the crystal-sphere card-reward back texture, or <see langword="null" /> to keep the vanilla back.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">获取水晶球卡奖励格底图；返回 <see langword="null" /> 时保留原版纹理。</para>
+        /// </summary>
+        Texture2D? CrystalSphereCardTexture => null;
+
+        /// <summary>
+        ///     <para xml:lang="en">
+        ///         Gets the crystal-sphere card-reward back material, or <see langword="null" /> to keep
+        ///         <see cref="CardPoolModel.FrameMaterial" />.
+        ///     </para>
+        ///     <para xml:lang="zh-CN">
+        ///         获取水晶球卡奖励格材质；返回 <see langword="null" /> 时保留
+        ///         <see cref="CardPoolModel.FrameMaterial" />。
+        ///     </para>
+        /// </summary>
+        Material? CrystalSphereCardMaterial => null;
+    }
+}

--- a/src/Scaffolding/Characters/Patches/CrystalSphereCardPoolCardBackPatch.cs
+++ b/src/Scaffolding/Characters/Patches/CrystalSphereCardPoolCardBackPatch.cs
@@ -1,0 +1,56 @@
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Events.Custom.CrystalSphereEvent;
+using MegaCrit.Sts2.Core.Events.Custom.CrystalSphereEvent.CrystalSphereItems;
+using MegaCrit.Sts2.Core.Nodes.Events.Custom.CrystalSphere;
+using STS2RitsuLib.Patching.Models;
+
+namespace STS2RitsuLib.Scaffolding.Characters.Patches
+{
+    /// <summary>
+    ///     <para xml:lang="en">
+    ///         Replaces the crystal-sphere card-reward back texture and/or material when a card pool supplies
+    ///         <see cref="ICrystalSphereCardPool" />.
+    ///     </para>
+    ///     <para xml:lang="zh-CN">
+    ///         当卡池提供 <see cref="ICrystalSphereCardPool" /> 时，按非空项替换水晶球卡奖励格的底图和/或材质。
+    ///     </para>
+    /// </summary>
+    internal class CrystalSphereCardPoolCardBackPatch : IPatchMethod
+    {
+        private static readonly AccessTools.FieldRef<NCrystalSphereItem, CrystalSphereItem> ItemRef =
+            AccessTools.FieldRefAccess<NCrystalSphereItem, CrystalSphereItem>("_item");
+
+        private static readonly AccessTools.FieldRef<NCrystalSphereItem, TextureRect> CardFrameRef =
+            AccessTools.FieldRefAccess<NCrystalSphereItem, TextureRect>("_cardFrame");
+
+        private static readonly AccessTools.FieldRef<CrystalSphereCardReward, Player> OwnerRef =
+            AccessTools.FieldRefAccess<CrystalSphereCardReward, Player>("_owner");
+
+        public static string PatchId => "crystal_sphere_card_pool_card_back";
+        public static string Description =>
+            "Allow card pools to replace the crystal-sphere card-reward back texture and material";
+        public static bool IsCritical => false;
+
+        public static ModPatchTarget[] GetTargets() =>
+            [new(typeof(NCrystalSphereItem), nameof(NCrystalSphereItem._Ready))];
+
+        public static void Postfix(NCrystalSphereItem __instance)
+        {
+            if (ItemRef(__instance) is not CrystalSphereCardReward reward)
+                return;
+            if (OwnerRef(reward).Character?.CardPool is not ICrystalSphereCardPool overrides)
+                return;
+
+            var cardFrame = CardFrameRef(__instance);
+            if (cardFrame == null || !GodotObject.IsInstanceValid(cardFrame))
+                return;
+
+            if (overrides.CrystalSphereCardTexture is { } texture && GodotObject.IsInstanceValid(texture))
+                cardFrame.Texture = texture;
+            if (overrides.CrystalSphereCardMaterial is { } material && GodotObject.IsInstanceValid(material))
+                cardFrame.Material = material;
+        }
+    }
+}


### PR DESCRIPTION
## Summary / 概要
- 添加了`ICrystalSphereCardPool`接口，用于在水晶球事件中替换小卡牌的材质和图片。默认不为卡池实现。

<img width="210" height="192" alt="图片" src="https://github.com/user-attachments/assets/ea0be451-2a4b-41b4-aea8-4f8d3bed40d3" />

## Why / 背景与动机
- 水晶球事件会使用卡池的材质，但是底图仍然是红色底图。这导致使用`CreateUnmodulatedHsvShaderMaterial`和自定义卡框图片的角色的卡池，在水晶球事件中的小卡牌仍然显示红色。因此增加`ICrystalSphereCardPool`接口，提供替换小卡牌的材质和图片的方式便于选择。

## What changed / 变更点
- `src/RitsuLibFramework.PatcherSetup.cs`: 增加了一个patch安装
- `src/Scaffolding/Characters/ICrystalSphereCardPool.cs`：增加了接口
- `src/Scaffolding/Characters/Patches/CrystalSphereCardPoolCardBackPatch.cs`：增加一个patch
